### PR TITLE
feat: scope workflow hiding to root, worktree, or pull requests

### DIFF
--- a/src/renderer/components/Project/Project.tsx
+++ b/src/renderer/components/Project/Project.tsx
@@ -68,6 +68,7 @@ export const Project: FC<Props> = ({ project }) => {
   const anyExpanded = worktrees.some(({ path }) => expandedPaths[path]);
 
   const worktreeBranches = useMemo(() => worktrees.map((worktree) => worktree.branch), [worktrees]);
+  const mainBranch = useMemo(() => worktrees.find((worktree) => worktree.isMain)?.branch ?? '', [worktrees]);
 
   const {
     clearHiddenPulls,
@@ -83,7 +84,7 @@ export const Project: FC<Props> = ({ project }) => {
     refresh,
     runsByBranch,
     runsLoaded
-  } = useRepoData(project, anyExpanded, worktreeBranches, query);
+  } = useRepoData(project, anyExpanded, worktreeBranches, mainBranch, query);
 
   // Worktrees arrive asynchronously — seed each new card from its saved state,
   // defaulting to open when the checkout has an open pull request.

--- a/src/renderer/components/Project/components/CheckoutCard/CheckoutCard.tsx
+++ b/src/renderer/components/Project/components/CheckoutCard/CheckoutCard.tsx
@@ -206,6 +206,7 @@ export const CheckoutCard: FC<Props> = ({
           a worktree only ever shows its own branch and keeps the default. */}
       <GroupRuns
         footer={footer}
+        isRoot={isMain}
         limit={isMain ? count : undefined}
         loadingOlder={loadingOlder}
         moreHistory={moreHistory}
@@ -447,6 +448,7 @@ export const CheckoutCard: FC<Props> = ({
           {showHidden && hiddenRuns.length > 0 && (
             <div className="mx-2 rounded-md [&>*]:mt-0 opacity-70">
               <GroupRuns
+                isRoot={isMain}
                 onRefresh={onRefresh}
                 project={project}
                 runs={hiddenRuns}

--- a/src/renderer/components/Project/components/CheckoutCard/GroupRuns.tsx
+++ b/src/renderer/components/Project/components/CheckoutCard/GroupRuns.tsx
@@ -14,6 +14,8 @@ type Props = {
   // Chips the card wants to share this row — its own folds would otherwise
   // stack another rule under this one.
   footer?: ReactNode;
+  // Where this list renders, so a run's hide menu can scope to root vs worktree.
+  isRoot?: boolean;
   limit?: number;
   loadingOlder?: boolean;
   moreHistory?: boolean;
@@ -31,6 +33,7 @@ type Props = {
 // attention stays on screen, the rest is one click away.
 export const GroupRuns: FC<Props> = ({
   footer,
+  isRoot = false,
   limit,
   loadingOlder,
   moreHistory,
@@ -66,6 +69,7 @@ export const GroupRuns: FC<Props> = ({
 
   const row = (run: Run) => (
     <Workflow
+      isRoot={isRoot}
       key={run.id}
       onRefresh={onRefresh}
       project={project}

--- a/src/renderer/components/Project/components/IgnoreWorkflowAlert/IgnoreWorkflowAlert.tsx
+++ b/src/renderer/components/Project/components/IgnoreWorkflowAlert/IgnoreWorkflowAlert.tsx
@@ -1,6 +1,7 @@
 import { Alert, Classes } from '@blueprintjs/core';
 import { type FC } from 'react';
 import { useAppSettings } from 'renderer/hooks/useAppSettings';
+import { addScope, parseIgnored } from 'renderer/utils/ignoredWorkflows';
 import { type ModalProps } from 'types/Modal';
 
 export type IgnoreWorkflowAlertProps = {
@@ -16,12 +17,10 @@ export const IgnoreWorkflowAlert: FC<IgnoreWorkflowAlertProps & ModalProps> = ({
   workflowPath
 }) => {
   const { gitHubActions, set } = useAppSettings();
-  const { ignoredWorkflows = [] } = gitHubActions;
 
   const confirm = () => {
-    if (!ignoredWorkflows.includes(workflowPath)) {
-      set({ gitHubActions: { ...gitHubActions, ignoredWorkflows: [...ignoredWorkflows, workflowPath] } });
-    }
+    const ignoredWorkflows = addScope(parseIgnored(gitHubActions.ignoredWorkflows), workflowPath, 'all');
+    set({ gitHubActions: { ...gitHubActions, ignoredWorkflows } });
     onClose();
   };
 

--- a/src/renderer/components/Project/components/Workflow/Workflow.tsx
+++ b/src/renderer/components/Project/components/Workflow/Workflow.tsx
@@ -4,10 +4,12 @@ import { getStatusIcon } from 'renderer/assets/gitHubStatusUtils';
 import { useAppSettings, useIsSunset } from 'renderer/hooks/useAppSettings';
 import { useModal } from 'renderer/hooks/useModal';
 import { cn } from 'renderer/utils/cn';
+import { addScope, parseIgnored, type WorkflowScope } from 'renderer/utils/ignoredWorkflows';
 import { timeAgo } from 'renderer/utils/timeAgo';
 import { type Run } from 'types/gitHub';
 import { type Project } from 'types/project';
 
+import { isPullRun } from '../../hooks/useRepoData/groupByBranch';
 import { WorkflowGraph } from './WorkflowGraph';
 
 type Job = {
@@ -21,6 +23,9 @@ type Job = {
 };
 
 type Props = {
+  // True when this row lives in the main (root) card, false in a worktree card.
+  // Decides which location the "hide on…" option scopes to.
+  isRoot?: boolean;
   onRefresh?: () => void;
   project: Project;
   run: Run;
@@ -46,7 +51,7 @@ const formatDuration = (start?: string, end?: string) => {
   return `${seconds}s`;
 };
 
-export const Workflow: FC<Props> = ({ onRefresh, project, run, stickyTop = 55 }) => {
+export const Workflow: FC<Props> = ({ isRoot = false, onRefresh, project, run, stickyTop = 55 }) => {
   const {
     conclusion,
     created_at,
@@ -67,12 +72,11 @@ export const Workflow: FC<Props> = ({ onRefresh, project, run, stickyTop = 55 })
   const pinnedWorkflows = gitHubActions.pinnedWorkflows ?? [];
   const isPinned = pinnedWorkflows.includes(path);
 
-  const ignoredWorkflows = gitHubActions.ignoredWorkflows ?? [];
+  const ignoredWorkflows = useMemo(() => parseIgnored(gitHubActions.ignoredWorkflows), [gitHubActions.ignoredWorkflows]);
+  const isPr = isPullRun(event);
 
-  const hideWorkflow = () => {
-    if (ignoredWorkflows.includes(path)) return;
-
-    set({ gitHubActions: { ...gitHubActions, ignoredWorkflows: [...ignoredWorkflows, path] } });
+  const hideScope = (scope: WorkflowScope) => {
+    set({ gitHubActions: { ...gitHubActions, ignoredWorkflows: addScope(ignoredWorkflows, path, scope) } });
   };
 
   const togglePinned = () => {
@@ -326,14 +330,29 @@ export const Workflow: FC<Props> = ({ onRefresh, project, run, stickyTop = 55 })
                 />
 
                 {/* Hiding one run of a workflow that runs on every push buys
-                    nothing — the next one is back in a minute. Hiding is
-                    per workflow, and Settings lists it for undoing. */}
-                <MenuItem
-                  icon="eye-off"
+                    nothing — the next one is back in a minute. Hiding is per
+                    workflow and scoped to where you clicked: a PR run hides only
+                    from pull requests, a push/manual run hides on its own card.
+                    Settings lists each scope for undoing. */}
+                <MenuItem icon="eye-off"
                   intent="warning"
-                  onClick={hideWorkflow}
                   text="Hide this workflow"
-                />
+                >
+                  {isPr ? (
+                    <MenuItem onClick={() => hideScope('pr')}
+                      text="From pull requests"
+                    />
+                  ) : (
+                    <MenuItem
+                      onClick={() => hideScope(isRoot ? 'root' : 'worktree')}
+                      text={isRoot ? 'On main' : 'On worktrees'}
+                    />
+                  )}
+
+                  <MenuItem onClick={() => hideScope('all')}
+                    text="Everywhere"
+                  />
+                </MenuItem>
               </Menu>
             }
             placement="bottom-end"

--- a/src/renderer/components/Project/hooks/useRepoData/groupByBranch.test.ts
+++ b/src/renderer/components/Project/hooks/useRepoData/groupByBranch.test.ts
@@ -688,18 +688,17 @@ describe('shouldNotifyRun', () => {
 });
 
 describe('shouldNotifyRun — hidden workflows', () => {
-  const hidden = new Set(['.github/workflows/graph.yml']);
-  const runOf = (path: string, conclusion: string) => ({ conclusion, event: 'push', id: 1, path }) as any;
+  const runOf = (conclusion: string) => ({ conclusion, event: 'push', id: 1 }) as any;
 
-  it('should stay quiet for a workflow you hid', () => {
-    expect(shouldNotifyRun(runOf('.github/workflows/graph.yml', 'success'), hidden)).toBe(false);
+  it('should stay quiet for a run hidden in its context', () => {
+    expect(shouldNotifyRun(runOf('success'), true)).toBe(false);
   });
 
-  it('should stay quiet even when a hidden workflow fails', () => {
-    expect(shouldNotifyRun(runOf('.github/workflows/graph.yml', 'failure'), hidden)).toBe(false);
+  it('should stay quiet even when a hidden run fails', () => {
+    expect(shouldNotifyRun(runOf('failure'), true)).toBe(false);
   });
 
-  it('should still announce a workflow that is not hidden', () => {
-    expect(shouldNotifyRun(runOf('.github/workflows/ci.yml', 'success'), hidden)).toBe(true);
+  it('should still announce a run that is not hidden', () => {
+    expect(shouldNotifyRun(runOf('success'), false)).toBe(true);
   });
 });

--- a/src/renderer/components/Project/hooks/useRepoData/groupByBranch.ts
+++ b/src/renderer/components/Project/hooks/useRepoData/groupByBranch.ts
@@ -166,11 +166,12 @@ const failedConclusions = new Set(['action_required', 'cancelled', 'failure', 's
 
 export const isPullRun = (event?: null | string) => event === 'pull_request' || event === 'pull_request_target';
 
-export const shouldNotifyRun = (run: Run, hiddenWorkflows: Set<string> = new Set()): boolean => {
+export const shouldNotifyRun = (run: Run, hidden = false): boolean => {
   if (!run.conclusion) return false;
   // A hidden workflow is still fetched — the cards offer a peek at it — but it
-  // has no business interrupting anyone.
-  if (run.path && hiddenWorkflows.has(run.path)) return false;
+  // has no business interrupting anyone. Whether it counts as hidden depends on
+  // where the run would render, so the caller decides with the run's context.
+  if (hidden) return false;
 
   return isPullRun(run.event) ? failedConclusions.has(run.conclusion) : true;
 };

--- a/src/renderer/components/Project/hooks/useRepoData/useRepoData.tsx
+++ b/src/renderer/components/Project/hooks/useRepoData/useRepoData.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppSettings } from 'renderer/hooks/useAppSettings';
 import { addHidden, hiddenPullsKey, hiddenRunsKey, parseHidden } from 'renderer/utils/hidden';
+import { type IgnoredWorkflow, isWorkflowHidden, parseIgnored, type RunContext } from 'renderer/utils/ignoredWorkflows';
 import { unhideEvent } from 'renderer/utils/unhide';
 import { type Run } from 'types/gitHub';
 import { type Project } from 'types/project';
@@ -8,6 +9,7 @@ import { type Project } from 'types/project';
 import {
   groupPullsByBranch,
   groupRunsByBranch,
+  isPullRun,
   mergeRuns,
   notifiableBranches,
   orphanPulls,
@@ -43,7 +45,13 @@ const hide = (key: string, id: number, label: string) => {
  * repo, but only checkouts on this machine — and pull requests you opened —
  * are worth interrupting you for.
  */
-export const useRepoData = (project: Project, pollRuns: boolean, worktreeBranches: string[], query = '') => {
+export const useRepoData = (
+  project: Project,
+  pollRuns: boolean,
+  worktreeBranches: string[],
+  mainBranch = '',
+  query = ''
+) => {
   const [runs, setRuns] = useState<Run[]>([]);
   const [searchedRuns, setSearchedRuns] = useState<Run[]>([]);
   const [pinnedRuns, setPinnedRuns] = useState<Run[]>([]);
@@ -72,19 +80,42 @@ export const useRepoData = (project: Project, pollRuns: boolean, worktreeBranche
   const initialRunsFetched = useRef(false);
   const notifyArmed = useRef(false);
   const notifyBranches = useRef<Set<string>>(new Set());
-  const hiddenWorkflows = useRef<Set<string>>(new Set());
+  const hiddenWorkflows = useRef<IgnoredWorkflow[]>([]);
+  // The pieces `getRuns` needs to place a run in root vs worktree, kept in a ref
+  // so a branch-list change never rebuilds the poll.
+  const rootContext = useRef<{ mainBranch: string; worktrees: Set<string> }>({ mainBranch: '', worktrees: new Set() });
+
+  // Stored data may still be the legacy `string[]`, so it is parsed forward on
+  // every read rather than trusted to match the current shape.
+  const ignored = useMemo(() => parseIgnored(ignoredWorkflows), [ignoredWorkflows]);
+
+  // A run's card decides its scope: the main branch and any branch checked out
+  // nowhere render under the main (root) card; a worktree's own branch is the
+  // one worktree context. `isPr` comes straight off the run's event.
+  const contextOf = useCallback(
+    (run: Run): RunContext => ({
+      isPr: isPullRun(run.event),
+      isRoot: !(worktreeBranches.includes(run.head_branch) && run.head_branch !== mainBranch),
+      path: run.path
+    }),
+    [mainBranch, worktreeBranches]
+  );
 
   // Refs, not deps: `getRuns` reads them when it fires, and rebuilding it would
   // restart the poll every time a setting changes.
   useEffect(() => {
-    hiddenWorkflows.current = new Set(ignoredWorkflows);
-  }, [ignoredWorkflows]);
+    hiddenWorkflows.current = ignored;
+  }, [ignored]);
 
   // A ref, not state: `getRuns` reads it at fire time and must not be rebuilt
   // (and so restart the poll) every time a branch list changes identity.
   useEffect(() => {
     notifyBranches.current = notifiableBranches(worktreeBranches, pulls);
   }, [pulls, worktreeBranches]);
+
+  useEffect(() => {
+    rootContext.current = { mainBranch, worktrees: new Set(worktreeBranches) };
+  }, [mainBranch, worktreeBranches]);
 
   /**
    * `arm` is passed only by the *polling* fetch. The mount fetch runs for every
@@ -112,7 +143,14 @@ export const useRepoData = (project: Project, pollRuns: boolean, worktreeBranche
         notifyArmed.current &&
         prev !== undefined &&
         !prev &&
-        shouldNotifyRun(run, hiddenWorkflows.current) &&
+        shouldNotifyRun(
+          run,
+          isWorkflowHidden(hiddenWorkflows.current, {
+            isPr: isPullRun(run.event),
+            isRoot: !(rootContext.current.worktrees.has(run.head_branch) && run.head_branch !== rootContext.current.mainBranch),
+            path: run.path
+          })
+        ) &&
         notifications &&
         notifyBranches.current.has(run.head_branch ?? '')
       ) {
@@ -386,21 +424,20 @@ export const useRepoData = (project: Project, pollRuns: boolean, worktreeBranche
   }, [olderRuns, pinnedRuns, runs, searchedRuns]);
 
   // Hiding a workflow has to apply here too, not only to the next fetch: runs
-  // already merged into state would otherwise keep showing forever.
-  const runsByBranch = useMemo(() => {
-    const hiddenWorkflows = new Set(ignoredWorkflows);
-
-    return groupRunsByBranch(allRuns.filter((run) => !hiddenWorkflows.has(run.path)));
-  }, [allRuns, ignoredWorkflows]);
+  // already merged into state would otherwise keep showing forever. A run's
+  // scope depends on where it renders, so it is judged by its own context.
+  const runsByBranch = useMemo(
+    () => groupRunsByBranch(allRuns.filter((run) => !isWorkflowHidden(ignored, contextOf(run)))),
+    [allRuns, contextOf, ignored]
+  );
 
   // The same runs, but only the hidden ones: a card can offer a peek at what it
   // is holding back without anything being unhidden.
   const hiddenRunsByBranch = useMemo(() => {
-    const hiddenWorkflows = new Set(ignoredWorkflows);
-    if (hiddenWorkflows.size === 0) return {};
+    if (ignored.length === 0) return {};
 
-    return groupRunsByBranch(allRuns.filter((run) => hiddenWorkflows.has(run.path)));
-  }, [allRuns, ignoredWorkflows]);
+    return groupRunsByBranch(allRuns.filter((run) => isWorkflowHidden(ignored, contextOf(run))));
+  }, [allRuns, contextOf, ignored]);
 
   const pullsByBranch = useMemo(
     () => groupPullsByBranch(pulls.filter(({ pull }) => !hiddenPulls.has(pull.id))),

--- a/src/renderer/components/SettingsActions/SettingsActions.tsx
+++ b/src/renderer/components/SettingsActions/SettingsActions.tsx
@@ -4,16 +4,18 @@ import { useAppSettings } from 'renderer/hooks/useAppSettings';
 import { useProjects } from 'renderer/hooks/useProjects';
 import { cn } from 'renderer/utils/cn';
 import { type HiddenEntry, hiddenPullsPrefix, parseHidden, projectIdOf, removeHidden } from 'renderer/utils/hidden';
+import { parseIgnored, removeScope, scopeLabel } from 'renderer/utils/ignoredWorkflows';
 import { unhideEvent } from 'renderer/utils/unhide';
 
 type HiddenRow = HiddenEntry & { key: string; projectId: string };
 
 // One row shape for both lists: hidden workflows carry no repo badge, hidden
-// pull requests do.
+// pull requests do. A row can offer more than one unhide button — a workflow
+// hidden in several scopes lists one per scope on the same line.
 type ListRow = {
+  actions: { label: string; onUnhide: () => void }[];
   badge?: string;
   label: string;
-  onUnhide: () => void;
   rowKey: string;
 };
 
@@ -30,10 +32,12 @@ const readHidden = () => readRows(hiddenPullsPrefix);
 
 export const SettingsActions = () => {
   const { gitHubActions, set } = useAppSettings();
-  const { count = 5, ignoreDependabot = false, ignoredWorkflows = [], notifications = true } = gitHubActions;
+  const { count = 5, ignoreDependabot = false, notifications = true } = gitHubActions;
+  // Stored data may still be the legacy `string[]`, so parse it forward.
+  const ignoredWorkflows = parseIgnored(gitHubActions.ignoredWorkflows);
 
-  const removeIgnored = (name: string) => {
-    set({ gitHubActions: { ...gitHubActions, ignoredWorkflows: ignoredWorkflows.filter((w) => w !== name) } });
+  const unhideScope = (path: string, scope: Parameters<typeof scopeLabel>[0]) => {
+    set({ gitHubActions: { ...gitHubActions, ignoredWorkflows: removeScope(ignoredWorkflows, path, scope) } });
   };
 
   const { projects } = useProjects();
@@ -95,28 +99,34 @@ export const SettingsActions = () => {
               <span className="text-xs truncate flex-1 min-w-0">{item.label}</span>
               {item.badge && <Tag minimal>{item.badge}</Tag>}
 
-              <Button
-                onClick={item.onUnhide}
-                size="small"
-                text="Unhide"
-                variant="minimal"
-              />
+              {item.actions.map((action) => (
+                <Button
+                  key={action.label}
+                  onClick={action.onUnhide}
+                  size="small"
+                  text={action.label}
+                  variant="minimal"
+                />
+              ))}
             </div>
           ))}
         </div>
       </>
     );
 
-  const workflowRows: ListRow[] = ignoredWorkflows.map((path) => ({
+  // One row per hidden workflow, with an unhide button for each scope it is
+  // hidden in — "Everywhere", "main", "Pull requests" — so any one can be lifted
+  // without touching the others.
+  const workflowRows: ListRow[] = ignoredWorkflows.map(({ path, scopes }) => ({
+    actions: scopes.map((scope) => ({ label: scopeLabel(scope), onUnhide: () => unhideScope(path, scope) })),
     label: workflowName(path),
-    onUnhide: () => removeIgnored(path),
     rowKey: path
   }));
 
   const pullRows: ListRow[] = hiddenPulls.map((row) => ({
+    actions: [{ label: 'Unhide', onUnhide: () => unhideOne(row) }],
     badge: projectName(row.projectId),
     label: row.label,
-    onUnhide: () => unhideOne(row),
     rowKey: `${row.key}-${row.id}`
   }));
 

--- a/src/renderer/components/SettingsActions/SettingsActions.tsx
+++ b/src/renderer/components/SettingsActions/SettingsActions.tsx
@@ -118,7 +118,7 @@ export const SettingsActions = () => {
   // hidden in — "Everywhere", "main", "Pull requests" — so any one can be lifted
   // without touching the others.
   const workflowRows: ListRow[] = ignoredWorkflows.map(({ path, scopes }) => ({
-    actions: scopes.map((scope) => ({ label: scopeLabel(scope), onUnhide: () => unhideScope(path, scope) })),
+    actions: scopes.map((scope) => ({ label: `Unhide ${scopeLabel(scope)}`, onUnhide: () => unhideScope(path, scope) })),
     label: workflowName(path),
     rowKey: path
   }));

--- a/src/renderer/utils/ignoredWorkflows.test.ts
+++ b/src/renderer/utils/ignoredWorkflows.test.ts
@@ -138,10 +138,10 @@ describe('removeScope', () => {
 
 describe('scopeLabel', () => {
   it('should name every scope', () => {
-    expect(scopeLabel('all')).toBe('Everywhere');
-    expect(scopeLabel('root')).toBe('main');
+    expect(scopeLabel('all')).toBe('everywhere');
+    expect(scopeLabel('root')).toBe('root');
     expect(scopeLabel('worktree')).toBe('worktrees');
-    expect(scopeLabel('pr')).toBe('Pull requests');
-    expect(scopeLabel('non-pr')).toBe('Non-PR');
+    expect(scopeLabel('pr')).toBe('pull requests');
+    expect(scopeLabel('non-pr')).toBe('non-PR');
   });
 });

--- a/src/renderer/utils/ignoredWorkflows.test.ts
+++ b/src/renderer/utils/ignoredWorkflows.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addScope,
+  type IgnoredWorkflow,
+  isWorkflowHidden,
+  parseIgnored,
+  removeScope,
+  type RunContext,
+  scopeLabel,
+  scopeMatches
+} from './ignoredWorkflows';
+
+describe('parseIgnored', () => {
+  it('should return nothing for a non-array', () => {
+    expect(parseIgnored(null)).toEqual([]);
+    expect(parseIgnored('nope')).toEqual([]);
+  });
+
+  it('should migrate legacy bare paths to hide everywhere', () => {
+    expect(parseIgnored(['.github/workflows/ci.yml'])).toEqual([
+      { path: '.github/workflows/ci.yml', scopes: ['all'] }
+    ]);
+  });
+
+  it('should migrate a scopeless object to hide everywhere', () => {
+    expect(parseIgnored([{ path: 'a.yml' }])).toEqual([{ path: 'a.yml', scopes: ['all'] }]);
+  });
+
+  it('should keep valid scopes and drop invalid ones', () => {
+    expect(parseIgnored([{ path: 'a.yml', scopes: ['root', 'bogus', 'pr'] }])).toEqual([
+      { path: 'a.yml', scopes: ['root', 'pr'] }
+    ]);
+  });
+
+  it('should fall back to all when every stored scope is invalid', () => {
+    expect(parseIgnored([{ path: 'a.yml', scopes: ['bogus'] }])).toEqual([{ path: 'a.yml', scopes: ['all'] }]);
+  });
+
+  it('should merge duplicate paths into one entry', () => {
+    expect(parseIgnored([{ path: 'a.yml', scopes: ['root'] }, { path: 'a.yml', scopes: ['pr'] }])).toEqual([
+      { path: 'a.yml', scopes: ['root', 'pr'] }
+    ]);
+  });
+
+  it('should order scopes canonically regardless of input order', () => {
+    expect(parseIgnored([{ path: 'a.yml', scopes: ['pr', 'root', 'worktree'] }])[0].scopes).toEqual([
+      'root',
+      'worktree',
+      'pr'
+    ]);
+  });
+});
+
+describe('scopeMatches', () => {
+  const rootPush: RunContext = { isPr: false, isRoot: true };
+  const worktreePush: RunContext = { isPr: false, isRoot: false };
+  const rootPr: RunContext = { isPr: true, isRoot: true };
+  const worktreePr: RunContext = { isPr: true, isRoot: false };
+
+  it('all should match every context', () => {
+    for (const ctx of [rootPush, worktreePush, rootPr, worktreePr]) {
+      expect(scopeMatches('all', ctx)).toBe(true);
+    }
+  });
+
+  it('root should match only non-PR runs on the main card', () => {
+    expect(scopeMatches('root', rootPush)).toBe(true);
+    expect(scopeMatches('root', rootPr)).toBe(false);
+    expect(scopeMatches('root', worktreePush)).toBe(false);
+  });
+
+  it('worktree should match only non-PR runs on a worktree card', () => {
+    expect(scopeMatches('worktree', worktreePush)).toBe(true);
+    expect(scopeMatches('worktree', worktreePr)).toBe(false);
+    expect(scopeMatches('worktree', rootPush)).toBe(false);
+  });
+
+  it('pr should match any pull-request run, root or worktree', () => {
+    expect(scopeMatches('pr', rootPr)).toBe(true);
+    expect(scopeMatches('pr', worktreePr)).toBe(true);
+    expect(scopeMatches('pr', rootPush)).toBe(false);
+  });
+
+  it('non-pr should match any non-PR run, root or worktree', () => {
+    expect(scopeMatches('non-pr', rootPush)).toBe(true);
+    expect(scopeMatches('non-pr', worktreePush)).toBe(true);
+    expect(scopeMatches('non-pr', worktreePr)).toBe(false);
+  });
+});
+
+describe('isWorkflowHidden', () => {
+  const entries: IgnoredWorkflow[] = [{ path: 'a.yml', scopes: ['worktree'] }];
+
+  it('should hide the worktree push run but not the worktree PR run', () => {
+    expect(isWorkflowHidden(entries, { isPr: false, isRoot: false, path: 'a.yml' })).toBe(true);
+    // The exact bug: hiding on worktrees must leave PR checks visible.
+    expect(isWorkflowHidden(entries, { isPr: true, isRoot: false, path: 'a.yml' })).toBe(false);
+  });
+
+  it('should not hide a run whose path is not listed', () => {
+    expect(isWorkflowHidden(entries, { isPr: false, isRoot: false, path: 'b.yml' })).toBe(false);
+  });
+
+  it('should never hide a run with no path', () => {
+    expect(isWorkflowHidden([{ path: '', scopes: ['all'] }], { isPr: false, isRoot: false, path: null })).toBe(false);
+  });
+});
+
+describe('addScope', () => {
+  it('should add a new workflow', () => {
+    expect(addScope([], 'a.yml', 'root')).toEqual([{ path: 'a.yml', scopes: ['root'] }]);
+  });
+
+  it('should add a scope to an existing workflow in canonical order', () => {
+    expect(addScope([{ path: 'a.yml', scopes: ['pr'] }], 'a.yml', 'root')).toEqual([
+      { path: 'a.yml', scopes: ['root', 'pr'] }
+    ]);
+  });
+
+  it('should be a no-op when the scope is already present', () => {
+    const entries: IgnoredWorkflow[] = [{ path: 'a.yml', scopes: ['root'] }];
+    expect(addScope(entries, 'a.yml', 'root')).toBe(entries);
+  });
+});
+
+describe('removeScope', () => {
+  it('should drop just the one scope', () => {
+    expect(removeScope([{ path: 'a.yml', scopes: ['root', 'pr'] }], 'a.yml', 'root')).toEqual([
+      { path: 'a.yml', scopes: ['pr'] }
+    ]);
+  });
+
+  it('should remove the whole workflow when its last scope goes', () => {
+    expect(removeScope([{ path: 'a.yml', scopes: ['root'] }], 'a.yml', 'root')).toEqual([]);
+  });
+});
+
+describe('scopeLabel', () => {
+  it('should name every scope', () => {
+    expect(scopeLabel('all')).toBe('Everywhere');
+    expect(scopeLabel('root')).toBe('main');
+    expect(scopeLabel('worktree')).toBe('worktrees');
+    expect(scopeLabel('pr')).toBe('Pull requests');
+    expect(scopeLabel('non-pr')).toBe('Non-PR');
+  });
+});

--- a/src/renderer/utils/ignoredWorkflows.ts
+++ b/src/renderer/utils/ignoredWorkflows.ts
@@ -1,0 +1,110 @@
+import { type IgnoredWorkflow, type WorkflowScope } from 'types/ignoredWorkflow';
+
+export { type IgnoredWorkflow, type WorkflowScope } from 'types/ignoredWorkflow';
+
+// Where a run renders, which is all the scope test needs: is it in the main
+// card (root) or a worktree card, and is it a pull-request run.
+export type RunContext = {
+  isPr: boolean;
+  isRoot: boolean;
+  path?: null | string;
+};
+
+const validScopes: WorkflowScope[] = ['all', 'root', 'worktree', 'pr', 'non-pr'];
+
+const isScope = (value: unknown): value is WorkflowScope => validScopes.includes(value as WorkflowScope);
+
+// Order scopes for stable rendering regardless of the order they were added in.
+const scopeOrder = (scope: WorkflowScope) => validScopes.indexOf(scope);
+
+/**
+ * Hidden workflows used to be stored as bare `string[]` paths, meaning "hide
+ * everywhere". A later shape carried `{ path }` objects. Both migrate forward to
+ * scoped entries so nothing hidden before the change gets stranded, and an entry
+ * with no recognisable scope falls back to `all`.
+ */
+export const parseIgnored = (raw: unknown): IgnoredWorkflow[] => {
+  if (!Array.isArray(raw)) return [];
+
+  const byPath = new Map<string, Set<WorkflowScope>>();
+
+  for (const item of raw) {
+    let path: string | undefined;
+    let scopes: WorkflowScope[] = ['all'];
+
+    if (typeof item === 'string') {
+      path = item;
+    } else if (item && typeof item === 'object' && typeof (item as { path?: unknown }).path === 'string') {
+      const { path: storedPath, scopes: storedScopes } = item as { path: string; scopes?: unknown };
+      const kept = Array.isArray(storedScopes) ? storedScopes.filter(isScope) : [];
+      path = storedPath;
+      scopes = kept.length > 0 ? kept : ['all'];
+    }
+
+    if (!path) continue;
+
+    const set = byPath.get(path) ?? new Set<WorkflowScope>();
+    for (const scope of scopes) set.add(scope);
+    byPath.set(path, set);
+  }
+
+  return [...byPath.entries()].map(([path, set]) => ({
+    path,
+    scopes: [...set].sort((a, b) => scopeOrder(a) - scopeOrder(b))
+  }));
+};
+
+export const scopeMatches = (scope: WorkflowScope, { isPr, isRoot }: RunContext): boolean => {
+  switch (scope) {
+    case 'all':
+      return true;
+    case 'non-pr':
+      return !isPr;
+    case 'pr':
+      return isPr;
+    case 'root':
+      return isRoot && !isPr;
+    case 'worktree':
+      return !isRoot && !isPr;
+    default:
+      return false;
+  }
+};
+
+export const isWorkflowHidden = (entries: IgnoredWorkflow[], ctx: RunContext): boolean => {
+  if (!ctx.path) return false;
+
+  const entry = entries.find((item) => item.path === ctx.path);
+
+  return entry ? entry.scopes.some((scope) => scopeMatches(scope, ctx)) : false;
+};
+
+export const addScope = (entries: IgnoredWorkflow[], path: string, scope: WorkflowScope): IgnoredWorkflow[] => {
+  const existing = entries.find((item) => item.path === path);
+
+  if (!existing) return [...entries, { path, scopes: [scope] }];
+  if (existing.scopes.includes(scope)) return entries;
+
+  return entries.map((item) =>
+    item.path === path
+      ? { ...item, scopes: [...item.scopes, scope].sort((a, b) => scopeOrder(a) - scopeOrder(b)) }
+      : item
+  );
+};
+
+// Dropping the last scope of a workflow removes the workflow entirely, so an
+// unhidden workflow leaves no empty row behind.
+export const removeScope = (entries: IgnoredWorkflow[], path: string, scope: WorkflowScope): IgnoredWorkflow[] =>
+  entries
+    .map((item) => (item.path === path ? { ...item, scopes: item.scopes.filter((s) => s !== scope) } : item))
+    .filter((item) => item.scopes.length > 0);
+
+const scopeLabels: Record<WorkflowScope, string> = {
+  all: 'Everywhere',
+  'non-pr': 'Non-PR',
+  pr: 'Pull requests',
+  root: 'main',
+  worktree: 'worktrees'
+};
+
+export const scopeLabel = (scope: WorkflowScope): string => scopeLabels[scope];

--- a/src/renderer/utils/ignoredWorkflows.ts
+++ b/src/renderer/utils/ignoredWorkflows.ts
@@ -100,10 +100,10 @@ export const removeScope = (entries: IgnoredWorkflow[], path: string, scope: Wor
     .filter((item) => item.scopes.length > 0);
 
 const scopeLabels: Record<WorkflowScope, string> = {
-  all: 'Everywhere',
-  'non-pr': 'Non-PR',
-  pr: 'Pull requests',
-  root: 'main',
+  all: 'everywhere',
+  'non-pr': 'non-PR',
+  pr: 'pull requests',
+  root: 'root',
   worktree: 'worktrees'
 };
 

--- a/src/types/appSettings.ts
+++ b/src/types/appSettings.ts
@@ -1,5 +1,6 @@
 import { type FoundEditor } from './foundEditor';
 import { type FoundShell } from './foundShell';
+import { type IgnoredWorkflow } from './ignoredWorkflow';
 
 export type AppSettings = {
   claudeAccountDir?: string; // config dir of the account shown in the usage footer
@@ -10,7 +11,7 @@ export type AppSettings = {
     all: boolean;
     count: number;
     ignoreDependabot: boolean;
-    ignoredWorkflows: string[];
+    ignoredWorkflows: IgnoredWorkflow[];
     notifications: boolean;
     pinnedWorkflows: string[];
   };

--- a/src/types/ignoredWorkflow.ts
+++ b/src/types/ignoredWorkflow.ts
@@ -1,0 +1,10 @@
+export type IgnoredWorkflow = {
+  path: string;
+  scopes: WorkflowScope[];
+};
+
+// A workflow can be hidden in more than one place at once. The scopes are
+// buckets, not independent axes: a pull-request run is only ever a `pr`, and a
+// push/manual run is a `root`/`worktree`/`non-pr`. That is why hiding on
+// worktrees leaves the PR checks alone — a PR run never matches `worktree`.
+export type WorkflowScope = 'all' | 'non-pr' | 'pr' | 'root' | 'worktree';


### PR DESCRIPTION
## What

Hiding a workflow used to be global — one flat list of workflow paths that hid the workflow in every card and every context. Hiding a workflow to quiet a worktree also swallowed its pull-request checks.

Hiding is now **scoped to where the run renders**.

## How it works

Each ignored workflow carries a set of scopes: `all` (everywhere), `root` (on main), `worktree` (on worktrees), `pr` (from pull requests). A run is hidden only when one of the workflow's scopes matches the run's own context — which card it renders in, and whether it's a pull-request run.

The scopes are **buckets, not independent axes**: a pull-request run only ever matches `pr`, and a push/manual run matches `root`/`worktree`. That's the fix for the reported bug — hiding on worktrees no longer hides the PR checks in that worktree.

## UI

- **Run menu → Hide this workflow** now offers two choices scoped to where you clicked:
  - non-PR run on main → **On main** · **Everywhere**
  - non-PR run on a worktree → **On worktrees** · **Everywhere**
  - PR run → **From pull requests** · **Everywhere**
- **Settings → GitHub → Hidden** lists each hidden workflow once, with an unhide button per active scope on the same line, so any one scope can be lifted without touching the others.

## Migration

Legacy `string[]` entries are parsed forward to `everywhere` on read, so nothing hidden before this change is stranded.

## Tests

New `ignoredWorkflows` util is unit-tested (parse/migration, scope matching, add/remove, labels), including the exact bug: a `worktree`-scoped workflow hides the worktree push run but leaves the worktree PR run visible. `shouldNotifyRun` updated to take a precomputed hidden flag. Full suite: 416 tests pass, lint and typecheck clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)