### PR TITLE
fix: fold failed runs superseded by a newer successful run

### DIFF
--- a/src/renderer/components/Project/hooks/useRepoData/groupByBranch.test.ts
+++ b/src/renderer/components/Project/hooks/useRepoData/groupByBranch.test.ts
@@ -521,6 +521,62 @@ describe('splitDoneRuns — pinned workflows', () => {
   });
 });
 
+describe('splitDoneRuns — failures superseded by a newer success', () => {
+  const at = (id: number, conclusion: null | string, path: string, createdAt: string) =>
+    ({ conclusion, created_at: createdAt, head_branch: 'main', id, path, status: 'completed' }) as any;
+  const deploy = '.github/workflows/deploy.yml';
+
+  it('should fold an old failure once a newer run of the same workflow succeeds', () => {
+    const result = splitDoneRuns([
+      at(1, 'failure', deploy, '2026-08-16T10:00:00Z'),
+      at(2, 'success', deploy, '2026-08-16T12:00:00Z')
+    ]);
+
+    expect(result.active).toEqual([]);
+    expect(result.done.map((item) => item.id)).toEqual([1, 2]);
+  });
+
+  it('should keep a failure active when the newer success is a different workflow', () => {
+    const result = splitDoneRuns([
+      at(1, 'failure', deploy, '2026-08-16T10:00:00Z'),
+      at(2, 'success', '.github/workflows/ci.yml', '2026-08-16T12:00:00Z')
+    ]);
+
+    expect(result.active.map((item) => item.id)).toEqual([1]);
+    expect(result.done.map((item) => item.id)).toEqual([2]);
+  });
+
+  it('should keep a failure active when the only success is older', () => {
+    const result = splitDoneRuns([
+      at(1, 'success', deploy, '2026-08-16T10:00:00Z'),
+      at(2, 'failure', deploy, '2026-08-16T12:00:00Z')
+    ]);
+
+    expect(result.active.map((item) => item.id)).toEqual([2]);
+    expect(result.done.map((item) => item.id)).toEqual([1]);
+  });
+
+  it('should fold superseded cancelled and timed-out runs too', () => {
+    const result = splitDoneRuns([
+      at(1, 'cancelled', deploy, '2026-08-16T10:00:00Z'),
+      at(2, 'timed_out', deploy, '2026-08-16T11:00:00Z'),
+      at(3, 'success', deploy, '2026-08-16T12:00:00Z')
+    ]);
+
+    expect(result.active).toEqual([]);
+    expect(result.done.map((item) => item.id)).toEqual([1, 2, 3]);
+  });
+
+  it('should not supersede a failure that lacks a workflow path', () => {
+    const result = splitDoneRuns([
+      { conclusion: 'failure', created_at: '2026-08-16T10:00:00Z', head_branch: 'main', id: 1, status: 'completed' } as any,
+      at(2, 'success', deploy, '2026-08-16T12:00:00Z')
+    ]);
+
+    expect(result.active.map((item) => item.id)).toEqual([1]);
+  });
+});
+
 describe('notifiableBranches', () => {
   it('should include every locally checked out branch', () => {
     const result = notifiableBranches(['main', 'feature'], []);

--- a/src/renderer/components/Project/hooks/useRepoData/groupByBranch.ts
+++ b/src/renderer/components/Project/hooks/useRepoData/groupByBranch.ts
@@ -33,10 +33,30 @@ export const splitDoneRuns = (
     }
   }
 
+  // Newest successful run per workflow. A failure that a later run of the same
+  // workflow already went green over has been dealt with — a re-run passed — so
+  // it retires to `done` instead of nagging from the active list forever.
+  const latestSuccessAt = new Map<string, number>();
+
+  for (const run of runs) {
+    if (!run.path || run.conclusion !== 'success') continue;
+
+    const at = new Date(run.created_at).getTime();
+    const current = latestSuccessAt.get(run.path);
+    if (current === undefined || at > current) latestSuccessAt.set(run.path, at);
+  }
+
+  const isSuperseded = (run: Run): boolean => {
+    if (!run.path || !run.conclusion || settledConclusions.has(run.conclusion)) return false;
+
+    const successAt = latestSuccessAt.get(run.path);
+    return successAt !== undefined && successAt > new Date(run.created_at).getTime();
+  };
+
   for (const run of runs) {
     if (run.path && latestPinned.get(run.path)?.id === run.id) {
       pinned.push(run);
-    } else if (run.conclusion && settledConclusions.has(run.conclusion)) {
+    } else if ((run.conclusion && settledConclusions.has(run.conclusion)) || isSuperseded(run)) {
       done.push(run);
     } else {
       active.push(run);


### PR DESCRIPTION
## Problem

A failed workflow run stayed in the active run list for the full 24h window even after a later run of the *same workflow* succeeded. The result: an old failure (e.g. Production Deployment #476, 17h ago) kept showing on the card right next to its own newer green re-run (#478, 1h ago).

Root cause is in `splitDoneRuns`: runs were bucketed purely by conclusion. `failure`/`cancelled`/`timed_out` are deliberately kept in the `active` bucket ("usually want a re-run"), but there was no check for whether a newer run of the same workflow had already gone green.

## Fix

`splitDoneRuns` now builds a newest-success-per-workflow-`path` map, then retires any *finished* non-settled run (`failure`, `cancelled`, `timed_out`, `action_required`) that is older than a success of the same workflow into the folded `done` bucket.

Guards:
- Still-running runs (no conclusion) stay active.
- Only a success of the *same* workflow path supersedes.
- Only a *newer* success supersedes; an older success leaves the failure active.
- A failure with no workflow `path` is unaffected.

## Testing

- New `splitDoneRuns — failures superseded by a newer success` describe block (5 cases).
- Full `groupByBranch.test.ts` suite passes (90 tests).
- Ran `pnpm dev`; app builds and launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)