### PR TITLE
Fix getInstalledApps implementation

### DIFF
--- a/src/main/libs/integrations/getInstalledApps.ts
+++ b/src/main/libs/integrations/getInstalledApps.ts
@@ -1,29 +1,13 @@
-import { exec } from 'child_process';
-
-const getAppsSubDirectory = (stdout: string, directory: string): Array<string> => {
-  let stdoutArr = stdout.split(/[(\r\n)\r\n]+/);
-  stdoutArr = stdoutArr
-    .filter((o: any) => o)
-    .map((i: any) => {
-      return `${directory}/${i}`;
-    });
-  return stdoutArr;
-};
-
-const getDirectoryContents = (directory: string): Promise<Array<string>> => {
-  return new Promise((resolve, reject) => {
-    exec(`ls ${directory}`, (error, stdout) => {
-      if (error) {
-        reject(error);
-      } else {
-        try {
-          resolve(getAppsSubDirectory(stdout, directory));
-        } catch (err) {
-          reject(err);
-        }
-      }
-    });
-  });
+import { promises as fs } from 'fs';
+import path from 'path';
+/**
+ * Read application bundles from the given directory.
+ *
+ * This implementation avoids spawning a shell and works cross platform.
+ */
+const getDirectoryContents = async (directory: string): Promise<string[]> => {
+  const entries = await fs.readdir(directory);
+  return entries.map((name) => path.join(directory, name));
 };
 
 export const getInstalledApps = async (directory: string): Promise<string[]> => {


### PR DESCRIPTION
## Summary
- use fs.readdir instead of spawning `ls`

## Testing
- `npx tsc --noEmit` *(fails: cannot find module types)*
- `npm run eslint` *(fails: couldn't find eslint config)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the method for retrieving installed apps to enhance reliability and cross-platform compatibility. No changes to the user interface or visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->