### PR TITLE
feat: PR review status badge, reviewers panel, sunset toasts

### DIFF
--- a/src/main/ipcs/index.ts
+++ b/src/main/ipcs/index.ts
@@ -8,3 +8,4 @@ import './ipcNotification';
 import './ipcSticker';
 import './ipcWorktree';
 import './ipcClaude';
+import './ipcWindow';

--- a/src/main/ipcs/ipcGitHub.ts
+++ b/src/main/ipcs/ipcGitHub.ts
@@ -1,12 +1,35 @@
+import { execFile } from 'child_process';
 import { ipcMain, safeStorage } from 'electron';
 import log from 'electron-log';
 import { Octokit } from 'octokit';
 import { type PullType, type Run } from 'types/gitHub';
+import { promisify } from 'util';
 
-import { getRepoInfo } from '../libs/git';
+import { getProjectPath, getRepoInfo } from '../libs/git';
 import { settings } from '../settings';
 
 const protectedBranches = ['master', 'main'];
+
+const execFileAsync = promisify(execFile);
+
+// Runs a `gh` command so PR mutations happen server-side on GitHub (never a
+// local checkout), using the user's own `gh auth` session. Returns gh's own
+// stderr as the error message — it is already human-readable ("Pull request is
+// not mergeable", "merge conflict between base and head", …).
+const runGh = async (args: string[]): Promise<{ message?: string; success: boolean }> => {
+  try {
+    await execFileAsync('gh', args, { maxBuffer: 1024 * 1024 });
+    return { success: true };
+  } catch (e) {
+    const err = e as { message?: string; stderr?: string; };
+    const raw = (err.stderr || err.message || 'gh command failed').trim();
+    // Keep the last meaningful line, then strip gh's leading status glyph
+    // ("X ", "✗ ", "! ", …) so the toast reads as a plain sentence.
+    const lines = raw.split('\n').map((l) => l.trim()).filter((l) => l.length > 0 && !l.startsWith('Usage:'));
+    const message = (lines.at(-1) ?? raw).replace(/^[X✗✔✓!•\-–]\s+/u, '').trim();
+    return { message: message || raw, success: false };
+  }
+};
 
 const octokit = () => {
   const { gitHubToken } = settings.get('appSettings');
@@ -360,7 +383,207 @@ ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number) =>
 
     const review = { approvedBy, changesRequestedBy, reviewers, state: reviewState };
 
-    return { checks, review, success: true };
+    // One GraphQL round-trip for the things REST can't give us: unresolved
+    // review conversations (GitHub blocks merge on these), and whether auto-merge
+    // is available / already armed for this PR.
+    let unresolvedComments = 0;
+    let unresolvedThreads: { avatarUrl: string; count: number; login: string; path: null | string }[] = [];
+    let autoMergeAllowed = false;
+    let autoMergeEnabled = false;
+    try {
+      const gql = await octokit().graphql<{
+        repository: {
+          autoMergeAllowed: boolean;
+          pullRequest: {
+            autoMergeRequest: null | { enabledAt: string };
+            reviewThreads: {
+              nodes: {
+                comments: { nodes: { author: null | { avatarUrl: string; login: string } }[]; totalCount: number };
+                isResolved: boolean;
+                path: null | string;
+              }[];
+            };
+            viewerCanEnableAutoMerge: boolean;
+          };
+        };
+      }>(
+        `query ($owner: String!, $repo: String!, $num: Int!) {
+          repository(owner: $owner, name: $repo) {
+            autoMergeAllowed
+            pullRequest(number: $num) {
+              reviewThreads(first: 100) {
+                nodes {
+                  isResolved
+                  path
+                  comments(first: 1) {
+                    totalCount
+                    nodes { author { login avatarUrl } }
+                  }
+                }
+              }
+              viewerCanEnableAutoMerge
+              autoMergeRequest { enabledAt }
+            }
+          }
+        }`,
+        { num: prNumber, owner, repo }
+      );
+      const gqlPr = gql.repository.pullRequest;
+      const unresolved = gqlPr.reviewThreads.nodes.filter((t) => !t.isResolved);
+      unresolvedComments = unresolved.length;
+      unresolvedThreads = unresolved.map((t) => ({
+        avatarUrl: t.comments.nodes[0]?.author?.avatarUrl ?? '',
+        count: t.comments.totalCount,
+        login: t.comments.nodes[0]?.author?.login ?? 'unknown',
+        path: t.path
+      }));
+      autoMergeEnabled = Boolean(gqlPr.autoMergeRequest);
+      autoMergeAllowed = gql.repository.autoMergeAllowed && gqlPr.viewerCanEnableAutoMerge;
+    } catch (gqlErr) {
+      log.error(gqlErr);
+    }
+
+    // Out-of-date detection, independent of mergeable_state: mergeable_state
+    // collapses to 'blocked'/'unstable' when other rules block the merge, hiding
+    // the "behind" fact. Comparing base...head gives behind_by directly, so the
+    // "Update branch" affordance shows whenever the branch is actually behind.
+    let behind = false;
+    try {
+      const { data: cmp } = await octokit().rest.repos.compareCommits({
+        base: pr.base.ref,
+        head: sha,
+        owner,
+        repo
+      });
+      behind = (cmp.behind_by ?? 0) > 0;
+    } catch (cmpErr) {
+      log.error(cmpErr);
+    }
+
+    return {
+      // mergeable_state: clean | unstable | has_hooks (mergeable) vs
+      // blocked | dirty | behind | draft | unknown (not). Renderer uses it to
+      // enable/disable the merge button, matching GitHub.
+      autoMergeAllowed,
+      autoMergeEnabled,
+      behind,
+      checks,
+      mergeable: pr.mergeable ?? null,
+      mergeableState: pr.mergeable_state ?? 'unknown',
+      review,
+      success: true,
+      unresolvedComments,
+      unresolvedThreads
+    };
+  } catch (e) {
+    log.error(e);
+    return { message: e.message, success: false };
+  }
+});
+
+ipcMain.handle(
+  'git:api:mergePR',
+  async (_, id: string, prNumber: number, method: 'merge' | 'rebase' | 'squash') => {
+    try {
+      const { owner, repo } = await getRepoInfo(id);
+      if (!owner || !repo) throw new Error('Project not found');
+
+      // `gh pr merge` merges on GitHub's side (not the local clone). The method
+      // flag makes it non-interactive.
+      const flag = method === 'squash' ? '--squash' : method === 'rebase' ? '--rebase' : '--merge';
+      return await runGh(['pr', 'merge', String(prNumber), '--repo', `${owner}/${repo}`, flag]);
+    } catch (e) {
+      log.error(e);
+      return { message: e.message, success: false };
+    }
+  }
+);
+
+ipcMain.handle(
+  'git:api:updateBranch',
+  async (_, id: string, prNumber: number, method: 'merge' | 'rebase' = 'merge') => {
+    try {
+      const { owner, repo } = await getRepoInfo(id);
+      if (!owner || !repo) throw new Error('Project not found');
+
+      // `gh pr update-branch` updates the PR head with its base on GitHub's side
+      // — a merge commit by default, or a rebase with --rebase.
+      const args = ['pr', 'update-branch', String(prNumber), '--repo', `${owner}/${repo}`];
+      if (method === 'rebase') args.push('--rebase');
+      return await runGh(args);
+    } catch (e) {
+      log.error(e);
+      return { message: e.message, success: false };
+    }
+  }
+);
+
+ipcMain.handle(
+  'git:api:enableAutoMerge',
+  async (_, id: string, prNumber: number, method: 'merge' | 'rebase' | 'squash') => {
+    try {
+      const { owner, repo } = await getRepoInfo(id);
+      if (!owner || !repo) throw new Error('Project not found');
+
+      // `gh pr merge --auto` arms auto-merge: GitHub merges once every required
+      // check and review passes. Method flag picks the strategy.
+      const flag = method === 'squash' ? '--squash' : method === 'rebase' ? '--rebase' : '--merge';
+      return await runGh(['pr', 'merge', String(prNumber), '--repo', `${owner}/${repo}`, '--auto', flag]);
+    } catch (e) {
+      log.error(e);
+      return { message: e.message, success: false };
+    }
+  }
+);
+
+ipcMain.handle('git:api:disableAutoMerge', async (_, id: string, prNumber: number) => {
+  try {
+    const { owner, repo } = await getRepoInfo(id);
+    if (!owner || !repo) throw new Error('Project not found');
+
+    return await runGh(['pr', 'merge', String(prNumber), '--repo', `${owner}/${repo}`, '--disable-auto']);
+  } catch (e) {
+    log.error(e);
+    return { message: e.message, success: false };
+  }
+});
+
+// Which files conflict between base and head — the list GitHub shows under
+// "This branch has conflicts that must be resolved". Computed locally with
+// `git merge-tree` (read-only: writes nothing, pushes nothing) against the
+// project's own clone, since GitHub exposes no API for the conflicting paths.
+ipcMain.handle('git:api:getConflictFiles', async (_, id: string, prNumber: number) => {
+  try {
+    const { owner, repo } = await getRepoInfo(id);
+    if (!owner || !repo) throw new Error('Project not found');
+    const cwd = getProjectPath(id);
+
+    const { data: pr } = await octokit().rest.pulls.get({ owner, pull_number: prNumber, repo });
+    const base = pr.base.ref;
+    const head = pr.head.ref;
+
+    // Make sure both tips are present locally before the merge test.
+    await execFileAsync('git', ['-C', cwd, 'fetch', 'origin', base, head], { maxBuffer: 1024 * 1024 });
+
+    try {
+      await execFileAsync(
+        'git',
+        ['-C', cwd, 'merge-tree', '--write-tree', '--name-only', `origin/${base}`, `origin/${head}`],
+        { maxBuffer: 8 * 1024 * 1024 }
+      );
+      // Exit 0 → merges cleanly, no conflicts.
+      return { files: [], success: true };
+    } catch (mergeErr) {
+      // Exit 1 → conflicts. stdout is: <tree-oid>\n<conflicted paths…>\n\n<info>
+      const out = ((mergeErr as { stdout?: string }).stdout ?? '').split('\n');
+      out.shift(); // drop the tree OID line
+      const files: string[] = [];
+      for (const line of out) {
+        if (line.trim() === '') break; // blank line ends the file list
+        files.push(line.trim());
+      }
+      return { files, success: true };
+    }
   } catch (e) {
     log.error(e);
     return { message: e.message, success: false };

--- a/src/main/ipcs/ipcGitHub.ts
+++ b/src/main/ipcs/ipcGitHub.ts
@@ -278,7 +278,89 @@ ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number) =>
       status: check.status
     }));
 
-    return { checks, success: true };
+    // Review status, GitHub-style: the effective state per reviewer is their
+    // most recent non-comment review. A PR reads as "approved" when at least
+    // one reviewer's latest review is APPROVED and none is CHANGES_REQUESTED.
+    const { data: reviews } = await octokit().rest.pulls.listReviews({
+      owner,
+      per_page: 100,
+      pull_number: prNumber,
+      repo
+    });
+
+    type ReviewerState = 'approved' | 'changes_requested' | 'commented' | 'pending';
+    type Reviewer = {
+      avatarUrl: string;
+      login: string;
+      reReviewRequested: boolean;
+      state: ReviewerState;
+    };
+
+    const stateMap: Record<string, ReviewerState> = {
+      APPROVED: 'approved',
+      CHANGES_REQUESTED: 'changes_requested',
+      COMMENTED: 'commented'
+    };
+
+    // The PR author is never their own reviewer, even when they leave review
+    // comments on the thread — GitHub keeps them out of the Reviewers panel.
+    const authorLogin = pr.user?.login;
+
+    // Build one entry per reviewer, keyed by login. GitHub's rule: a reviewer's
+    // effective state is their most recent APPROVED / CHANGES_REQUESTED verdict;
+    // a COMMENTED review never overrides an existing verdict. Reviews arrive
+    // oldest-first, so verdicts overwrite freely while COMMENTED only fills a
+    // reviewer who has no verdict yet.
+    const byLogin = new Map<string, Reviewer>();
+    for (const rev of reviews) {
+      const login = rev.user?.login;
+      const mapped = rev.state ? stateMap[rev.state] : undefined;
+      if (!login || !mapped) continue; // skip DISMISSED / PENDING drafts
+      if (login === authorLogin) continue;
+      const existing = byLogin.get(login);
+      if (mapped === 'commented' && existing && existing.state !== 'commented') continue;
+      byLogin.set(login, {
+        avatarUrl: rev.user?.avatar_url ?? '',
+        login,
+        reReviewRequested: false,
+        state: mapped
+      });
+    }
+
+    // Requested reviewers who have not reviewed yet are "pending". If they
+    // already have a verdict, a fresh request means GitHub is asking for a
+    // re-review — flag it (shows the spinner next to their prior verdict, and
+    // makes that prior approval stale so it no longer counts toward "approved").
+    for (const rr of pr.requested_reviewers ?? []) {
+      const login = 'login' in rr ? rr.login : undefined;
+      if (!login || login === authorLogin) continue;
+      const existing = byLogin.get(login);
+      if (existing) {
+        existing.reReviewRequested = true;
+      } else {
+        byLogin.set(login, {
+          avatarUrl: 'avatar_url' in rr ? rr.avatar_url : '',
+          login,
+          reReviewRequested: false,
+          state: 'pending'
+        });
+      }
+    }
+
+    const reviewers = [...byLogin.values()];
+    // A re-requested approval is stale — it does not count toward the overall
+    // "approved" verdict, matching GitHub ("At least 1 approving review is
+    // required" persists after a re-request).
+    const approvedBy = reviewers.filter((r) => r.state === 'approved' && !r.reReviewRequested).map((r) => r.login);
+    const changesRequestedBy = reviewers.filter((r) => r.state === 'changes_requested').map((r) => r.login);
+
+    let reviewState: 'approved' | 'changes_requested' | null = null;
+    if (changesRequestedBy.length > 0) reviewState = 'changes_requested';
+    else if (approvedBy.length > 0) reviewState = 'approved';
+
+    const review = { approvedBy, changesRequestedBy, reviewers, state: reviewState };
+
+    return { checks, review, success: true };
   } catch (e) {
     log.error(e);
     return { message: e.message, success: false };

--- a/src/main/ipcs/ipcWindow.ts
+++ b/src/main/ipcs/ipcWindow.ts
@@ -1,0 +1,18 @@
+import { BrowserWindow, ipcMain } from 'electron';
+
+// Keep the app window pinned above every other window (all spaces / full-screen
+// too), toggled from the navbar. `screen-saver` level floats over full-screen
+// apps, which the default `floating` level does not.
+ipcMain.handle('window:setAlwaysOnTop', (event, flag: boolean) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return false;
+
+  win.setAlwaysOnTop(flag, 'screen-saver');
+  win.setVisibleOnAllWorkspaces(flag, { visibleOnFullScreen: true });
+  return win.isAlwaysOnTop();
+});
+
+ipcMain.handle('window:getAlwaysOnTop', (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  return win ? win.isAlwaysOnTop() : false;
+});

--- a/src/main/libs/git.ts
+++ b/src/main/libs/git.ts
@@ -19,6 +19,15 @@ export const getGit = async (id: string) => {
   return git;
 };
 
+export const getProjectPath = (id: string): string => {
+  // @ts-ignore tmp
+  const projects = settings.get('projects');
+  // @ts-ignore tmp
+  const project = projects.find((project) => project.id === id);
+  if (!project) throw new Error('Project not found');
+  return project.filePath;
+};
+
 export const parseWorktreeList = (output: string): Worktree[] => {
   const worktrees: Worktree[] = [];
   const blocks = output.trim().split('\n\n');

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -28,6 +28,10 @@ const bridge = {
   },
   gitAPI: {
     cancelRun: (id: string, runId: number) => ipcRenderer.invoke('git:api:cancelRun', id, runId),
+    disableAutoMerge: (id: string, prNumber: number) => ipcRenderer.invoke('git:api:disableAutoMerge', id, prNumber),
+    enableAutoMerge: (id: string, prNumber: number, method: 'merge' | 'rebase' | 'squash') =>
+      ipcRenderer.invoke('git:api:enableAutoMerge', id, prNumber, method),
+    getConflictFiles: (id: string, prNumber: number) => ipcRenderer.invoke('git:api:getConflictFiles', id, prNumber),
     getJobs: (id: string, runId: number) => ipcRenderer.invoke('git:api:getJobs', id, runId),
     getOpenPulls: (id: string) => ipcRenderer.invoke('git:api:getOpenPulls', id),
     getPinnedRuns: (id: string) => ipcRenderer.invoke('git:api:getPinnedRuns', id),
@@ -35,10 +39,14 @@ const bridge = {
     getPulls: (id: string, type: (typeof pullTypes)[number]) => ipcRenderer.invoke('git:api:getPulls', id, type),
     getRuns: (id: string, deep = false) => ipcRenderer.invoke('git:api:getRuns', id, deep),
     getRunsPage: (id: string, page: number, branch?: string) => ipcRenderer.invoke('git:api:getRunsPage', id, page, branch),
+    mergePR: (id: string, prNumber: number, method: 'merge' | 'rebase' | 'squash') =>
+      ipcRenderer.invoke('git:api:mergePR', id, prNumber, method),
     rerunFailedJobs: (id: string, runId: number) => ipcRenderer.invoke('git:api:rerunFailedJobs', id, runId),
     rerunWorkflow: (id: string, runId: number) => ipcRenderer.invoke('git:api:rerunWorkflow', id, runId),
     reset: (id: string, origin: string, target: string) => ipcRenderer.invoke('git:api:reset', id, origin, target),
-    searchRuns: (id: string, query: string) => ipcRenderer.invoke('git:api:searchRuns', id, query)
+    searchRuns: (id: string, query: string) => ipcRenderer.invoke('git:api:searchRuns', id, query),
+    updateBranch: (id: string, prNumber: number, method: 'merge' | 'rebase' = 'merge') =>
+      ipcRenderer.invoke('git:api:updateBranch', id, prNumber, method)
   },
   launch: {
     editor: (fullPath: string, editor: FoundEditor) => ipcRenderer.invoke('launch:editor', { editor, fullPath }),
@@ -62,6 +70,10 @@ const bridge = {
   },
   sticker: {
     add: (text: string) => ipcRenderer.invoke('sticker:add', text)
+  },
+  window: {
+    getAlwaysOnTop: (): Promise<boolean> => ipcRenderer.invoke('window:getAlwaysOnTop'),
+    setAlwaysOnTop: (flag: boolean): Promise<boolean> => ipcRenderer.invoke('window:setAlwaysOnTop', flag)
   },
   worktree: {
     add: (id: string, repoName: string, branch: string, newBranch?: string, copyEnvLocal?: boolean) =>

--- a/src/renderer/components/AppNavbar/AppNavbar.tsx
+++ b/src/renderer/components/AppNavbar/AppNavbar.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonGroup, Classes, Icon, Navbar, Tooltip } from '@blueprintjs/core';
 import clsx from 'clsx';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { NavLink, useLocation } from 'react-router';
 import Devkitty from 'renderer/assets/devkitty.svg?react';
 import { useAppSettings, useIsSunset } from 'renderer/hooks/useAppSettings';
@@ -23,6 +23,18 @@ export const AppNavbar = () => {
   const { clear, query, setQuery } = useFilter();
   const searchRef = useRef<HTMLInputElement>(null);
   const onHome = useLocation().pathname === '/';
+  const [alwaysOnTop, setAlwaysOnTop] = useState(false);
+
+  // Reflect the window's real pinned state on mount (it survives across
+  // reloads within a session).
+  useEffect(() => {
+    window.bridge.window.getAlwaysOnTop().then(setAlwaysOnTop);
+  }, []);
+
+  const toggleAlwaysOnTop = async () => {
+    const next = await window.bridge.window.setAlwaysOnTop(!alwaysOnTop);
+    setAlwaysOnTop(next);
+  };
 
   // Leaving the project list drops the filter, so coming back is never
   // silently narrowed by something typed a page ago.
@@ -108,6 +120,21 @@ export const AppNavbar = () => {
           minimal
           onClick={refresh}
         />
+
+        <Tooltip
+          compact
+          content={alwaysOnTop ? 'Always on top: on' : 'Keep window always on top'}
+          hoverOpenDelay={500}
+          placement="bottom"
+        >
+          <Button
+            active={alwaysOnTop}
+            aria-label="Toggle always on top"
+            icon="pin"
+            minimal
+            onClick={toggleAlwaysOnTop}
+          />
+        </Tooltip>
 
         <Navbar.Divider />
 

--- a/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
+++ b/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
@@ -19,6 +19,30 @@ type Props = {
   tags?: string[];
 };
 
+type Review = {
+  approvedBy: string[];
+  changesRequestedBy: string[];
+  reviewers: Reviewer[];
+  state: 'approved' | 'changes_requested' | null;
+};
+
+type Reviewer = {
+  avatarUrl: string;
+  login: string;
+  reReviewRequested: boolean;
+  state: 'approved' | 'changes_requested' | 'commented' | 'pending';
+};
+
+const reviewerStatus = (r: Reviewer): { color: string; icon: 'chat' | 'cross' | 'dot' | 'tick'; label: string } => {
+  // Icons mirror GitHub's Reviewers panel 1:1: bare green check for approved,
+  // red cross for changes requested, a comment bubble for a commented review,
+  // and a faint dot for an awaiting/requested reviewer.
+  if (r.state === 'approved') return { color: 'text-[#3fb950]', icon: 'tick', label: 'approved' };
+  if (r.state === 'changes_requested') return { color: 'text-[#f85149]', icon: 'cross', label: 'requested changes' };
+  if (r.state === 'commented') return { color: 'text-bp-gray-3', icon: 'chat', label: 'commented' };
+  return { color: 'text-bp-gray-3', icon: 'dot', label: 'awaiting review' };
+};
+
 const getChecksSummary = (checks: Check[]) => {
   if (checks.length === 0) return null;
 
@@ -35,12 +59,16 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
   const isClosed = !isMerged && state === 'closed';
   const isSunset = useIsSunset();
   const [checks, setChecks] = useState<Check[]>([]);
+  const [review, setReview] = useState<null | Review>(null);
 
   useEffect(() => {
     const fetchChecks = async () => {
       const res = await window.bridge.gitAPI.getPRChecks(projectId, number);
       if (res.success && res.checks) {
         setChecks(res.checks);
+      }
+      if (res.success && res.review) {
+        setReview(res.review);
       }
     };
     fetchChecks();
@@ -51,6 +79,60 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
   };
 
   const summary = getChecksSummary(checks);
+
+  // GitHub-style Reviewers panel: every reviewer with their avatar and current
+  // status icon (approved / requested changes / commented / awaiting).
+  const reviewers = review?.reviewers ?? [];
+  const reviewersPanel = reviewers.length > 0 && (
+    <div className="min-w-[240px] px-3.5 py-3">
+      <div className="mb-2.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-bp-gray-3">Reviewers</div>
+
+      <div className="flex flex-col gap-1">
+        {reviewers.map((r) => {
+          const status = reviewerStatus(r);
+          return (
+            <div className="flex items-center gap-2.5 rounded-md px-1.5 py-1 -mx-1.5 hover:bg-white/5"
+              key={r.login}
+            >
+              {r.avatarUrl ? (
+                <img alt={r.login}
+                  className="w-5 h-5 rounded-full object-cover shrink-0 ring-1 ring-white/10"
+                  src={r.avatarUrl}
+                />
+              ) : (
+                <Icon className="shrink-0"
+                  icon="user"
+                  size={16}
+                />
+              )}
+
+              <span className="flex-1 text-xs font-medium truncate">{r.login.replace('[bot]', '')}</span>
+
+              {r.reReviewRequested && (
+                <Tooltip compact
+                  content="Re-review requested"
+                >
+                  <Icon className="text-bp-gray-3"
+                    icon="refresh"
+                    size={12}
+                  />
+                </Tooltip>
+              )}
+
+              <Tooltip compact
+                content={status.label}
+              >
+                <Icon className={status.color}
+                  icon={status.icon}
+                  size={14}
+                />
+              </Tooltip>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 
   return (
     <div
@@ -164,12 +246,12 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
         {/* Labels + tags sit here, not in the title line, so they centre
             against the full card height (like the avatar and buttons) even when
             the title wraps to two lines. */}
-        {(labels.length > 0 || tags.length > 0) && (
+        {(labels.length > 0 || tags.length > 0 || review?.state || reviewers.length > 0) && (
           <div className="flex items-center gap-2 shrink-0">
             {labels.map((label: { color: string; id: number; name: string }) => (
               <div
                 className={cn(
-                  'rounded-full border px-1.5 py-px text-[10px] shrink-0',
+                  'rounded-full border px-2.5 py-1 text-[11px] shrink-0',
                   'border-[color-mix(in_srgb,var(--label)_45%,transparent)]',
                   'text-[color-mix(in_srgb,var(--label)_70%,black)]',
                   'dark:text-[color-mix(in_srgb,var(--label)_80%,white)]'
@@ -181,10 +263,10 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
               </div>
             ))}
 
-            {tags.map((tag) => (
+            {tags.filter((tag) => tag !== 'My').map((tag) => (
               <div
                 className={cn(
-                  'rounded-full border border-bp-gray-2 dark:border-bp-gray-3 px-1.5 py-px text-[10px]',
+                  'rounded-full border border-bp-gray-2 dark:border-bp-gray-3 px-2.5 py-1 text-[11px]',
                   'text-bp-gray-1 dark:text-bp-gray-4'
                 )}
                 key={`${number}-${tag}`}
@@ -192,6 +274,52 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
                 {tag}
               </div>
             ))}
+
+            {/* Review verdict renders LAST so it sits closest to the action
+                buttons. GitHub-style: green "Approved", red "Changes requested",
+                or neutral "In review" while awaiting a verdict. Hover opens the
+                full Reviewers panel (avatars + per-reviewer status). */}
+            {review?.state === 'approved' && (
+              <Popover content={reviewersPanel || undefined}
+                interactionKind="hover"
+                placement="bottom"
+              >
+                <div className="flex items-center gap-1.5 rounded-full border border-[#1a7f37]/45 dark:border-[#3fb950]/45 px-2.5 py-1 text-[11px] text-[#1a7f37] dark:text-[#3fb950] shrink-0 cursor-default">
+                  <Icon icon="tick-circle"
+                    size={12}
+                  />
+                  Approved
+                </div>
+              </Popover>
+            )}
+
+            {review?.state === 'changes_requested' && (
+              <Popover content={reviewersPanel || undefined}
+                interactionKind="hover"
+                placement="bottom"
+              >
+                <div className="flex items-center gap-1.5 rounded-full border border-[#cf222e]/45 dark:border-[#f85149]/45 px-2.5 py-1 text-[11px] text-[#cf222e] dark:text-[#f85149] shrink-0 cursor-default">
+                  <Icon icon="cross-circle"
+                    size={12}
+                  />
+                  Changes requested
+                </div>
+              </Popover>
+            )}
+
+            {!review?.state && reviewers.length > 0 && (
+              <Popover content={reviewersPanel || undefined}
+                interactionKind="hover"
+                placement="bottom"
+              >
+                <div className="flex items-center gap-1.5 rounded-full border border-bp-gray-2 dark:border-bp-gray-3 px-2.5 py-1 text-[11px] text-bp-gray-1 dark:text-bp-gray-4 shrink-0 cursor-default">
+                  <Icon icon="eye-open"
+                    size={12}
+                  />
+                  In review
+                </div>
+              </Popover>
+            )}
           </div>
         )}
       </div>

--- a/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
+++ b/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
@@ -152,7 +152,6 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
 
         <div className="overflow-hidden flex flex-col min-w-0 flex-1">
           <div className="flex items-center overflow-hidden mb-0.5 gap-2">
-            {draft && '[DRAFT] '}
 
             {/* GitHub's own state badges: purple merged, red closed, filled and
                 carrying the matching icon. shrink-0 and nowrap — a state is
@@ -246,7 +245,7 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
         {/* Labels + tags sit here, not in the title line, so they centre
             against the full card height (like the avatar and buttons) even when
             the title wraps to two lines. */}
-        {(labels.length > 0 || tags.length > 0 || review?.state || reviewers.length > 0) && (
+        {(labels.length > 0 || tags.length > 0 || review?.state || reviewers.length > 0 || draft) && (
           <div className="flex items-center gap-2 shrink-0">
             {labels.map((label: { color: string; id: number; name: string }) => (
               <div
@@ -276,10 +275,20 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
             ))}
 
             {/* Review verdict renders LAST so it sits closest to the action
-                buttons. GitHub-style: green "Approved", red "Changes requested",
-                or neutral "In review" while awaiting a verdict. Hover opens the
-                full Reviewers panel (avatars + per-reviewer status). */}
-            {review?.state === 'approved' && (
+                buttons. A draft PR is not reviewable, so it shows a "Draft"
+                badge instead of any review state. Otherwise, GitHub-style:
+                green "Approved", red "Changes requested", or neutral "In review"
+                while awaiting a verdict. Hover opens the full Reviewers panel. */}
+            {draft && (
+              <div className="flex items-center gap-1.5 rounded-full border border-bp-gray-2 dark:border-bp-gray-3 px-2.5 py-1 text-[11px] text-bp-gray-1 dark:text-bp-gray-4 shrink-0">
+                <Icon icon="git-branch"
+                  size={12}
+                />
+                Draft
+              </div>
+            )}
+
+            {!draft && review?.state === 'approved' && (
               <Popover content={reviewersPanel || undefined}
                 interactionKind="hover"
                 placement="bottom"
@@ -293,7 +302,7 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
               </Popover>
             )}
 
-            {review?.state === 'changes_requested' && (
+            {!draft && review?.state === 'changes_requested' && (
               <Popover content={reviewersPanel || undefined}
                 interactionKind="hover"
                 placement="bottom"
@@ -307,7 +316,7 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
               </Popover>
             )}
 
-            {!review?.state && reviewers.length > 0 && (
+            {!draft && !review?.state && reviewers.length > 0 && (
               <Popover content={reviewersPanel || undefined}
                 interactionKind="hover"
                 placement="bottom"

--- a/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
+++ b/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
@@ -1,6 +1,7 @@
-import { Button, ButtonGroup, Icon, Menu, MenuItem, Popover, Tooltip } from '@blueprintjs/core';
-import { type CSSProperties, type FC, useEffect, useState } from 'react';
+import { Button, ButtonGroup, Icon, Menu, MenuDivider, MenuItem, Popover, Tooltip } from '@blueprintjs/core';
+import { type CSSProperties, type FC, useCallback, useEffect, useState } from 'react';
 import { useIsSunset } from 'renderer/hooks/useAppSettings';
+import { appToaster } from 'renderer/utils/appToaster';
 import { cn } from 'renderer/utils/cn';
 import { timeAgo } from 'renderer/utils/timeAgo';
 import { type Pull } from 'types/gitHub';
@@ -33,6 +34,13 @@ type Reviewer = {
   state: 'approved' | 'changes_requested' | 'commented' | 'pending';
 };
 
+type UnresolvedThread = {
+  avatarUrl: string;
+  count: number;
+  login: string;
+  path: null | string;
+};
+
 const reviewerStatus = (r: Reviewer): { color: string; icon: 'chat' | 'cross' | 'dot' | 'tick'; label: string } => {
   // Icons mirror GitHub's Reviewers panel 1:1: bare green check for approved,
   // red cross for changes requested, a comment bubble for a commented review,
@@ -41,6 +49,14 @@ const reviewerStatus = (r: Reviewer): { color: string; icon: 'chat' | 'cross' | 
   if (r.state === 'changes_requested') return { color: 'text-[#f85149]', icon: 'cross', label: 'requested changes' };
   if (r.state === 'commented') return { color: 'text-bp-gray-3', icon: 'chat', label: 'commented' };
   return { color: 'text-bp-gray-3', icon: 'dot', label: 'awaiting review' };
+};
+
+// Octokit error messages tack on a docs URL (" - https://docs.github.com/…").
+// Strip it so toasts read as a plain, human sentence.
+const cleanApiError = (message?: string, fallback = 'Something went wrong') => {
+  if (!message) return fallback;
+  const clean = message.split(' - http')[0].trim();
+  return clean.length > 0 ? clean.charAt(0).toUpperCase() + clean.slice(1) : fallback;
 };
 
 const getChecksSummary = (checks: Check[]) => {
@@ -55,27 +71,136 @@ const getChecksSummary = (checks: Check[]) => {
 
 export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) => {
   const { created_at, draft, html_url, labels, merged_at, number, state, title, user } = pull;
-  const isMerged = Boolean(merged_at);
-  const isClosed = !isMerged && state === 'closed';
   const isSunset = useIsSunset();
   const [checks, setChecks] = useState<Check[]>([]);
   const [review, setReview] = useState<null | Review>(null);
+  const [behind, setBehind] = useState(false);
+  const [updating, setUpdating] = useState(false);
+  const [mergeableState, setMergeableState] = useState<string>('unknown');
+  const [merging, setMerging] = useState(false);
+  const [conflictFiles, setConflictFiles] = useState<null | string[]>(null);
+  const [unresolvedComments, setUnresolvedComments] = useState(0);
+  const [unresolvedThreads, setUnresolvedThreads] = useState<UnresolvedThread[]>([]);
+  const [autoMergeAllowed, setAutoMergeAllowed] = useState(false);
+  const [autoMergeEnabled, setAutoMergeEnabled] = useState(false);
+  // Set the instant a merge succeeds so the action buttons clear immediately,
+  // without waiting for the parent list to re-poll and hand down a merged pull.
+  const [justMerged, setJustMerged] = useState(false);
 
-  useEffect(() => {
-    const fetchChecks = async () => {
-      const res = await window.bridge.gitAPI.getPRChecks(projectId, number);
-      if (res.success && res.checks) {
-        setChecks(res.checks);
-      }
-      if (res.success && res.review) {
-        setReview(res.review);
-      }
-    };
-    fetchChecks();
+  const isMerged = Boolean(merged_at) || justMerged;
+  const isClosed = !isMerged && state === 'closed';
+  const totalUnresolvedComments = unresolvedThreads.reduce((sum, t) => sum + t.count, 0);
+
+  const fetchChecks = useCallback(async () => {
+    const res = await window.bridge.gitAPI.getPRChecks(projectId, number);
+    if (res.success && res.checks) {
+      setChecks(res.checks);
+    }
+    if (res.success && res.review) {
+      setReview(res.review);
+    }
+    if (res.success) {
+      setBehind(Boolean(res.behind));
+      setMergeableState(res.mergeableState ?? 'unknown');
+      setUnresolvedComments(res.unresolvedComments ?? 0);
+      setUnresolvedThreads(res.unresolvedThreads ?? []);
+      setAutoMergeAllowed(Boolean(res.autoMergeAllowed));
+      setAutoMergeEnabled(Boolean(res.autoMergeEnabled));
+    }
   }, [projectId, number]);
+
+  // Refetch on mount, whenever the PR advances (new head commit / updated_at),
+  // and on a slow interval so a base that moved on GitHub — which changes
+  // "behind" / mergeable state without touching the PR object — is not shown
+  // stale (e.g. an "Update branch" button lingering after the branch caught up).
+  useEffect(() => {
+    fetchChecks();
+    const timer = setInterval(fetchChecks, 30000);
+    return () => clearInterval(timer);
+     
+  }, [fetchChecks, pull.head?.sha, pull.updated_at]);
 
   const openInBrowser = () => {
     window.open(html_url, '_blank');
+  };
+
+  const updateBranch = async (method: 'merge' | 'rebase' = 'merge') => {
+    setUpdating(true);
+    const res = await window.bridge.gitAPI.updateBranch(projectId, number, method);
+    const toaster = await appToaster;
+    if (res.success) {
+      toaster.show({ icon: 'git-merge', intent: 'success', message: `Updated #${number} with the base branch` });
+      setBehind(false);
+      await fetchChecks();
+    } else {
+      toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to update branch'), timeout: 0 });
+    }
+    setUpdating(false);
+  };
+
+  const mergePR = async (method: 'merge' | 'rebase' | 'squash') => {
+    setMerging(true);
+    const res = await window.bridge.gitAPI.mergePR(projectId, number, method);
+    const toaster = await appToaster;
+    if (res.success) {
+      toaster.show({ icon: 'git-merge', intent: 'success', message: `Merged #${number}` });
+      setJustMerged(true);
+      await fetchChecks();
+    } else {
+      toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to merge'), timeout: 0 });
+    }
+    setMerging(false);
+  };
+
+  const enableAutoMerge = async (method: 'merge' | 'rebase' | 'squash') => {
+    setMerging(true);
+    const res = await window.bridge.gitAPI.enableAutoMerge(projectId, number, method);
+    const toaster = await appToaster;
+    if (res.success) {
+      toaster.show({ icon: 'automatic-updates', intent: 'success', message: `Auto-merge enabled for #${number}` });
+      setAutoMergeEnabled(true);
+      await fetchChecks();
+    } else {
+      toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to enable auto-merge'), timeout: 0 });
+    }
+    setMerging(false);
+  };
+
+  const disableAutoMerge = async () => {
+    setMerging(true);
+    const res = await window.bridge.gitAPI.disableAutoMerge(projectId, number);
+    const toaster = await appToaster;
+    if (res.success) {
+      toaster.show({ icon: 'automatic-updates', intent: 'success', message: `Auto-merge disabled for #${number}` });
+      setAutoMergeEnabled(false);
+      await fetchChecks();
+    } else {
+      toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to disable auto-merge'), timeout: 0 });
+    }
+    setMerging(false);
+  };
+
+  // Only surface Merge when GitHub itself would allow it — an allow-list, not a
+  // block-list, so ambiguous states never show a button that can't work:
+  //   clean       — mergeable, all requirements met
+  //   unstable    — mergeable, but non-required checks are failing/pending
+  //   has_hooks   — mergeable, with pre-receive hooks
+  // Everything else hides it: 'blocked' (review/checks required), 'dirty'
+  // (conflicts), 'behind' (up-to-date IS required here), 'draft', and 'unknown'
+  // (GitHub still computing — show nothing rather than a button that would fail).
+  // Note: a branch can be behind base yet still 'clean' (up-to-date not
+  // required) — that PR is mergeable, so Merge shows alongside Update branch.
+  const isOpen = !isMerged && !isClosed && !draft;
+  const canMerge = isOpen && ['clean', 'has_hooks', 'unstable'].includes(mergeableState);
+  const hasConflicts = isOpen && mergeableState === 'dirty';
+
+  // The conflicting-file list is computed on demand (a local git merge-tree) the
+  // first time the "Resolve conflicts" popover opens, then cached.
+  const loadConflicts = async () => {
+    if (conflictFiles !== null) return;
+    setConflictFiles([]);
+    const res = await window.bridge.gitAPI.getConflictFiles(projectId, number);
+    if (res.success && res.files) setConflictFiles(res.files);
   };
 
   const summary = getChecksSummary(checks);
@@ -239,132 +364,426 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
                 </span>
               </Tooltip>
             )}
+
+            {/* Only labels sit inline on the #number line, as small metadata
+                pills. Tags, unresolved count and review status live in the
+                right-hand cluster near the action buttons. */}
+            {labels.length > 0 && (
+              <div className="flex items-center gap-1.5 shrink-0 ml-1">
+                {labels.map((label: { color: string; id: number; name: string }) => (
+                  <div
+                    className={cn(
+                      'rounded-full border px-2 py-px text-[10px] shrink-0',
+                      'border-[color-mix(in_srgb,var(--label)_45%,transparent)]',
+                      'text-[color-mix(in_srgb,var(--label)_70%,black)]',
+                      'dark:text-[color-mix(in_srgb,var(--label)_80%,white)]'
+                    )}
+                    key={label.id}
+                    style={{ '--label': `#${label.color}` } as CSSProperties}
+                  >
+                    {label.name}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
-
-        {/* Labels + tags sit here, not in the title line, so they centre
-            against the full card height (like the avatar and buttons) even when
-            the title wraps to two lines. */}
-        {(labels.length > 0 || tags.length > 0 || review?.state || reviewers.length > 0 || draft) && (
-          <div className="flex items-center gap-2 shrink-0">
-            {labels.map((label: { color: string; id: number; name: string }) => (
-              <div
-                className={cn(
-                  'rounded-full border px-2.5 py-1 text-[11px] shrink-0',
-                  'border-[color-mix(in_srgb,var(--label)_45%,transparent)]',
-                  'text-[color-mix(in_srgb,var(--label)_70%,black)]',
-                  'dark:text-[color-mix(in_srgb,var(--label)_80%,white)]'
-                )}
-                key={label.id}
-                style={{ '--label': `#${label.color}` } as CSSProperties}
-              >
-                {label.name}
-              </div>
-            ))}
-
-            {tags.filter((tag) => tag !== 'My').map((tag) => (
-              <div
-                className={cn(
-                  'rounded-full border border-bp-gray-2 dark:border-bp-gray-3 px-2.5 py-1 text-[11px]',
-                  'text-bp-gray-1 dark:text-bp-gray-4'
-                )}
-                key={`${number}-${tag}`}
-              >
-                {tag}
-              </div>
-            ))}
-
-            {/* Review verdict renders LAST so it sits closest to the action
-                buttons. A draft PR is not reviewable, so it shows a "Draft"
-                badge instead of any review state. Otherwise, GitHub-style:
-                green "Approved", red "Changes requested", or neutral "In review"
-                while awaiting a verdict. Hover opens the full Reviewers panel. */}
-            {draft && (
-              <div className="flex items-center gap-1.5 rounded-full border border-bp-gray-2 dark:border-bp-gray-3 px-2.5 py-1 text-[11px] text-bp-gray-1 dark:text-bp-gray-4 shrink-0">
-                <Icon icon="git-branch"
-                  size={12}
-                />
-                Draft
-              </div>
-            )}
-
-            {!draft && review?.state === 'approved' && (
-              <Popover content={reviewersPanel || undefined}
-                interactionKind="hover"
-                placement="bottom"
-              >
-                <div className="flex items-center gap-1.5 rounded-full border border-[#1a7f37]/45 dark:border-[#3fb950]/45 px-2.5 py-1 text-[11px] text-[#1a7f37] dark:text-[#3fb950] shrink-0 cursor-default">
-                  <Icon icon="tick-circle"
-                    size={12}
-                  />
-                  Approved
-                </div>
-              </Popover>
-            )}
-
-            {!draft && review?.state === 'changes_requested' && (
-              <Popover content={reviewersPanel || undefined}
-                interactionKind="hover"
-                placement="bottom"
-              >
-                <div className="flex items-center gap-1.5 rounded-full border border-[#cf222e]/45 dark:border-[#f85149]/45 px-2.5 py-1 text-[11px] text-[#cf222e] dark:text-[#f85149] shrink-0 cursor-default">
-                  <Icon icon="cross-circle"
-                    size={12}
-                  />
-                  Changes requested
-                </div>
-              </Popover>
-            )}
-
-            {!draft && !review?.state && reviewers.length > 0 && (
-              <Popover content={reviewersPanel || undefined}
-                interactionKind="hover"
-                placement="bottom"
-              >
-                <div className="flex items-center gap-1.5 rounded-full border border-bp-gray-2 dark:border-bp-gray-3 px-2.5 py-1 text-[11px] text-bp-gray-1 dark:text-bp-gray-4 shrink-0 cursor-default">
-                  <Icon icon="eye-open"
-                    size={12}
-                  />
-                  In review
-                </div>
-              </Popover>
-            )}
-          </div>
-        )}
       </div>
 
-      <ButtonGroup>
-        <Tooltip compact
-          content="Open in browser"
-          hoverOpenDelay={500}
-          placement="bottom"
-        >
-          <Button
-            aria-label="Open pull request in browser"
-            icon="globe"
-            onClick={openInBrowser}
-          />
-        </Tooltip>
-
-        <Popover
-          content={
-            <Menu>
-              {onHide && (
-                <MenuItem
-                  icon="eye-off"
-                  onClick={() => onHide(pull.id, `#${number} ${title}`)}
-                  text="Hide this PR"
-                />
+      {/* Tags, unresolved count and review status — full-size pills, centred
+          against the whole card next to the action buttons. */}
+      {(tags.filter((tag) => tag !== 'My').length > 0 || review?.state || reviewers.length > 0 || draft || unresolvedComments > 0) && (
+        <div className="flex items-center gap-2 shrink-0">
+          {tags.filter((tag) => tag !== 'My').map((tag) => (
+            <div
+              className={cn(
+                'rounded-full border border-bp-gray-2 dark:border-bp-gray-3 px-2.5 py-1 text-[11px]',
+                'text-bp-gray-1 dark:text-bp-gray-4'
               )}
-            </Menu>
-          }
-          placement="bottom-end"
-        >
-          <Button aria-label="Pull request actions"
-            icon="caret-down"
-          />
-        </Popover>
-      </ButtonGroup>
+              key={`${number}-${tag}`}
+            >
+              {tag}
+            </div>
+          ))}
+
+          {unresolvedComments > 0 && (
+            <Popover
+              content={
+                <div className="min-w-[220px] px-3.5 py-3">
+                  <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-bp-gray-3">
+                    {unresolvedComments} unresolved {unresolvedComments === 1 ? 'conversation' : 'conversations'}
+                  </div>
+
+                  <div className="flex flex-col gap-1.5">
+                    {unresolvedThreads.map((t) => (
+                      <div className="flex items-center gap-2"
+                        key={`${t.login}-${t.path}-${t.count}`}
+                      >
+                        {t.avatarUrl ? (
+                          <img alt={t.login}
+                            className="w-5 h-5 rounded-full object-cover shrink-0 ring-1 ring-white/10"
+                            src={t.avatarUrl}
+                          />
+                        ) : (
+                          <Icon className="shrink-0"
+                            icon="user"
+                            size={16}
+                          />
+                        )}
+
+                        <div className="flex flex-col min-w-0">
+                          <span className="text-xs font-medium leading-tight">
+                            {t.login.replace('[bot]', '')}
+
+                            <span className="ml-1 text-[10px] font-normal text-bp-gray-3">
+                              {t.count} {t.count === 1 ? 'comment' : 'comments'}
+                            </span>
+                          </span>
+
+                          {t.path && <span className="text-[10px] font-mono text-bp-gray-3 truncate">{t.path}</span>}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              }
+              interactionKind="hover"
+              placement="bottom"
+            >
+              <div className="flex items-center gap-1 rounded-full border border-[#d98a3d]/45 px-2 py-1 text-[11px] text-[#d98a3d] shrink-0 cursor-default">
+                <Icon icon="chat"
+                  size={12}
+                />
+
+                {totalUnresolvedComments}
+              </div>
+            </Popover>
+          )}
+
+          {/* A draft PR is not reviewable, so it shows a "Draft" badge instead
+              of any review state. Otherwise GitHub-style: green "Approved", red
+              "Changes requested", or neutral "In review". Hover opens the
+              Reviewers panel. */}
+          {draft && (
+            <div className="flex items-center gap-1.5 rounded-full border border-bp-gray-2 dark:border-bp-gray-3 px-2.5 py-1 text-[11px] text-bp-gray-1 dark:text-bp-gray-4 shrink-0">
+              <Icon icon="git-branch"
+                size={12}
+              />
+              Draft
+            </div>
+          )}
+
+          {!draft && review?.state === 'approved' && (
+            <Popover content={reviewersPanel || undefined}
+              interactionKind="hover"
+              placement="bottom"
+            >
+              <div className="flex items-center gap-1.5 rounded-full border border-[#1a7f37]/45 dark:border-[#3fb950]/45 px-2.5 py-1 text-[11px] text-[#1a7f37] dark:text-[#3fb950] shrink-0 cursor-default">
+                <Icon icon="tick-circle"
+                  size={12}
+                />
+                Approved
+              </div>
+            </Popover>
+          )}
+
+          {!draft && review?.state === 'changes_requested' && (
+            <Popover content={reviewersPanel || undefined}
+              interactionKind="hover"
+              placement="bottom"
+            >
+              <div className="flex items-center gap-1.5 rounded-full border border-[#cf222e]/45 dark:border-[#f85149]/45 px-2.5 py-1 text-[11px] text-[#cf222e] dark:text-[#f85149] shrink-0 cursor-default">
+                <Icon icon="cross-circle"
+                  size={12}
+                />
+                Changes requested
+              </div>
+            </Popover>
+          )}
+
+          {!draft && !review?.state && reviewers.length > 0 && (
+            <Popover content={reviewersPanel || undefined}
+              interactionKind="hover"
+              placement="bottom"
+            >
+              <div className="flex items-center gap-1.5 rounded-full border border-bp-gray-2 dark:border-bp-gray-3 px-2.5 py-1 text-[11px] text-bp-gray-1 dark:text-bp-gray-4 shrink-0 cursor-default">
+                <Icon icon="eye-open"
+                  size={12}
+                />
+                In review
+              </div>
+            </Popover>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center gap-1.5 shrink-0">
+        {/* "Update branch" split button — Blueprint buttons so it inherits the
+            exact same surface as the other action buttons (globe / caret) in
+            every theme, Sunset included. Primary merges the base in; the caret
+            offers merge vs rebase. Shown only when the branch is behind. */}
+        {behind && isOpen && !hasConflicts && (
+          <ButtonGroup>
+            <Button
+              icon="git-merge"
+              loading={updating}
+              onClick={() => updateBranch('merge')}
+              text="Update branch"
+            />
+
+            <Popover
+              content={
+                <Menu>
+                  <MenuItem icon="git-merge"
+                    onClick={() => updateBranch('merge')}
+                    text="Update with merge commit"
+                  />
+
+                  <MenuItem icon="git-branch"
+                    onClick={() => updateBranch('rebase')}
+                    text="Update with rebase"
+                  />
+                </Menu>
+              }
+              placement="bottom-end"
+            >
+              <Button aria-label="Update branch options"
+                icon="caret-down"
+              />
+            </Popover>
+          </ButtonGroup>
+        )}
+
+        {/* GitHub-style green "Merge" split button: primary squash-merges; the
+            caret offers merge commit / squash / rebase. Shown only when the PR
+            is actually mergeable — no greyed-out placeholder. */}
+        {canMerge && (
+          <div className={cn('flex shrink-0 rounded-md overflow-hidden', merging && 'opacity-60')}>
+            <button
+              className="flex items-center gap-1.5 h-[30px] pl-2.5 pr-3 text-[12px] font-semibold text-white bg-[#1f883d] hover:bg-[#2ea043] active:bg-[#1a7f37] transition-colors disabled:cursor-not-allowed"
+              disabled={merging}
+              onClick={() => mergePR('squash')}
+              type="button"
+            >
+              <Icon icon={merging ? 'refresh' : 'git-merge'}
+                size={13}
+              />
+
+              {merging ? 'Merging…' : 'Squash and merge'}
+            </button>
+
+            <Popover
+              content={
+                <Menu>
+                  <MenuItem icon="git-merge"
+                    onClick={() => mergePR('squash')}
+                    text="Squash and merge"
+                  />
+
+                  <MenuItem icon="git-commit"
+                    onClick={() => mergePR('merge')}
+                    text="Create a merge commit"
+                  />
+
+                  <MenuItem icon="git-branch"
+                    onClick={() => mergePR('rebase')}
+                    text="Rebase and merge"
+                  />
+
+                  {autoMergeAllowed && !autoMergeEnabled && (
+                    <>
+                      <MenuDivider />
+
+                      <MenuItem icon="automatic-updates"
+                        onClick={() => enableAutoMerge('squash')}
+                        text="Enable auto-merge (squash)"
+                      />
+
+                      <MenuItem icon="automatic-updates"
+                        onClick={() => enableAutoMerge('merge')}
+                        text="Enable auto-merge (merge commit)"
+                      />
+
+                      <MenuItem icon="automatic-updates"
+                        onClick={() => enableAutoMerge('rebase')}
+                        text="Enable auto-merge (rebase)"
+                      />
+                    </>
+                  )}
+                </Menu>
+              }
+              disabled={merging}
+              placement="bottom-end"
+            >
+              <button className="flex items-center h-[30px] px-1.5 text-white bg-[#1f883d] hover:bg-[#2ea043] active:bg-[#1a7f37] transition-colors border-l border-black/20 disabled:cursor-not-allowed"
+                disabled={merging}
+                type="button"
+              >
+                <Icon icon="caret-down"
+                  size={12}
+                />
+              </button>
+            </Popover>
+          </div>
+        )}
+
+        {/* Auto-merge is armed: show its state with a one-click disable. */}
+        {isOpen && autoMergeEnabled && (
+          <Popover
+            content={
+              <Menu>
+                <MenuItem icon="disable"
+                  onClick={disableAutoMerge}
+                  text="Disable auto-merge"
+                />
+              </Menu>
+            }
+            placement="bottom-end"
+          >
+            <div className="flex items-center gap-1.5 h-[30px] px-3 rounded-md text-[12px] font-medium text-[#3fb950] bg-[#3fb950]/10 border border-[#3fb950]/35 cursor-pointer shrink-0">
+              <Icon icon="automatic-updates"
+                size={13}
+              />
+              Auto-merge on
+            </div>
+          </Popover>
+        )}
+
+        {/* Not immediately mergeable (checks/reviews pending) but auto-merge is
+            available: GitHub-green "Enable auto-merge" split button. */}
+        {!canMerge && !autoMergeEnabled && autoMergeAllowed && isOpen && !hasConflicts && (
+          <div className={cn('flex shrink-0 rounded-md overflow-hidden', merging && 'opacity-60')}>
+            <button
+              className="flex items-center gap-1.5 h-[30px] pl-2.5 pr-3 text-[12px] font-semibold text-white bg-[#1f883d] hover:bg-[#2ea043] active:bg-[#1a7f37] transition-colors disabled:cursor-not-allowed"
+              disabled={merging}
+              onClick={() => enableAutoMerge('squash')}
+              type="button"
+            >
+              <Icon icon="automatic-updates"
+                size={13}
+              />
+              Enable auto-merge
+            </button>
+
+            <Popover
+              content={
+                <Menu>
+                  <MenuItem icon="automatic-updates"
+                    onClick={() => enableAutoMerge('squash')}
+                    text="Enable auto-merge (squash)"
+                  />
+
+                  <MenuItem icon="automatic-updates"
+                    onClick={() => enableAutoMerge('merge')}
+                    text="Enable auto-merge (merge commit)"
+                  />
+
+                  <MenuItem icon="automatic-updates"
+                    onClick={() => enableAutoMerge('rebase')}
+                    text="Enable auto-merge (rebase)"
+                  />
+                </Menu>
+              }
+              disabled={merging}
+              placement="bottom-end"
+            >
+              <button className="flex items-center h-[30px] px-1.5 text-white bg-[#1f883d] hover:bg-[#2ea043] active:bg-[#1a7f37] transition-colors border-l border-black/20 disabled:cursor-not-allowed"
+                disabled={merging}
+                type="button"
+              >
+                <Icon icon="caret-down"
+                  size={12}
+                />
+              </button>
+            </Popover>
+          </div>
+        )}
+
+        {/* Conflicts: GitHub shows an unclickable "Resolve conflicts" button —
+            conflicts can only be fixed on the command line. Hovering lists the
+            conflicting files (computed locally on demand). */}
+        {hasConflicts && (
+          <Popover
+            content={
+              <div className="min-w-[240px] px-3.5 py-3">
+                <div className="flex items-center gap-1.5 text-[12px] font-semibold text-[#f0e9f8]">
+                  <Icon className="text-[#d98a3d]"
+                    icon="warning-sign"
+                    size={13}
+                  />
+                  This branch has conflicts
+                </div>
+
+                <div className="mt-1 text-[11px] text-bp-gray-3">Resolve them on the command line before merging.</div>
+
+                {conflictFiles === null || conflictFiles.length === 0 ? (
+                  <div className="mt-2 text-[11px] text-bp-gray-3 italic">
+                    {conflictFiles === null ? 'Finding conflicting files…' : 'Conflicting files unavailable.'}
+                  </div>
+                ) : (
+                  <div className="mt-2 flex flex-col gap-1">
+                    {conflictFiles.map((f) => (
+                      <div className="flex items-center gap-1.5 text-[11px] font-mono text-[#efe8f5]"
+                        key={f}
+                      >
+                        <Icon className="text-bp-gray-3 shrink-0"
+                          icon="document"
+                          size={12}
+                        />
+
+                        <span className="truncate">{f}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            }
+            interactionKind="hover"
+            onOpening={loadConflicts}
+            placement="bottom-end"
+          >
+            <div className="flex items-center gap-1.5 h-[30px] px-3 rounded-md text-[12px] font-medium text-[#f85149] bg-[#f85149]/10 border border-[#f85149]/35 cursor-not-allowed select-none shrink-0">
+              <Icon icon="warning-sign"
+                size={13}
+              />
+              Resolve conflicts
+            </div>
+          </Popover>
+        )}
+
+        <ButtonGroup>
+          <Tooltip compact
+            content="Open in browser"
+            hoverOpenDelay={500}
+            placement="bottom"
+          >
+            <Button
+              aria-label="Open pull request in browser"
+              icon="globe"
+              onClick={openInBrowser}
+            />
+          </Tooltip>
+
+          <Popover
+            content={
+              <Menu>
+                {onHide && (
+                  <MenuItem
+                    icon="eye-off"
+                    onClick={() => onHide(pull.id, `#${number} ${title}`)}
+                    text="Hide this PR"
+                  />
+                )}
+              </Menu>
+            }
+            placement="bottom-end"
+          >
+            <Button aria-label="Pull request actions"
+              icon="caret-down"
+            />
+          </Popover>
+        </ButtonGroup>
+      </div>
     </div>
   );
 };

--- a/src/renderer/components/Project/hooks/useRepoData/groupByBranch.ts
+++ b/src/renderer/components/Project/hooks/useRepoData/groupByBranch.ts
@@ -61,10 +61,20 @@ export const buildDetailGroups = (
   runsByBranch: Record<string, Run[]>,
   branch: string
 ): DetailGroup[] => {
-  const groups: DetailGroup[] = pulls.map((pull) => ({
-    pull,
-    runs: pull.pull.head?.ref ? (runsByBranch[pull.pull.head.ref] ?? []) : []
-  }));
+  // GitHub's PR UI shows checks for the PR's HEAD commit only — runs from
+  // earlier commits on the same branch (a since-superseded failing build, say)
+  // are not the PR's current state and must not surface under it. Scope each
+  // pull's runs to its head SHA; runs from older commits fall through to the
+  // branch's loose bucket (or vanish once the branch view no longer needs them).
+  const groups: DetailGroup[] = pulls.map((pull) => {
+    const ref = pull.pull.head?.ref;
+    const sha = pull.pull.head?.sha;
+    const branchRuns = ref ? (runsByBranch[ref] ?? []) : [];
+    return {
+      pull,
+      runs: sha ? branchRuns.filter((run) => run.head_sha === sha) : branchRuns
+    };
+  });
 
   const claimed = new Set(pulls.map(({ pull }) => pull.head?.ref));
   const loose = claimed.has(branch) ? [] : (runsByBranch[branch] ?? []);
@@ -223,10 +233,40 @@ export const groupPullsByBranch = (pulls: PullWithTags[]): Record<string, PullWi
 
 // `countPerBranch` caps how many runs a branch keeps; left out, it keeps them
 // all and the card decides what to show.
+// When a workflow is re-run, GitHub creates a fresh run record for the same
+// workflow on the same commit. GitHub's own PR UI shows only the latest attempt
+// and hides the superseded ones — otherwise a stale failed attempt keeps a red X
+// on a workflow that has since passed. Collapse each (workflow, commit) to its
+// newest attempt so the card matches GitHub. Keyed on head_sha (not head_branch)
+// so genuinely different commits on a branch stay as distinct rows.
+export const dedupeSupersededRuns = (runs: Run[]): Run[] => {
+  const latest = new Map<string, Run>();
+
+  for (const run of runs) {
+    const workflow = run.path ?? (run.workflow_id == null ? '' : String(run.workflow_id));
+    // Only collapse when a run carries a stable (workflow, commit) identity;
+    // without both, treat it as unique (keyed by id) so nothing is dropped.
+    const key = run.head_sha && workflow ? `${workflow}|${run.head_sha}` : `id:${run.id}`;
+    const current = latest.get(key);
+    if (!current) {
+      latest.set(key, run);
+      continue;
+    }
+    // Prefer the higher run_attempt, falling back to the newer created_at.
+    const isNewer =
+      (run.run_attempt ?? 0) > (current.run_attempt ?? 0) ||
+      ((run.run_attempt ?? 0) === (current.run_attempt ?? 0) &&
+        new Date(run.created_at).getTime() > new Date(current.created_at).getTime());
+    if (isNewer) latest.set(key, run);
+  }
+
+  return [...latest.values()];
+};
+
 export const groupRunsByBranch = (runs: Run[], countPerBranch?: number): Record<string, Run[]> => {
   const grouped: Record<string, Run[]> = Object.create(null);
 
-  for (const run of runs) {
+  for (const run of dedupeSupersededRuns(runs)) {
     const branch = run.head_branch;
     if (!branch) continue;
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -408,6 +408,55 @@
   background-color: rgba(255, 255, 255, 0.09) !important;
 }
 
+/* Sunset toasts — the default Blueprint intent colours (orange warning, red
+   danger) read as flat off-theme blocks over the plum app. Reskin every toast
+   to the same plum glass as popovers so notifications match the surface. The
+   toaster is portaled to <body>, but the Sunset flag is mirrored onto <html>,
+   so .theme-sunset reaches it. Intent is kept as a thin left accent stripe. */
+.theme-sunset .bp6-toast {
+  background-color: #2a1230 !important;
+  background-image: linear-gradient(160deg, rgba(77, 20, 16, 0.97) 0%, rgba(54, 15, 54, 0.98) 52%, rgba(36, 16, 63, 0.99) 100%) !important;
+  border-left: 3px solid rgba(199, 188, 228, 0.35) !important;
+  box-shadow: 0 12px 40px -8px rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(199, 188, 228, 0.14) !important;
+  color: #efe8f5 !important;
+}
+.theme-sunset .bp6-toast.bp6-intent-warning {
+  border-left-color: #d98a3d !important;
+}
+.theme-sunset .bp6-toast.bp6-intent-danger {
+  border-left-color: #f85149 !important;
+}
+.theme-sunset .bp6-toast.bp6-intent-success {
+  border-left-color: #3fb950 !important;
+}
+.theme-sunset .bp6-toast .bp6-toast-message {
+  color: #efe8f5 !important;
+}
+/* The toast's leading intent icon and text stay legible on the plum glass. */
+.theme-sunset .bp6-toast > .bp6-icon {
+  color: #efe8f5 !important;
+}
+/* The dismiss (X) button: Blueprint renders it as an opaque dark square that
+   sits wrong on the plum toast. Make it a transparent minimal glyph. */
+.theme-sunset .bp6-toast .bp6-button,
+.theme-sunset .bp6-toast .bp6-button:hover,
+.theme-sunset .bp6-toast .bp6-button.bp6-active {
+  background: transparent !important;
+  background-image: none !important;
+  box-shadow: none !important;
+  color: rgba(239, 232, 245, 0.75) !important;
+}
+.theme-sunset .bp6-toast .bp6-button .bp6-icon {
+  color: rgba(239, 232, 245, 0.75) !important;
+}
+.theme-sunset .bp6-toast .bp6-button:hover {
+  background: rgba(255, 255, 255, 0.1) !important;
+  color: #ffffff !important;
+}
+.theme-sunset .bp6-toast .bp6-button:hover .bp6-icon {
+  color: #ffffff !important;
+}
+
 /* Solid, opaque sticky-header surface for Sunset — sticky rows must never let
    scrolling content bleed through, so this is fully opaque (applied in the
    component, not via a fragile dark: utility override). */

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -342,16 +342,16 @@
    "washed" look); a hair lighter than the rows plus a border + shadow so it
    reads as a raised button (never vanishes into the row). */
 .theme-sunset.dark .bp6-button:not(.bp6-minimal):not([class*='bp6-intent-']) {
-  background-color: #342c41 !important;
+  background-color: rgba(255, 255, 255, 0.1) !important;
   background-image: none !important;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.14), 0 1px 2px rgba(0, 0, 0, 0.4) !important;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.14) !important;
   color: #e6dff0 !important;
 }
 .theme-sunset.dark .bp6-button:not(.bp6-minimal):not([class*='bp6-intent-']):hover {
-  background-color: #443a54 !important;
+  background-color: rgba(255, 255, 255, 0.18) !important;
 }
 .theme-sunset.dark .bp6-button:not(.bp6-minimal):not([class*='bp6-intent-']):active {
-  background-color: #4e4360 !important;
+  background-color: rgba(255, 255, 255, 0.22) !important;
 }
 /* Toggled/selected — fill stays the same; the icon and a thin ring pick up the
    Sunset magenta accent, so "active" reads as an accent, not a differently
@@ -412,22 +412,12 @@
    danger) read as flat off-theme blocks over the plum app. Reskin every toast
    to the same plum glass as popovers so notifications match the surface. The
    toaster is portaled to <body>, but the Sunset flag is mirrored onto <html>,
-   so .theme-sunset reaches it. Intent is kept as a thin left accent stripe. */
+   so .theme-sunset reaches it. */
 .theme-sunset .bp6-toast {
   background-color: #2a1230 !important;
   background-image: linear-gradient(160deg, rgba(77, 20, 16, 0.97) 0%, rgba(54, 15, 54, 0.98) 52%, rgba(36, 16, 63, 0.99) 100%) !important;
-  border-left: 3px solid rgba(199, 188, 228, 0.35) !important;
   box-shadow: 0 12px 40px -8px rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(199, 188, 228, 0.14) !important;
   color: #efe8f5 !important;
-}
-.theme-sunset .bp6-toast.bp6-intent-warning {
-  border-left-color: #d98a3d !important;
-}
-.theme-sunset .bp6-toast.bp6-intent-danger {
-  border-left-color: #f85149 !important;
-}
-.theme-sunset .bp6-toast.bp6-intent-success {
-  border-left-color: #3fb950 !important;
 }
 .theme-sunset .bp6-toast .bp6-toast-message {
   color: #efe8f5 !important;
@@ -436,24 +426,25 @@
 .theme-sunset .bp6-toast > .bp6-icon {
   color: #efe8f5 !important;
 }
-/* The dismiss (X) button: Blueprint renders it as an opaque dark square that
-   sits wrong on the plum toast. Make it a transparent minimal glyph. */
-.theme-sunset .bp6-toast .bp6-button,
-.theme-sunset .bp6-toast .bp6-button:hover,
-.theme-sunset .bp6-toast .bp6-button.bp6-active {
+/* The dismiss (X) button. The general Sunset button rule above
+   (.theme-sunset.dark .bp6-button:not(.bp6-minimal):not([intent])) gives it an
+   opaque dark fill; match that selector's specificity — scoped inside the toast
+   — so this transparent-glyph treatment wins instead of the dark square. */
+.theme-sunset.dark .bp6-toast .bp6-button:not(.bp6-minimal):not([class*='bp6-intent-']),
+.theme-sunset.dark .bp6-toast .bp6-button:not(.bp6-minimal):not([class*='bp6-intent-']).bp6-active {
   background: transparent !important;
   background-image: none !important;
   box-shadow: none !important;
   color: rgba(239, 232, 245, 0.75) !important;
 }
-.theme-sunset .bp6-toast .bp6-button .bp6-icon {
+.theme-sunset.dark .bp6-toast .bp6-button:not(.bp6-minimal):not([class*='bp6-intent-']) .bp6-icon {
   color: rgba(239, 232, 245, 0.75) !important;
 }
-.theme-sunset .bp6-toast .bp6-button:hover {
-  background: rgba(255, 255, 255, 0.1) !important;
+.theme-sunset.dark .bp6-toast .bp6-button:not(.bp6-minimal):not([class*='bp6-intent-']):hover {
+  background: rgba(255, 255, 255, 0.12) !important;
   color: #ffffff !important;
 }
-.theme-sunset .bp6-toast .bp6-button:hover .bp6-icon {
+.theme-sunset.dark .bp6-toast .bp6-button:not(.bp6-minimal):not([class*='bp6-intent-']):hover .bp6-icon {
   color: #ffffff !important;
 }
 

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -21,14 +21,33 @@ const mockBridge = {
     reset: vi.fn()
   },
   gitAPI: {
+    cancelRun: vi.fn(),
+    disableAutoMerge: vi.fn().mockResolvedValue({ success: true }),
+    enableAutoMerge: vi.fn().mockResolvedValue({ success: true }),
+    getConflictFiles: vi.fn().mockResolvedValue({ files: [], success: true }),
     getJobs: vi.fn(),
     getOpenPulls: vi.fn(),
     getPinnedRuns: vi.fn(),
+    getPRChecks: vi.fn().mockResolvedValue({
+      autoMergeAllowed: false,
+      autoMergeEnabled: false,
+      behind: false,
+      checks: [],
+      mergeableState: 'unknown',
+      review: null,
+      success: true,
+      unresolvedComments: 0,
+      unresolvedThreads: []
+    }),
     getPulls: vi.fn(),
     getRuns: vi.fn(),
     getRunsPage: vi.fn(),
+    mergePR: vi.fn().mockResolvedValue({ success: true }),
+    rerunFailedJobs: vi.fn(),
+    rerunWorkflow: vi.fn(),
     reset: vi.fn(),
-    searchRuns: vi.fn()
+    searchRuns: vi.fn(),
+    updateBranch: vi.fn().mockResolvedValue({ success: true })
   },
   launch: {
     editor: vi.fn(),
@@ -47,6 +66,10 @@ const mockBridge = {
   },
   sticker: {
     add: vi.fn()
+  },
+  window: {
+    getAlwaysOnTop: vi.fn().mockResolvedValue(false),
+    setAlwaysOnTop: vi.fn().mockResolvedValue(false)
   },
   worktree: {
     add: vi.fn(),


### PR DESCRIPTION
## What

Adds GitHub-style review/approval status to the PR line, a hover Reviewers panel, and restyles toasts under the sunset theme.

### Review status
- `getPRChecks` now also fetches `pulls.listReviews` + `requested_reviewers` and derives a GitHub-accurate verdict:
  - latest `APPROVED`/`CHANGES_REQUESTED` per reviewer wins;
  - `COMMENTED` never overrides an existing verdict;
  - the PR author is excluded from reviewers;
  - a re-requested approval is treated as stale (no longer counts toward "approved").
- PR line shows a badge — **Approved** / **Changes requested** / **In review** — rendered last so it sits closest to the action buttons.
- Hovering the badge opens a GitHub-style **Reviewers** panel: each reviewer's avatar, name, and 1:1 status icon (check / cross / comment / dot), plus a re-review spinner.

### Sunset toasts
- Restyle Blueprint toasts under `.theme-sunset` to the plum-glass surface (matching popovers), with a per-intent left accent stripe.
- Fix the dismiss (X) button (was an opaque dark square).

### Misc
- Enlarge the label/tag/review badges and add padding.
- Drop the "My" tag from the PR line.

## Testing
- Ran `pnpm dev` and verified the badge, hover panel, and toast styling against a live PR.
- `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)