### PR TITLE
fix: remove empty pull requests placeholder

### DIFF
--- a/src/renderer/components/Project/hooks/usePulls/usePulls.tsx
+++ b/src/renderer/components/Project/hooks/usePulls/usePulls.tsx
@@ -102,12 +102,6 @@ export const usePulls = (project: Project) => {
     () =>
       showPulls && (
         <div className="relative">
-          {isEmpty && pulls.length < 1 && (
-            <div className={cn('flex justify-between items-center py-2.5 px-4', Classes.TEXT_MUTED, loading && Classes.SKELETON)}>
-              <span>No pull request were found</span>
-            </div>
-          )}
-
           {pulls.map(({ pull, tags }) => (
             <PullRequest
               key={pull.id}


### PR DESCRIPTION
## Summary
- Remove "No pull request were found" placeholder — show nothing when there are no PRs

## Test plan
- [ ] Confirm no placeholder text when a project has no open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)