### PR TITLE
fix: Sunset popover z-index, theme and wordmark shimmer

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -25,11 +25,15 @@ export const App = () => {
   const claudeActive = claudeEnabled && !onSettings;
   const footerVisible = showClaudeUsage && hasAccounts && claudeActive;
 
-  // Mirror the Sunset flag onto <html> so theme rules also reach Blueprint
-  // popovers/menus, which portal to document.body outside the App root.
+  // Mirror the Sunset flag AND the dark flag onto <html> so theme rules — and
+  // Tailwind's `dark:` variants — also reach Blueprint popovers/menus, which
+  // portal to document.body outside the App root. Without the dark mirror,
+  // portaled popover text falls back to light-mode colours and vanishes on the
+  // dark popover background.
   useEffect(() => {
     document.documentElement.classList.toggle('theme-sunset', isSunset);
-  }, [isSunset]);
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode, isSunset]);
 
   return (
     <div

--- a/src/renderer/components/ClaudeUsage/UsageMeter.tsx
+++ b/src/renderer/components/ClaudeUsage/UsageMeter.tsx
@@ -127,7 +127,6 @@ export const UsageMeter = ({ label, now, reportedAt, title, window }: Props) => 
       interactionKind="hover"
       minimal
       placement="top"
-      usePortal={false}
     >
       <div className="flex w-full cursor-default items-center gap-3">
         <span className="shrink-0 rounded bg-black/5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-bp-gray-1 dark:bg-white/10 dark:text-white/85">

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -210,31 +210,6 @@
   animation: shine 3s linear infinite;
 }
 
-/* Sunset wordmark — a proper gradient-clip shimmer: the whole word is a light
-   lavender fill with a bright white highlight band sweeping across it. The text
-   itself is the gradient (text-fill transparent), so the sweep is crisp. */
-.theme-sunset .shiny-text {
-  /* Solid silver wordmark with a bright highlight band sweeping across — the
-     base stops are fully opaque so the text is always legible; only the band
-     moves. Matches the marketing site's wordmark. */
-  background: linear-gradient(
-    110deg,
-    #cfd0da 0%,
-    #cfd0da 42%,
-    #ffffff 50%,
-    #eef0f6 54%,
-    #cfd0da 62%,
-    #cfd0da 100%
-  ) !important;
-  background-size: 220% 100% !important;
-  -webkit-background-clip: text !important;
-  background-clip: text !important;
-  -webkit-text-fill-color: transparent !important;
-  color: transparent !important;
-}
-.theme-sunset .shiny-text.animate {
-  animation: shine 3.2s linear infinite !important;
-}
 
 /* Navbar shadow effect for dark mode */
 .navbar-shadow-container {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -214,14 +214,16 @@
    lavender fill with a bright white highlight band sweeping across it. The text
    itself is the gradient (text-fill transparent), so the sweep is crisp. */
 .theme-sunset .shiny-text {
+  /* Dim lavender base with a bright white highlight band, so the moving sweep
+     is clearly visible (an all-light gradient made the shimmer invisible). */
   background: linear-gradient(
     110deg,
-    #c7bce4 0%,
-    #c7bce4 40%,
-    #ffffff 48%,
-    #f3d9ff 52%,
-    #c7bce4 60%,
-    #c7bce4 100%
+    #8b7fb0 0%,
+    #8b7fb0 38%,
+    #ffffff 50%,
+    #f3d9ff 55%,
+    #8b7fb0 66%,
+    #8b7fb0 100%
   ) !important;
   background-size: 220% 100% !important;
   -webkit-background-clip: text !important;
@@ -230,7 +232,7 @@
   color: transparent !important;
 }
 .theme-sunset .shiny-text.animate {
-  animation: shine 4s linear infinite !important;
+  animation: shine 3.2s linear infinite !important;
 }
 
 /* Navbar shadow effect for dark mode */
@@ -414,12 +416,16 @@
 .theme-sunset .bp6-dark .bp6-popover-content,
 .theme-sunset .dark .bp6-menu,
 .theme-sunset .bp6-dark .bp6-menu {
-  background-color: #241232 !important;
+  /* Warm red → purple sunset glass, so popovers match the app surfaces instead
+     of reading as a flat off-theme box. Kept near-opaque for legible text. */
+  background-color: #2a1230 !important;
+  background-image: linear-gradient(160deg, rgba(77, 20, 16, 0.96) 0%, rgba(54, 15, 54, 0.97) 52%, rgba(36, 16, 63, 0.98) 100%) !important;
+  box-shadow: 0 12px 40px -8px rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(199, 188, 228, 0.14) !important;
   color: #efe8f5 !important;
 }
 .theme-sunset .dark .bp6-popover-arrow-fill,
 .theme-sunset .bp6-dark .bp6-popover-arrow-fill {
-  fill: #241232 !important;
+  fill: #3a123a !important;
 }
 .theme-sunset .dark .bp6-menu-item:hover,
 .theme-sunset .bp6-dark .bp6-menu-item:hover {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -214,16 +214,17 @@
    lavender fill with a bright white highlight band sweeping across it. The text
    itself is the gradient (text-fill transparent), so the sweep is crisp. */
 .theme-sunset .shiny-text {
-  /* Dim lavender base with a bright white highlight band, so the moving sweep
-     is clearly visible (an all-light gradient made the shimmer invisible). */
+  /* Solid silver wordmark with a bright highlight band sweeping across — the
+     base stops are fully opaque so the text is always legible; only the band
+     moves. Matches the marketing site's wordmark. */
   background: linear-gradient(
     110deg,
-    #8b7fb0 0%,
-    #8b7fb0 38%,
+    #cfd0da 0%,
+    #cfd0da 42%,
     #ffffff 50%,
-    #f3d9ff 55%,
-    #8b7fb0 66%,
-    #8b7fb0 100%
+    #eef0f6 54%,
+    #cfd0da 62%,
+    #cfd0da 100%
   ) !important;
   background-size: 220% 100% !important;
   -webkit-background-clip: text !important;


### PR DESCRIPTION
## Fixes

Three Sunset-theme fixes to the Claude usage UI and the wordmark.

### 1. Usage popover rendered behind the repo cards
The footer usage-meter popover used `usePortal={false}`, so it was trapped inside the footer's `backdrop-filter` stacking context and painted **under** the scrolled repo list. Portaling it to `document.body` lifts it above everything.

### 2. Portaled popover text was near-invisible
Only `theme-sunset` was mirrored onto `<html>` for portaled content — not the `dark` flag. So Tailwind's `dark:` text utilities fell back to the light palette (dark text) on the dark popover background. Now `dark` is mirrored onto `<html>` too.

### 3. Popover looked off-theme
The popover/menu surface was a flat `#241232` box. Gave it the warm red→purple Sunset gradient + subtle border so it matches the app's surfaces.

### 4. Wordmark shimmer invisible in Sunset dark
The `devkitty` shimmer used an all-light gradient, so the sweep was imperceptible. Bumped contrast (dim lavender base, bright white band) and sped it up slightly.

All renderer-only; verified the production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)