### PR TITLE
refactor: shared polling coordinator (one scheduler, adaptive + deduped)

### DIFF
--- a/src/main/ipcs/ipcGitHub.ts
+++ b/src/main/ipcs/ipcGitHub.ts
@@ -280,11 +280,20 @@ ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number) =>
     const { owner, repo } = await getRepoInfo(id);
     if (!owner || !repo) throw new Error('Project not found');
 
-    const { data: pr } = await octokit().rest.pulls.get({
+    let { data: pr } = await octokit().rest.pulls.get({
       owner,
       pull_number: prNumber,
       repo
     });
+
+    // GitHub computes mergeable/mergeable_state asynchronously; the first read
+    // after any change returns mergeable: null (state 'unknown'). Poll briefly
+    // so the Merge affordance reflects the real state instead of staying hidden
+    // behind a stale "unknown".
+    for (let attempt = 0; attempt < 3 && pr.mergeable === null; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 700));
+      ({ data: pr } = await octokit().rest.pulls.get({ owner, pull_number: prNumber, repo }));
+    }
 
     const {sha} = pr.head;
 

--- a/src/renderer/components/Project/components/CheckoutCard/CheckoutCard.tsx
+++ b/src/renderer/components/Project/components/CheckoutCard/CheckoutCard.tsx
@@ -1,11 +1,11 @@
 import { Button, ButtonGroup, Classes, Collapse, Spinner, Tag, Tooltip } from '@blueprintjs/core';
-import { type FC, type ReactNode, useCallback, useEffect, useState } from 'react';
+import { type FC, type ReactNode, useState } from 'react';
 import { FaCopy, FaRegCopy } from 'react-icons/fa';
 import { GitStatusBadge } from 'renderer/components/GitStatusBadge';
 import { useAppSettings, useIsSunset } from 'renderer/hooks/useAppSettings';
 import { useModal } from 'renderer/hooks/useModal';
+import { usePoll } from 'renderer/services/poller';
 import { cn } from 'renderer/utils/cn';
-import { refreshEvent } from 'renderer/utils/refresh';
 import { type Run } from 'types/gitHub';
 import { type GitStatus, type Project } from 'types/project';
 import { type Worktree } from 'types/worktree';
@@ -72,7 +72,6 @@ export const CheckoutCard: FC<Props> = ({
     selectedShell
   } = useAppSettings();
   const isSunset = useIsSunset();
-  const [status, setStatus] = useState<CheckoutStatus | null>(null);
   const [showStray, setShowStray] = useState(false);
   const [showHidden, setShowHidden] = useState(false);
   const [showAllOwn, setShowAllOwn] = useState(false);
@@ -87,57 +86,36 @@ export const CheckoutCard: FC<Props> = ({
   const { isMain } = worktree;
   const abbreviated = worktree.path.replace(/^.*\//, '.../');
 
-  const fetchStatus = useCallback(async () => {
-    if (isMain) return;
+  // Main's status arrives with the repo poll (via `gitStatus`), but a
+  // worktree has no such feed — it keeps its own subscription on the shared
+  // poller coordinator so the ahead/behind counts don't go stale through
+  // every rebase and push. The coordinator owns the recurring timer (pausing
+  // while hidden/offline and catching up on visible/focus/online, and
+  // deduping this key against any other subscriber of the same worktree), so
+  // there's no local `setInterval`, `visibilitychange` check, or
+  // `refreshEvent` listener here anymore — a gentle refresh from the navbar
+  // now goes through `refresh()`/`mutate()` on the coordinator itself.
+  const { data: worktreeStatus } = usePoll<Awaited<ReturnType<typeof window.bridge.worktree.getStatus>>>({
+    fetch: () => (isMain ? Promise.resolve({ success: false }) : window.bridge.worktree.getStatus(worktree.path)),
+    interval: () => (isMain ? Infinity : fetchInterval > 2000 ? fetchInterval : 10000),
+    key: `worktreeStatus:${worktree.path}`
+  });
 
-    const res = await window.bridge.worktree.getStatus(worktree.path);
-    if (res.success && res.status) {
-      setStatus({
-        ahead: res.status.ahead,
-        behind: res.status.behind,
-        modified: res.status.modified
-      });
-    }
-  }, [isMain, worktree.path]);
-
-  useEffect(() => {
-    if (isMain) {
-      setStatus(
-        gitStatus?.status
-          ? {
-              ahead: gitStatus.status.ahead,
-              behind: gitStatus.status.behind,
-              modified: gitStatus.status.modified
-            }
-          : null
-      );
-      return;
-    }
-
-    fetchStatus();
-  }, [fetchStatus, gitStatus, isMain]);
-
-  // Main's status arrives with the repo poll, but a worktree has no such feed —
-  // without its own clock the ahead/behind counts stayed at whatever they were
-  // when the card mounted, through every rebase and push.
-  useEffect(() => {
-    if (isMain) return;
-
-    const timer = window.setInterval(() => {
-      if (!document.hidden) fetchStatus();
-    }, fetchInterval > 2000 ? fetchInterval : 10000);
-
-    return () => window.clearInterval(timer);
-  }, [fetchInterval, fetchStatus, isMain]);
-
-  // Gentle refresh from the navbar re-reads git status in place.
-  useEffect(() => {
-    const onRefresh = () => fetchStatus();
-
-    window.addEventListener(refreshEvent, onRefresh);
-
-    return () => window.removeEventListener(refreshEvent, onRefresh);
-  }, [fetchStatus]);
+  const status: CheckoutStatus | null = isMain
+    ? gitStatus?.status
+      ? {
+          ahead: gitStatus.status.ahead,
+          behind: gitStatus.status.behind,
+          modified: gitStatus.status.modified
+        }
+      : null
+    : worktreeStatus?.success && worktreeStatus.status
+      ? {
+          ahead: worktreeStatus.status.ahead,
+          behind: worktreeStatus.status.behind,
+          modified: worktreeStatus.status.modified
+        }
+      : null;
 
   const copyToClipboard = () => {
     setCopyIcon(

--- a/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
+++ b/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
@@ -2,9 +2,9 @@ import { Button, ButtonGroup, Icon, Menu, MenuDivider, MenuItem, Popover, Toolti
 import { type FC, useCallback, useEffect, useState } from 'react';
 import { FaCopy, FaRegCopy } from 'react-icons/fa';
 import { useIsSunset } from 'renderer/hooks/useAppSettings';
+import { mutate, refresh, usePoll } from 'renderer/services/poller';
 import { appToaster } from 'renderer/utils/appToaster';
 import { cn } from 'renderer/utils/cn';
-import { refreshEvent } from 'renderer/utils/refresh';
 import { timeAgo } from 'renderer/utils/timeAgo';
 import { type Pull } from 'types/gitHub';
 
@@ -16,6 +16,9 @@ type Check = {
   name: string;
   status: string;
 };
+
+type ChecksResult = Awaited<ReturnType<typeof window.bridge.gitAPI.getPRChecks>>;
+type MutationResult = { message?: string; success: boolean };
 
 type MergeMethod = 'merge' | 'rebase' | 'squash';
 
@@ -111,7 +114,7 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
   const isClosed = !isMerged && state === 'closed';
   const totalUnresolvedComments = unresolvedThreads.reduce((sum, t) => sum + t.count, 0);
 
-  const applyChecks = useCallback((res: Awaited<ReturnType<typeof window.bridge.gitAPI.getPRChecks>>) => {
+  const applyChecks = useCallback((res: ChecksResult) => {
     if (!res.success) return;
     if (res.checks) setChecks(res.checks);
     if (res.review) setReview(res.review);
@@ -124,28 +127,42 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
     setAllowedMergeMethods(res.allowedMergeMethods ?? []);
   }, []);
 
-  const fetchChecks = useCallback(async () => {
-    applyChecks(await window.bridge.gitAPI.getPRChecks(projectId, number));
-  }, [applyChecks, projectId, number]);
+  // One shared-coordinator poll per PR, keyed so every subscriber (this card,
+  // any other view of the same PR) shares one cache entry and one fetch. The
+  // coordinator owns the timer, pause-when-hidden/offline, refetch-on-focus,
+  // in-flight dedupe and error backoff — no local setInterval / refresh-event
+  // listener needed here.
+  const pollKey = `prChecks:${projectId}:${number}`;
 
-  // Refetch on mount, whenever the PR advances (new head commit / updated_at),
-  // and on a slow interval so a base that moved on GitHub — which changes
-  // "behind" / mergeable state without touching the PR object — is not shown
-  // stale (e.g. an "Update branch" button lingering after the branch caught up).
+  const { data: checksData } = usePoll<ChecksResult>({
+    fetch: () => window.bridge.gitAPI.getPRChecks(projectId, number),
+    // Poll hot (every 8s) while anything is still in flux — a check not done,
+    // GitHub still computing mergeable state, or the branch behind base — and
+    // back off to once a minute once everything has settled.
+    interval: (data) => {
+      if (!data || !data.success) return 8000;
+      const checksInFlux = (data.checks ?? []).some((c: Check) => c.status !== 'completed');
+      const inFlux = checksInFlux || data.mergeableState === 'unknown' || data.behind === true;
+      return inFlux ? 8000 : 60000;
+    },
+    key: pollKey
+  });
+
   useEffect(() => {
-    fetchChecks();
-    const timer = setInterval(fetchChecks, 30000);
-    return () => clearInterval(timer);
+    if (!checksData) return;
+    applyChecks(checksData);
+    // Clear the "Update branch" spinner only on a real read that reports the
+    // branch caught up — never on a stale one, and never by giving up.
+    if (checksData.success && !checksData.behind) setUpdating(false);
+  }, [applyChecks, checksData]);
 
-  }, [fetchChecks, pull.head?.sha, pull.updated_at]);
-
-  // Navbar refresh also refreshes this PR's review / mergeable / behind /
-  // unresolved states, not just runs and pulls.
+  // A new head commit or updated_at means GitHub has fresh PR data even though
+  // the poll key itself hasn't changed — re-heat this key now instead of
+  // waiting out the adaptive interval.
   useEffect(() => {
-    const onRefresh = () => fetchChecks();
-    window.addEventListener(refreshEvent, onRefresh);
-    return () => window.removeEventListener(refreshEvent, onRefresh);
-  }, [fetchChecks]);
+    refresh(pollKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pull.head?.sha, pull.updated_at]);
 
   const openInBrowser = () => {
     window.open(html_url, '_blank');
@@ -161,7 +178,12 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
 
   const updateBranch = async (method: 'merge' | 'rebase' = 'merge') => {
     setUpdating(true);
-    const res = await window.bridge.gitAPI.updateBranch(projectId, number, method);
+    // mutate() runs the bridge call, then hot re-polls prChecks (now, +800ms,
+    // +1500ms); the adaptive interval above keeps polling every 8s for as long
+    // as GitHub still reports "behind" (its recompute is asynchronous), so this
+    // settles on its own without a hand-rolled retry loop. The spinner clears
+    // in the poll-apply effect above, only on a real "not behind" read.
+    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.updateBranch(projectId, number, method));
     const toaster = await appToaster;
     if (!res.success) {
       toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to update branch'), timeout: 0 });
@@ -169,32 +191,15 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
       return;
     }
     toaster.show({ icon: 'git-merge', intent: 'success', message: `Updated #${number} with the base branch` });
-    // GitHub recomputes the PR's behind/mergeable state asynchronously after
-    // update-branch, so an immediate read still reports "behind". Poll fresh PR
-    // data until it settles (or give up) instead of trusting one stale read.
-    // The button stays in its updating spinner throughout, then clears on real
-    // state — no flicker back to "Update branch".
-    let settled = false;
-    for (let attempt = 0; attempt < 6 && !settled; attempt += 1) {
-      await new Promise((resolve) => setTimeout(resolve, attempt === 0 ? 800 : 1500));
-      const next = await window.bridge.gitAPI.getPRChecks(projectId, number);
-      if (next.success && !next.behind) {
-        applyChecks(next);
-        settled = true;
-      }
-    }
-    if (!settled) await fetchChecks();
-    setUpdating(false);
   };
 
   const mergePR = async (method: 'merge' | 'rebase' | 'squash') => {
     setMerging(true);
-    const res = await window.bridge.gitAPI.mergePR(projectId, number, method);
+    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.mergePR(projectId, number, method));
     const toaster = await appToaster;
     if (res.success) {
       toaster.show({ icon: 'git-merge', intent: 'success', message: `Merged #${number}` });
       setJustMerged(true);
-      await fetchChecks();
     } else {
       toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to merge'), timeout: 0 });
     }
@@ -203,12 +208,11 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
 
   const enableAutoMerge = async (method: 'merge' | 'rebase' | 'squash') => {
     setMerging(true);
-    const res = await window.bridge.gitAPI.enableAutoMerge(projectId, number, method);
+    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.enableAutoMerge(projectId, number, method));
     const toaster = await appToaster;
     if (res.success) {
       toaster.show({ icon: 'automatic-updates', intent: 'success', message: `Auto-merge enabled for #${number}` });
       setAutoMergeEnabled(true);
-      await fetchChecks();
     } else {
       toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to enable auto-merge'), timeout: 0 });
     }
@@ -217,12 +221,11 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
 
   const disableAutoMerge = async () => {
     setMerging(true);
-    const res = await window.bridge.gitAPI.disableAutoMerge(projectId, number);
+    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.disableAutoMerge(projectId, number));
     const toaster = await appToaster;
     if (res.success) {
       toaster.show({ icon: 'automatic-updates', intent: 'success', message: `Auto-merge disabled for #${number}` });
       setAutoMergeEnabled(false);
-      await fetchChecks();
     } else {
       toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to disable auto-merge'), timeout: 0 });
     }
@@ -455,7 +458,7 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
             {unresolvedComments > 0 && (
               <Popover
                 content={
-                  <div className="min-w-[220px] px-3.5 py-3">
+                  <div className="min-w-[220px] max-w-[340px] px-3.5 py-3">
                     <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-bp-gray-3">
                       {unresolvedComments} unresolved {unresolvedComments === 1 ? 'conversation' : 'conversations'}
                     </div>

--- a/src/renderer/components/Project/components/PullRequest/PullRequest.updateBranch.test.tsx
+++ b/src/renderer/components/Project/components/PullRequest/PullRequest.updateBranch.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
+import { __reset } from 'renderer/services/poller/coordinator';
 import { type Pull } from 'types/gitHub';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PullRequest } from './PullRequest';
 
@@ -41,27 +41,29 @@ const caret = () => screen.queryByLabelText('Update branch options');
 
 describe('PullRequest "Update branch" button', () => {
   beforeEach(() => {
+    __reset();
     vi.mocked(window.bridge.gitAPI.getPRChecks).mockReset();
     vi.mocked(window.bridge.gitAPI.updateBranch).mockReset();
   });
 
   afterEach(() => {
+    __reset();
     vi.clearAllMocks();
   });
 
   it('clears the button once GitHub settles, polling past the stale post-update read that still reports behind', async () => {
     // Mount sees behind: true. The update succeeds, but GitHub's first recompute
-    // still says behind (eventual consistency); the next poll reports it caught
-    // up. The fix must keep polling until that settled read, then clear.
+    // still says behind (eventual consistency); the coordinator's hot re-poll
+    // burst (mutate) keeps reading until one reports it caught up.
     vi.mocked(window.bridge.gitAPI.getPRChecks)
       .mockResolvedValueOnce(checksResponse(true)) // mount
-      .mockResolvedValueOnce(checksResponse(true)) // first poll: still stale
+      .mockResolvedValueOnce(checksResponse(true)) // first re-poll: still stale
       .mockResolvedValue(checksResponse(false)); // later polls: settled
     vi.mocked(window.bridge.gitAPI.updateBranch).mockResolvedValue({ success: true });
 
     render(<PullRequest projectId="project-1"
       pull={basePull}
-    />);
+           />);
 
     expect(await screen.findByText('Update branch')).toBeTruthy();
 
@@ -76,25 +78,25 @@ describe('PullRequest "Update branch" button', () => {
     expect(caret()).toBeNull();
 
     expect(window.bridge.gitAPI.updateBranch).toHaveBeenCalledWith('project-1', 1, 'merge');
-    // mount + at least two polls (the stale one, then the settled one).
+    // mount + at least two re-polls (the stale one, then the settled one).
     expect(vi.mocked(window.bridge.gitAPI.getPRChecks).mock.calls.length).toBeGreaterThanOrEqual(3);
   });
 
   it('keeps the button while GitHub still reports the branch behind, instead of falsely hiding it', async () => {
-    // GitHub never catches up within the poll window. The button must NOT lie
-    // and hide — it stays until a real "not behind" read (or the next refresh).
+    // GitHub never catches up. The button must NOT lie and hide — it stays
+    // until a real "not behind" read (or the next refresh).
     vi.mocked(window.bridge.gitAPI.getPRChecks).mockResolvedValue(checksResponse(true));
     vi.mocked(window.bridge.gitAPI.updateBranch).mockResolvedValue({ success: true });
 
     render(<PullRequest projectId="project-1"
       pull={basePull}
-    />);
+           />);
 
     expect(await screen.findByText('Update branch')).toBeTruthy();
     fireEvent.click(screen.getByText('Update branch'));
 
-    // Past the first poll (which still reports behind) the affordance is still
-    // present — a spinner, not a vanished button.
+    // Past the first re-poll (which still reports behind) the affordance is
+    // still present — a spinner, not a vanished button.
     await new Promise((resolve) => setTimeout(resolve, 1200));
     expect(caret()).not.toBeNull();
   });

--- a/src/renderer/components/Project/components/Workflow/Workflow.tsx
+++ b/src/renderer/components/Project/components/Workflow/Workflow.tsx
@@ -1,9 +1,10 @@
 import { Button, ButtonGroup, Collapse, Menu, MenuDivider, MenuItem, Popover, Tooltip } from '@blueprintjs/core';
-import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FaCopy, FaRegCopy } from 'react-icons/fa';
 import { getStatusIcon } from 'renderer/assets/gitHubStatusUtils';
 import { useAppSettings, useIsSunset } from 'renderer/hooks/useAppSettings';
 import { useModal } from 'renderer/hooks/useModal';
+import { refresh, subscribe } from 'renderer/services/poller';
 import { cn } from 'renderer/utils/cn';
 import { addScope, parseIgnored, type WorkflowScope } from 'renderer/utils/ignoredWorkflows';
 import { timeAgo } from 'renderer/utils/timeAgo';
@@ -143,59 +144,47 @@ export const Workflow: FC<Props> = ({ isRoot = false, onRefresh, project, run, s
     setIsOpen(!isOpen);
   };
 
+  // `conclusion`/`onRefresh` are read through refs inside the subscription
+  // below so that their churn never forces a resubscribe — per the poller's
+  // README, only a changed `key` (here, `isOpen`/`id`/`project.id`) should.
+  const conclusionRef = useRef(conclusion);
+  conclusionRef.current = conclusion;
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+
   useEffect(() => {
-    if (!isOpen || jobs.length === 0) return;
+    if (!isOpen) return;
 
-    const pollJobs = async () => {
-      const res = await window.bridge.gitAPI.getJobs(project.id, id);
-      if (res.success && res.jobs) {
-        setJobs(res.jobs);
+    const unsubscribe = subscribe(
+      {
+        fetch: (): Promise<{ jobs?: Job[]; success: boolean }> => window.bridge.gitAPI.getJobs(project.id, id),
+        // Keep polling every 5s while the run is in flight; once it has
+        // concluded, stop auto-polling entirely.
+        interval: () => (conclusionRef.current ? Infinity : 5000),
+        key: `jobs:${id}`
+      },
+      (res) => {
+        if (res.success && res.jobs) {
+          setJobs(res.jobs);
 
-        // If all jobs are done but the workflow run hasn't updated yet, trigger a refresh
-        if (!conclusion && res.jobs.length > 0 && res.jobs.every((j: Job) => j.conclusion)) {
-          onRefresh?.();
+          // If all jobs are done but the workflow run hasn't updated yet, trigger a refresh
+          if (!conclusionRef.current && res.jobs.length > 0 && res.jobs.every((j: Job) => j.conclusion)) {
+            onRefreshRef.current?.();
+          }
         }
       }
-    };
+    );
 
-    // Final fetch when workflow completes to get final job/step statuses
-    if (conclusion) {
-      pollJobs();
-      return;
+    return unsubscribe;
+  }, [isOpen, id, project.id]);
+
+  // Force one more fetch as soon as the run concludes, so job/step statuses
+  // reflect the final state instead of waiting for the next scheduled poll.
+  useEffect(() => {
+    if (isOpen && conclusion) {
+      refresh(`jobs:${id}`);
     }
-
-    let jobPollTimer: null | number = null;
-
-    const startJobPolling = () => {
-      if (!jobPollTimer) {
-        jobPollTimer = window.setInterval(pollJobs, 5000);
-      }
-    };
-
-    const stopJobPolling = () => {
-      if (jobPollTimer) {
-        window.clearInterval(jobPollTimer);
-        jobPollTimer = null;
-      }
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.hidden) {
-        stopJobPolling();
-      } else {
-        pollJobs();
-        startJobPolling();
-      }
-    };
-
-    startJobPolling();
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      stopJobPolling();
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [isOpen, jobs.length, id, project.id, conclusion, onRefresh]);
+  }, [conclusion, isOpen, id]);
 
   return (
     <>

--- a/src/renderer/components/Project/hooks/useRepoData/useRepoData.tsx
+++ b/src/renderer/components/Project/hooks/useRepoData/useRepoData.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppSettings } from 'renderer/hooks/useAppSettings';
+import { refresh as refreshPoller, subscribe } from 'renderer/services/poller';
 import { addHidden, hiddenPullsKey, hiddenRunsKey, parseHidden } from 'renderer/utils/hidden';
 import { type IgnoredWorkflow, isWorkflowHidden, parseIgnored, type RunContext } from 'renderer/utils/ignoredWorkflows';
 import { refreshEvent } from 'renderer/utils/refresh';
 import { unhideEvent } from 'renderer/utils/unhide';
-import { type Run } from 'types/gitHub';
+import { type Pull, type Run } from 'types/gitHub';
 import { type Project } from 'types/project';
 
 import {
@@ -23,6 +24,11 @@ import {
 // A pinned workflow costs one API call each, so it refreshes once a minute
 // rather than on every poll.
 const pinnedInterval = 60000;
+
+// Below this, the pre-poller-migration code refused to start the repeating
+// runs poll at all — kept so an absurdly low setting still can't hammer the
+// API every tick.
+const minRunsPollInterval = 2000;
 
 const getHidden = (key: string): Set<number> =>
   new Set(parseHidden(sessionStorage.getItem(key)).map((entry) => entry.id));
@@ -45,6 +51,12 @@ const hide = (key: string, id: number, label: string) => {
  * `worktreeBranches` scopes desktop notifications: the fetch covers the whole
  * repo, but only checkouts on this machine — and pull requests you opened —
  * are worth interrupting you for.
+ *
+ * Polling itself (the shared timer, pause-while-hidden/offline,
+ * refetch-on-visible/focus/online, in-flight dedupe, backoff) is delegated to
+ * the shared poller coordinator (`renderer/services/poller`). This hook only
+ * owns what the coordinator can't know about: the exact fetch args, how the
+ * fetched data is merged into state, and desktop-notification arming.
  */
 export const useRepoData = (
   project: Project,
@@ -75,16 +87,40 @@ export const useRepoData = (
     gitHubToken
   } = useAppSettings();
 
-  const runsIntervalId = useRef<null | number>(null);
-  const pullsIntervalId = useRef<null | number>(null);
   const prevConclusions = useRef<Map<number, null | string>>(new Map());
-  const initialRunsFetched = useRef(false);
   const notifyArmed = useRef(false);
   const notifyBranches = useRef<Set<string>>(new Set());
   const hiddenWorkflows = useRef<IgnoredWorkflow[]>([]);
   // The pieces `getRuns` needs to place a run in root vs worktree, kept in a ref
   // so a branch-list change never rebuilds the poll.
   const rootContext = useRef<{ mainBranch: string; worktrees: Set<string> }>({ mainBranch: '', worktrees: new Set() });
+
+  // The runs/pulls/pinned-runs poller subscriptions are set up once per
+  // project (see the `subscribe` calls below) and must not be torn down and
+  // rebuilt every time a setting or `pollRuns` changes — so their `fetch`/
+  // `interval` closures read the *latest* values off these refs instead of
+  // closing over props/state directly.
+  const pollRunsRef = useRef(pollRuns);
+  pollRunsRef.current = pollRuns;
+  const fetchIntervalRef = useRef(fetchInterval);
+  fetchIntervalRef.current = fetchInterval;
+  const pullsIntervalRef = useRef(gitHubPulls.pollInterval);
+  pullsIntervalRef.current = gitHubPulls.pollInterval;
+  const ignoreDependabotRef = useRef(ignoreDependabot);
+  ignoreDependabotRef.current = ignoreDependabot;
+  const notificationsRef = useRef(notifications);
+  notificationsRef.current = notifications;
+  const projectNameRef = useRef(project.name);
+  projectNameRef.current = project.name;
+
+  // One-shot overrides consumed by the very next runs fetch. `nextRunsFetchDeep`
+  // starts `true` so the first fetch of this hook's life walks back through
+  // history pages, same as the old `first = !initialRunsFetched.current`.
+  // Both refs are also set by a manual refresh (see `refresh` below and the
+  // `refreshEvent` listener) to reproduce the exact arm/deep args those call
+  // sites used to pass straight to `getRuns`.
+  const nextRunsFetchDeep = useRef(true);
+  const nextRunsFetchArmOverride = useRef<boolean | null>(null);
 
   // Stored data may still be the legacy `string[]`, so it is parsed forward on
   // every read rather than trusted to match the current shape.
@@ -102,14 +138,14 @@ export const useRepoData = (
     [mainBranch, worktreeBranches]
   );
 
-  // Refs, not deps: `getRuns` reads them when it fires, and rebuilding it would
-  // restart the poll every time a setting changes.
+  // Refs, not deps: the runs poll reads them when it fires, and rebuilding it
+  // would restart the poll every time a setting changes.
   useEffect(() => {
     hiddenWorkflows.current = ignored;
   }, [ignored]);
 
-  // A ref, not state: `getRuns` reads it at fire time and must not be rebuilt
-  // (and so restart the poll) every time a branch list changes identity.
+  // A ref, not state: the runs poll reads it at fire time and must not be
+  // rebuilt (and so restart the poll) every time a branch list changes identity.
   useEffect(() => {
     notifyBranches.current = notifiableBranches(worktreeBranches, pulls);
   }, [pulls, worktreeBranches]);
@@ -119,20 +155,19 @@ export const useRepoData = (
   }, [mainBranch, worktreeBranches]);
 
   /**
-   * `arm` is passed only by the *polling* fetch. The mount fetch runs for every
-   * repo, collapsed ones included, so it primes `prevConclusions` with `null`
-   * for anything still in flight. Notifying off that map would fire a burst of
-   * hours-old results the moment a card is first expanded — so notifications
-   * stay disarmed until a polling fetch has primed the map itself.
+   * Processes one `getRuns` response: merges it into state and fires desktop
+   * notifications. `arm` is true only for a fetch that belongs to a
+   * "continuous polling session" (expanded + visible); the mount fetch primes
+   * `prevConclusions` with `null` for anything still in flight, and notifying
+   * off that map would fire a burst of hours-old results the moment a card is
+   * first expanded — so notifications stay disarmed until an armed fetch has
+   * primed the map itself.
    */
-  const getRuns = useCallback(async (arm = false, deep = false) => {
-    if (!gitHubToken) return;
-
-    const res = await window.bridge.gitAPI.getRuns(project.id, deep);
+  const processRuns = useCallback((res: { runs?: Run[]; success: boolean }, arm: boolean) => {
     setRunsLoaded(true);
     if (!res.success) return;
 
-    const nextRuns: Run[] = ignoreDependabot
+    const nextRuns: Run[] = ignoreDependabotRef.current
       ? (res.runs ?? []).filter((run: Run) => !run.actor?.login?.toLowerCase().includes('dependabot'))
       : (res.runs ?? []);
 
@@ -152,13 +187,13 @@ export const useRepoData = (
             path: run.path
           })
         ) &&
-        notifications &&
+        notificationsRef.current &&
         notifyBranches.current.has(run.head_branch ?? '')
       ) {
         const status = run.conclusion === 'success' ? 'passed' : 'failed';
         const event = run.event !== 'workflow_dispatch' ? run.event : 'manual';
         window.bridge.notification.show(
-          `${project.name}: ${run.name} ${status}`,
+          `${projectNameRef.current}: ${run.name} ${status}`,
           `${event} » ${run.head_branch} (#${run.run_number})\n${run.display_title}`
         );
       }
@@ -170,7 +205,7 @@ export const useRepoData = (
     // Merge rather than replace, so a run does not vanish the moment a busy
     // repo pushes it off the first page.
     setRuns((prev) => mergeRuns(prev, nextRuns, Date.now()));
-  }, [gitHubToken, ignoreDependabot, notifications, project.id, project.name]);
+  }, []);
 
   /**
    * Walks the repo's run history a page at a time, with no date window — the
@@ -207,114 +242,115 @@ export const useRepoData = (
     [exhaustedHistory, gitHubToken, loadingHistory, project.id]
   );
 
-  const getPulls = useCallback(async () => {
+  // Subscribes once per project to the shared poller: it owns the single
+  // timer, pausing while hidden/offline, and refetching stale data on
+  // visible/focus/online. `fetch`/`interval` read their inputs off refs (see
+  // above) so a setting or `pollRuns` change never resubscribes — that would
+  // both restart the coordinator's cache entry for this key needlessly and
+  // (via the cache-hit replay on subscribe) risk re-running notification
+  // arming against already-processed data.
+  useEffect(() => {
     if (!gitHubToken) return;
 
+    const fetchRuns = async () => {
+      const deep = nextRunsFetchDeep.current;
+      nextRunsFetchDeep.current = false;
+
+      const armOverride = nextRunsFetchArmOverride.current;
+      nextRunsFetchArmOverride.current = null;
+      const arm = armOverride ?? pollRunsRef.current;
+
+      const res = await window.bridge.gitAPI.getRuns(project.id, deep);
+      return { arm, res };
+    };
+
+    const unsubscribe = subscribe(
+      {
+        fetch: fetchRuns,
+        interval: () => (pollRunsRef.current && fetchIntervalRef.current > minRunsPollInterval ? fetchIntervalRef.current : Infinity),
+        key: `runs:${project.id}`
+      },
+      ({ arm, res }) => processRuns(res, arm)
+    );
+
+    return unsubscribe;
+  }, [gitHubToken, processRuns, project.id]);
+
+  // `notifyArmed` means "prevConclusions was primed by a fetch inside the
+  // current continuous polling session". Collapsing a card stops the runs
+  // poll (via the `interval` above returning `Infinity`) without unsubscribing
+  // it, so disarming has to happen here explicitly rather than by tearing the
+  // subscription down.
+  useEffect(() => {
+    if (!pollRuns) {
+      notifyArmed.current = false;
+      return;
+    }
+
+    // Expanding a card (or mounting already expanded) shouldn't wait for the
+    // next scheduled tick — nudge the coordinator to fetch now.
+    refreshPoller(`runs:${project.id}`);
+    refreshPoller(`pinnedRuns:${project.id}`);
+  }, [pollRuns, project.id]);
+
+  // Same disarm the old `visibilitychange` handler did while hidden. Fetching
+  // itself is already paused by the coordinator while the tab is hidden; this
+  // only keeps `notifyArmed` from staying (or resuming) true across a gap
+  // nobody was watching, so the catch-up fetch on return never fires a burst
+  // of stale notifications.
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.hidden) notifyArmed.current = false;
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+  }, []);
+
+  const fetchPulls = useCallback(async () => {
     const [openRes, authorRes, reviewRes] = await Promise.all([
       window.bridge.gitAPI.getOpenPulls(project.id),
       window.bridge.gitAPI.getPulls(project.id, 'author'),
       window.bridge.gitAPI.getPulls(project.id, 'review-requested')
     ]);
 
-    if (!openRes.success || !authorRes.success || !reviewRes.success) return;
+    return { authorRes, openRes, reviewRes };
+  }, [project.id]);
 
-    const numbersOf = (res: { pulls?: { number: number }[] }) => (res.pulls ?? []).map((item) => item.number);
+  const handlePullsData = useCallback(
+    ({
+      authorRes,
+      openRes,
+      reviewRes
+    }: {
+      authorRes: { pulls?: { number: number }[]; success: boolean };
+      openRes: { pulls?: Pull[]; success: boolean };
+      reviewRes: { pulls?: { number: number }[]; success: boolean };
+    }) => {
+      if (!openRes.success || !authorRes.success || !reviewRes.success) return;
 
-    setPulls(tagPulls(openRes.pulls ?? [], numbersOf(authorRes), numbersOf(reviewRes)));
-  }, [gitHubToken, project.id]);
+      const numbersOf = (res: { pulls?: { number: number }[] }) => (res.pulls ?? []).map((item) => item.number);
 
-  useEffect(() => {
-    if (!gitHubToken) return;
-
-    // One fetch per mount even while details are hidden, so the repo has
-    // something to show the moment they are switched on.
-    // The first fetch walks back through pages so a quiet branch has its runs
-    // from the start; the polls that follow only need the newest page.
-    if (!initialRunsFetched.current || pollRuns) {
-      const first = !initialRunsFetched.current;
-      initialRunsFetched.current = true;
-      getRuns(pollRuns, first);
-    }
-
-    // `notifyArmed` means "prevConclusions was primed by a fetch inside the
-    // current continuous polling session". Whenever polling stops the map goes
-    // stale, so disarm — otherwise resuming fires a burst of notifications for
-    // runs that concluded while nobody was watching.
-    if (!pollRuns) {
-      notifyArmed.current = false;
-      return;
-    }
-
-    const startPolling = () => {
-      if (!runsIntervalId.current && fetchInterval > 2000) {
-        runsIntervalId.current = window.setInterval(() => getRuns(), fetchInterval);
-      }
-    };
-
-    const stopPolling = () => {
-      if (runsIntervalId.current) {
-        window.clearInterval(runsIntervalId.current);
-        runsIntervalId.current = null;
-      }
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.hidden) {
-        stopPolling();
-        notifyArmed.current = false;
-      } else {
-        getRuns(true);
-        startPolling();
-      }
-    };
-
-    startPolling();
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      stopPolling();
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [fetchInterval, getRuns, gitHubToken, pollRuns]);
+      setPulls(tagPulls(openRes.pulls ?? [], numbersOf(authorRes), numbersOf(reviewRes)));
+    },
+    []
+  );
 
   useEffect(() => {
     if (!gitHubToken) return;
 
-    getPulls();
+    const unsubscribe = subscribe(
+      {
+        fetch: fetchPulls,
+        interval: () => pullsIntervalRef.current,
+        key: `pulls:${project.id}`
+      },
+      handlePullsData
+    );
 
-    const start = () => {
-      // Guarding on the ref alone left the old timer running at the old
-      // interval whenever the setting changed.
-      if (!pullsIntervalId.current) {
-        pullsIntervalId.current = window.setInterval(getPulls, gitHubPulls.pollInterval);
-      }
-    };
-
-    const stop = () => {
-      if (pullsIntervalId.current) {
-        window.clearInterval(pullsIntervalId.current);
-        pullsIntervalId.current = null;
-      }
-    };
-
-    const onVisibility = () => {
-      if (document.hidden) {
-        stop();
-        return;
-      }
-
-      getPulls();
-      start();
-    };
-
-    start();
-    document.addEventListener('visibilitychange', onVisibility);
-
-    return () => {
-      stop();
-      document.removeEventListener('visibilitychange', onVisibility);
-    };
-  }, [getPulls, gitHubPulls.pollInterval, gitHubToken]);
+    return unsubscribe;
+  }, [fetchPulls, gitHubToken, handlePullsData, project.id]);
 
   const hidePull = useCallback(
     (pullId: number, label = `#${pullId}`) => {
@@ -350,63 +386,45 @@ export const useRepoData = (
    * that last ran days ago still shows. One call per pinned workflow, so this
    * runs on its own slow clock rather than with the poll.
    */
-  const getPinnedRuns = useCallback(async () => {
+  const fetchPinnedRuns = useCallback(() => window.bridge.gitAPI.getPinnedRuns(project.id), [project.id]);
+
+  const handlePinnedRunsData = useCallback((res: { runs?: Run[]; success: boolean }) => {
+    if (res.success) setPinnedRuns(res.runs ?? []);
+  }, []);
+
+  useEffect(() => {
     if (!gitHubToken) return;
 
-    const res = await window.bridge.gitAPI.getPinnedRuns(project.id);
-    if (res.success) setPinnedRuns(res.runs ?? []);
-  }, [gitHubToken, project.id]);
+    const unsubscribe = subscribe(
+      {
+        fetch: fetchPinnedRuns,
+        interval: () => (pollRunsRef.current ? pinnedInterval : Infinity),
+        key: `pinnedRuns:${project.id}`
+      },
+      handlePinnedRunsData
+    );
 
-  // The navbar refresh triggers a gentle in-place re-fetch of everything this
-  // card shows, instead of reloading the whole app.
+    return unsubscribe;
+  }, [fetchPinnedRuns, gitHubToken, handlePinnedRunsData, project.id]);
+
+  // Bridges both worlds during the poller migration: `requestRefresh` (the
+  // navbar's "refresh everything" action) still dispatches this legacy DOM
+  // event for any not-yet-migrated listener, alongside the shared coordinator
+  // refresh it now also triggers. This hook is migrated, so it no longer
+  // fetches off the event itself — the coordinator's own `refresh()` call
+  // (already wired into `requestRefresh`) does that — but it still needs the
+  // *deep*, force-armed fetch the old `getRuns(true, true)` call made, so it
+  // primes the same one-shot refs a manual `refresh()` below uses.
   useEffect(() => {
     const onRefresh = () => {
-      getRuns(true, true);
-      getPulls();
-      getPinnedRuns();
+      nextRunsFetchDeep.current = true;
+      nextRunsFetchArmOverride.current = true;
     };
 
     window.addEventListener(refreshEvent, onRefresh);
 
     return () => window.removeEventListener(refreshEvent, onRefresh);
-  }, [getRuns, getPulls, getPinnedRuns]);
-
-  useEffect(() => {
-    getPinnedRuns();
-
-    if (!pollRuns) return;
-
-    let timer: null | number = null;
-
-    const start = () => {
-      if (!timer) timer = window.setInterval(getPinnedRuns, pinnedInterval);
-    };
-
-    const stop = () => {
-      if (timer) {
-        window.clearInterval(timer);
-        timer = null;
-      }
-    };
-
-    const onVisibility = () => {
-      if (document.hidden) {
-        stop();
-        return;
-      }
-
-      getPinnedRuns();
-      start();
-    };
-
-    start();
-    document.addEventListener('visibilitychange', onVisibility);
-
-    return () => {
-      stop();
-      document.removeEventListener('visibilitychange', onVisibility);
-    };
-  }, [getPinnedRuns, pollRuns]);
+  }, []);
 
   /**
    * Typing a workflow name asks GitHub for that workflow's runs directly, which
@@ -469,11 +487,16 @@ export const useRepoData = (
     [pullsByBranch]
   );
 
+  // Matches the pre-migration `refresh()`: a deep runs fetch that does *not*
+  // force-arm notifications (unlike the global `refreshEvent`, which does),
+  // plus a plain re-fetch of pulls and pinned runs.
   const refresh = useCallback(() => {
-    getRuns(false, true);
-    getPulls();
-    getPinnedRuns();
-  }, [getPinnedRuns, getPulls, getRuns]);
+    nextRunsFetchDeep.current = true;
+    nextRunsFetchArmOverride.current = false;
+    refreshPoller(`runs:${project.id}`);
+    refreshPoller(`pulls:${project.id}`);
+    refreshPoller(`pinnedRuns:${project.id}`);
+  }, [project.id]);
 
   return {
     clearHiddenPulls,

--- a/src/renderer/hooks/useClaudeUsage.test.ts
+++ b/src/renderer/hooks/useClaudeUsage.test.ts
@@ -8,29 +8,41 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // *before* `./useClaudeUsage` is imported below. Static imports are hoisted above plain
 // statements, but `vi.hoisted` callbacks run before that hoisted import, so the mutation
 // belongs there.
-const { accountsMock, appSettingsSetMock, detectMock, settingsGetMock, usageMock } = vi.hoisted(() => {
-  // The module's top-level `init()` call fires the instant it's imported below,
-  // long before any test's `beforeEach` runs, so these need harmless resolved
-  // defaults up front to avoid an unhandled rejection during import.
-  const accountsMock = vi.fn().mockResolvedValue([]);
-  const detectMock = vi.fn().mockResolvedValue({ installed: false });
-  const usageMock = vi.fn().mockResolvedValue(undefined);
-  const settingsGetMock = vi.fn().mockResolvedValue({});
-  const appSettingsSetMock = vi.fn();
+const { accountsMock, appSettingsSetMock, detectMock, settingsGetMock, subscribeMock, unsubscribeMocks, usageMock } =
+  vi.hoisted(() => {
+    // The module's top-level `init()` call fires the instant it's imported below,
+    // long before any test's `beforeEach` runs, so these need harmless resolved
+    // defaults up front to avoid an unhandled rejection during import.
+    const accountsMock = vi.fn().mockResolvedValue([]);
+    const detectMock = vi.fn().mockResolvedValue({ installed: false });
+    const usageMock = vi.fn().mockResolvedValue(undefined);
+    const settingsGetMock = vi.fn().mockResolvedValue({});
+    const appSettingsSetMock = vi.fn();
 
-  const existingWindow = (globalThis as { window?: { bridge?: Record<string, unknown> } }).window;
+    // The store subscribes to the shared poller coordinator directly (imperative
+    // `subscribe()`, not the `usePoll` hook, since the key is dynamic). Mock it so
+    // these tests can assert *how* the store drives the coordinator (key, fetch,
+    // interval) without running the coordinator's real timer/visibility machinery.
+    const unsubscribeMocks: ReturnType<typeof vi.fn>[] = [];
+    const subscribeMock = vi.fn((_spec: unknown, _onData: (data: unknown) => void) => {
+      const unsub = vi.fn();
+      unsubscribeMocks.push(unsub);
+      return unsub;
+    });
 
-  (globalThis as unknown as { window: unknown }).window = {
-    ...existingWindow,
-    bridge: {
-      ...existingWindow?.bridge,
-      claude: { accounts: accountsMock, detect: detectMock, usage: usageMock },
-      settings: { ...(existingWindow?.bridge?.settings as Record<string, unknown>), get: settingsGetMock }
-    }
-  };
+    const existingWindow = (globalThis as { window?: { bridge?: Record<string, unknown> } }).window;
 
-  return { accountsMock, appSettingsSetMock, detectMock, settingsGetMock, usageMock };
-});
+    (globalThis as unknown as { window: unknown }).window = {
+      ...existingWindow,
+      bridge: {
+        ...existingWindow?.bridge,
+        claude: { accounts: accountsMock, detect: detectMock, usage: usageMock },
+        settings: { ...(existingWindow?.bridge?.settings as Record<string, unknown>), get: settingsGetMock }
+      }
+    };
+
+    return { accountsMock, appSettingsSetMock, detectMock, settingsGetMock, subscribeMock, unsubscribeMocks, usageMock };
+  });
 
 vi.mock('./useAppSettings', () => ({
   useAppSettings: {
@@ -38,7 +50,20 @@ vi.mock('./useAppSettings', () => ({
   }
 }));
 
-import { CLAUDE_POLL_MS, useClaudeUsage } from './useClaudeUsage';
+vi.mock('renderer/services/poller', () => ({
+  subscribe: subscribeMock
+}));
+
+import { __resetClaudeUsagePollingForTests, CLAUDE_POLL_MS, useClaudeUsage } from './useClaudeUsage';
+
+type UsagePollSpec = { fetch: () => Promise<ClaudeUsage>; interval: (data?: ClaudeUsage) => number; key: string };
+
+const lastSubscription = () => {
+  const call = subscribeMock.mock.calls.at(-1);
+  if (!call) throw new Error('subscribe() was never called');
+  const [spec, onData] = call as [UsagePollSpec, (data: ClaudeUsage) => void];
+  return { onData, spec };
+};
 
 const accountA: ClaudeAccount = { dir: '/Users/x/.claude', label: 'claude' };
 const accountB: ClaudeAccount = { dir: '/Users/x/.claude-b', label: 'claude-b' };
@@ -78,11 +103,13 @@ const resetStore = () => {
     usage: undefined,
     usageByDir: {}
   });
+  __resetClaudeUsagePollingForTests();
 };
 
 describe('useClaudeUsage store', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    unsubscribeMocks.length = 0;
 
     // Sensible defaults so any call that isn't overridden per-test resolves cleanly.
     detectMock.mockResolvedValue({ installed: true, version: '1.0.0' });
@@ -254,5 +281,83 @@ describe('useClaudeUsage store', () => {
 
   it('polls at a fixed one-minute interval', () => {
     expect(CLAUDE_POLL_MS).toBe(60000);
+  });
+
+  describe('poller coordinator subscription', () => {
+    it('subscribes to claudeUsage:<dir> with a 60s interval when init activates an account', async () => {
+      accountsMock.mockResolvedValue([accountA]);
+      settingsGetMock.mockResolvedValue({});
+      usageMock.mockResolvedValue(makeUsage(accountA));
+
+      await useClaudeUsage.getState().init();
+
+      expect(subscribeMock).toHaveBeenCalledTimes(1);
+      const { spec } = lastSubscription();
+      expect(spec.key).toBe(`claudeUsage:${accountA.dir}`);
+      expect(spec.interval(undefined)).toBe(CLAUDE_POLL_MS);
+    });
+
+    it("subscription's fetch calls window.bridge.claude.usage with the currently active account", async () => {
+      accountsMock.mockResolvedValue([accountA]);
+      usageMock.mockResolvedValue(makeUsage(accountA));
+
+      await useClaudeUsage.getState().init();
+
+      const { spec } = lastSubscription();
+      const usage = makeUsage(accountA);
+      usageMock.mockClear();
+      usageMock.mockResolvedValue(usage);
+
+      await expect(spec.fetch()).resolves.toEqual(usage);
+      expect(usageMock).toHaveBeenCalledWith(accountA);
+    });
+
+    it('onData writes usage into usageByDir and, while the dir is still active, into usage/loading', async () => {
+      accountsMock.mockResolvedValue([accountA]);
+      usageMock.mockResolvedValue(makeUsage(accountA));
+
+      await useClaudeUsage.getState().init();
+
+      const { onData } = lastSubscription();
+      const nextUsage = makeUsage(accountA);
+      onData(nextUsage);
+
+      const state = useClaudeUsage.getState();
+      expect(state.usageByDir[accountA.dir]).toEqual(nextUsage);
+      expect(state.usage).toEqual(nextUsage);
+      expect(state.loading).toBe(false);
+    });
+
+    it('onData caches usage for its dir but ignores it as the active usage once another account is active', async () => {
+      accountsMock.mockResolvedValue([accountA, accountB]);
+      usageMock.mockImplementation((account: ClaudeAccount) => Promise.resolve(makeUsage(account)));
+
+      await useClaudeUsage.getState().init();
+      const { onData } = lastSubscription();
+
+      // The user switches away from accountA before its subscription delivers data.
+      useClaudeUsage.setState({ activeDir: accountB.dir, usage: undefined });
+      const staleUsage = makeUsage(accountA);
+      onData(staleUsage);
+
+      const state = useClaudeUsage.getState();
+      expect(state.usageByDir[accountA.dir]).toEqual(staleUsage);
+      expect(state.usage).toBeUndefined();
+    });
+
+    it('unsubscribes the old key and subscribes the new key when the active account changes', async () => {
+      accountsMock.mockResolvedValue([accountA, accountB]);
+      usageMock.mockImplementation((account: ClaudeAccount) => Promise.resolve(makeUsage(account)));
+
+      await useClaudeUsage.getState().init();
+      expect(subscribeMock).toHaveBeenCalledTimes(1);
+      const [firstUnsubscribe] = unsubscribeMocks;
+
+      useClaudeUsage.getState().setActive(accountB.dir);
+
+      expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(subscribeMock).toHaveBeenCalledTimes(2);
+      expect(lastSubscription().spec.key).toBe(`claudeUsage:${accountB.dir}`);
+    });
   });
 });

--- a/src/renderer/hooks/useClaudeUsage.ts
+++ b/src/renderer/hooks/useClaudeUsage.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { subscribe, type Unsubscribe } from 'renderer/services/poller';
 import { type ClaudeAccount, type ClaudeDetection, type ClaudeUsage } from 'types/claudeUsage';
 import { create } from 'zustand';
 
@@ -27,101 +27,113 @@ const pickActive = (accounts: ClaudeAccount[], preferred?: string) => {
   return accounts[0]?.dir;
 };
 
-export const useClaudeUsage = create<Actions & State>((set, get) => ({
-  accounts: [],
-  detection: { installed: false },
-  init: async () => {
-    const [detection, accounts, appSettings] = await Promise.all([
-      window.bridge.claude.detect(),
-      window.bridge.claude.accounts(),
-      window.bridge.settings.get('appSettings')
-    ]);
+const claudeUsageKey = (dir: string) => `claudeUsage:${dir}`;
 
-    const activeDir = pickActive(accounts, appSettings?.claudeAccountDir);
-    set({ accounts, activeDir, detection, ready: true });
+// The coordinator subscription is dynamic (keyed by whichever account is
+// currently active), so it's managed imperatively via `subscribe()` rather
+// than the React `usePoll` hook. There's at most one live subscription at a
+// time; module-scoped state is enough to track it.
+let unsubscribeActive: undefined | Unsubscribe;
+let subscribedDir: string | undefined;
 
-    if (activeDir) await get().refresh();
-  },
-  loading: false,
-  ready: false,
-  refresh: async () => {
-    const { accounts, activeDir, usageByDir } = get();
-    const account = accounts.find((a) => a.dir === activeDir);
-    if (!account) return;
+export const useClaudeUsage = create<Actions & State>((set, get) => {
+  // Keeps the active account's usage fresh on the shared poller loop, which
+  // already handles the recurring timer, pause-when-hidden/offline, and
+  // refetch-on-visible/focus/online — this just points it at the right key
+  // for whichever account is currently active.
+  const subscribeToActiveDir = (dir?: string) => {
+    if (dir === subscribedDir) return;
 
-    // Only show the spinner on a true first fetch; a switch back to an account
-    // we already have data for refreshes silently behind the cached view.
-    if (!usageByDir[account.dir]) set({ loading: true });
+    unsubscribeActive?.();
+    unsubscribeActive = undefined;
+    subscribedDir = dir;
+    if (!dir) return;
 
-    const usage = await window.bridge.claude.usage(account);
-    set((s) => ({ usageByDir: { ...s.usageByDir, [account.dir]: usage } }));
+    unsubscribeActive = subscribe<ClaudeUsage>(
+      {
+        fetch: () => {
+          const account = get().accounts.find((a) => a.dir === dir);
+          if (!account) return Promise.reject(new Error(`No Claude account for ${dir}`));
+          return window.bridge.claude.usage(account);
+        },
+        interval: () => CLAUDE_POLL_MS,
+        key: claudeUsageKey(dir)
+      },
+      (usage) => {
+        // Same write as `refresh()` below: always cache by the dir the fetch
+        // was for, but only surface it as the active usage if that dir is
+        // still active (ignores a response for a no-longer-active account).
+        set((s) => ({ usageByDir: { ...s.usageByDir, [dir]: usage } }));
+        if (get().activeDir !== dir) return;
+        set({ loading: false, usage });
+      }
+    );
+  };
 
-    // Ignore a response that arrives after the user switched accounts.
-    if (get().activeDir !== account.dir) return;
-    set({ loading: false, usage });
-  },
-  setActive: (dir) => {
-    if (dir === get().activeDir) return;
+  return {
+    accounts: [],
+    detection: { installed: false },
+    init: async () => {
+      const [detection, accounts, appSettings] = await Promise.all([
+        window.bridge.claude.detect(),
+        window.bridge.claude.accounts(),
+        window.bridge.settings.get('appSettings')
+      ]);
 
-    // Show the remembered data for this account instantly; refresh in the
-    // background so a re-click (1 → 2 → 1) never blanks or re-blocks the UI.
-    const cached = get().usageByDir[dir];
-    set({ activeDir: dir, loading: !cached, usage: cached });
-    useAppSettings.getState().set({ claudeAccountDir: dir });
-    void get().refresh();
-  },
-  usage: undefined,
-  usageByDir: {}
-}));
+      const activeDir = pickActive(accounts, appSettings?.claudeAccountDir);
+      set({ accounts, activeDir, detection, ready: true });
+
+      if (activeDir) await get().refresh();
+      subscribeToActiveDir(activeDir);
+    },
+    loading: false,
+    ready: false,
+    refresh: async () => {
+      const { accounts, activeDir, usageByDir } = get();
+      const account = accounts.find((a) => a.dir === activeDir);
+      if (!account) return;
+
+      // Only show the spinner on a true first fetch; a switch back to an account
+      // we already have data for refreshes silently behind the cached view.
+      if (!usageByDir[account.dir]) set({ loading: true });
+
+      const usage = await window.bridge.claude.usage(account);
+      set((s) => ({ usageByDir: { ...s.usageByDir, [account.dir]: usage } }));
+
+      // Ignore a response that arrives after the user switched accounts.
+      if (get().activeDir !== account.dir) return;
+      set({ loading: false, usage });
+    },
+    setActive: (dir) => {
+      if (dir === get().activeDir) return;
+
+      // Show the remembered data for this account instantly; refresh in the
+      // background so a re-click (1 → 2 → 1) never blanks or re-blocks the UI.
+      const cached = get().usageByDir[dir];
+      set({ activeDir: dir, loading: !cached, usage: cached });
+      useAppSettings.getState().set({ claudeAccountDir: dir });
+      void get().refresh();
+      subscribeToActiveDir(dir);
+    },
+    usage: undefined,
+    usageByDir: {}
+  };
+});
 
 void useClaudeUsage.getState().init();
 
 /**
- * Keeps the active account's usage fresh while the footer is mounted and the
- * window is visible. A hidden background window polling the filesystem buys
- * nothing, so the timer idles until the window is shown again.
+ * Retained for backward compatibility with existing call sites (e.g.
+ * `ClaudeFooter`). Polling is now owned by the shared poller coordinator —
+ * subscribed directly inside this store by `init`/`setActive` (see
+ * `subscribeToActiveDir` above) rather than by component mount — so this
+ * hook no longer has any work of its own to do.
  */
-export const useClaudeUsagePolling = () => {
-  const refresh = useClaudeUsage((s) => s.refresh);
-  const activeDir = useClaudeUsage((s) => s.activeDir);
+export const useClaudeUsagePolling = (): void => {};
 
-  useEffect(() => {
-    if (!activeDir) return;
-
-    let timer: null | number = null;
-
-    const tick = () => {
-      void refresh();
-    };
-
-    const start = () => {
-      if (!timer) timer = window.setInterval(tick, CLAUDE_POLL_MS);
-    };
-
-    const stop = () => {
-      if (timer) {
-        window.clearInterval(timer);
-        timer = null;
-      }
-    };
-
-    const onVisibility = () => {
-      if (document.hidden) {
-        stop();
-        return;
-      }
-
-      tick();
-      start();
-    };
-
-    tick();
-    start();
-    document.addEventListener('visibilitychange', onVisibility);
-
-    return () => {
-      stop();
-      document.removeEventListener('visibilitychange', onVisibility);
-    };
-  }, [activeDir, refresh]);
+/** Test-only: clears the module-scoped subscription tracking between tests. */
+export const __resetClaudeUsagePollingForTests = (): void => {
+  unsubscribeActive?.();
+  unsubscribeActive = undefined;
+  subscribedDir = undefined;
 };

--- a/src/renderer/hooks/useGit.test.ts
+++ b/src/renderer/hooks/useGit.test.ts
@@ -1,16 +1,44 @@
 // @vitest-environment jsdom
 import { act, renderHook } from '@testing-library/react';
+import { type GitStatus } from 'types/project';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAppSettings } from './useAppSettings';
 import { useGit } from './useGit';
 import { useProjects } from './useProjects';
 
-const { showToast } = vi.hoisted(() => ({ showToast: vi.fn() }));
+const { showToast, subscribeMock, unsubscribeMocks } = vi.hoisted(() => {
+  const unsubscribeMocks: ReturnType<typeof vi.fn>[] = [];
+  const subscribeMock = vi.fn(() => {
+    const unsub = vi.fn();
+    unsubscribeMocks.push(unsub);
+    return unsub;
+  });
+
+  return { showToast: vi.fn(), subscribeMock, unsubscribeMocks };
+});
 
 vi.mock('renderer/utils/appToaster', () => ({
   appToaster: Promise.resolve({ show: showToast })
 }));
+
+// `useGit` hands the recurring background poll to the shared poller
+// coordinator (`renderer/services/poller`). Mocking `subscribe` lets these
+// tests assert *how* the hook drives the coordinator (key, fetch, interval)
+// and drive its `onData` callback directly, without running the
+// coordinator's real timer/visibility machinery.
+vi.mock('renderer/services/poller', () => ({
+  subscribe: subscribeMock
+}));
+
+type GitStatusPollSpec = { fetch: () => Promise<GitStatus>; interval: (data?: GitStatus) => number; key: string };
+
+const lastSubscription = () => {
+  const call = subscribeMock.mock.calls.at(-1);
+  if (!call) throw new Error('subscribe() was never called');
+  const [spec, onData] = call as [GitStatusPollSpec, (data: GitStatus) => void];
+  return { onData, spec };
+};
 
 // Waits for one microtask tick so pending promise callbacks (e.g. from
 // `await window.bridge.git.getStatus(...)`) have a chance to run inside `act`.
@@ -22,6 +50,7 @@ const flush = () => act(async () => {
 describe('useGit', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    unsubscribeMocks.length = 0;
 
     useAppSettings.setState({ fetchInterval: 10000 });
     useProjects.setState({ projects: [] });
@@ -67,12 +96,16 @@ describe('useGit', () => {
       expect(result.current.gitStatus).toEqual({ success: true });
     });
 
-    it('short-circuits a concurrent call while one is already in flight', async () => {
+    // The coordinator (mocked out here) owns fetch-dedupe for its own ticks;
+    // a manual `getStatus` call is a direct, ungated bridge call now that the
+    // old `inFlight` ref is gone, so two concurrent manual calls do fetch
+    // twice — a deliberate behavior change from the pre-migration hook.
+    it('performs a separate fetch for each concurrent manual call', async () => {
       let resolveFirst: (value: { success: boolean }) => void;
       const firstRead = new Promise<{ success: boolean }>((resolve) => {
         resolveFirst = resolve;
       });
-      vi.mocked(window.bridge.git.getStatus).mockReturnValueOnce(firstRead);
+      vi.mocked(window.bridge.git.getStatus).mockReturnValueOnce(firstRead).mockResolvedValueOnce({ success: true });
 
       const { result } = renderHook(() => useGit());
 
@@ -83,7 +116,7 @@ describe('useGit', () => {
         secondCall = result.current.getStatus('project-1', false);
       });
 
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(1);
+      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(2);
 
       await act(async () => {
         resolveFirst({ success: true });
@@ -91,7 +124,7 @@ describe('useGit', () => {
         await secondCall;
       });
 
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(1);
+      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(2);
     });
 
     it('ignores a resolved read after the component has unmounted', async () => {
@@ -121,9 +154,8 @@ describe('useGit', () => {
     });
   });
 
-  describe('polling', () => {
-    it('starts a timer that re-fetches the status silently on every tick', async () => {
-      vi.useFakeTimers();
+  describe('polling coordinator subscription', () => {
+    it('subscribes to gitStatus:<id> when getStatus is called with polling=true', async () => {
       vi.mocked(window.bridge.git.getStatus).mockResolvedValue({ success: true });
 
       const { result } = renderHook(() => useGit());
@@ -133,26 +165,69 @@ describe('useGit', () => {
       });
       await flush();
 
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(1);
+      expect(subscribeMock).toHaveBeenCalledTimes(1);
+      expect(lastSubscription().spec.key).toBe('gitStatus:project-1');
+    });
 
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(10000);
+    it("the subscription's fetch calls window.bridge.git.getStatus with the polled id", async () => {
+      vi.mocked(window.bridge.git.getStatus).mockResolvedValue({ success: true });
+
+      const { result } = renderHook(() => useGit());
+
+      act(() => {
+        result.current.getStatus('project-1');
+      });
+      await flush();
+
+      const { spec } = lastSubscription();
+      vi.mocked(window.bridge.git.getStatus).mockClear();
+      await spec.fetch();
+
+      expect(window.bridge.git.getStatus).toHaveBeenCalledWith('project-1');
+    });
+
+    it('the subscription interval is the configured fetchInterval, or Infinity at/below 2 seconds', async () => {
+      vi.mocked(window.bridge.git.getStatus).mockResolvedValue({ success: true });
+
+      const { rerender, result } = renderHook(() => useGit());
+
+      act(() => {
+        result.current.getStatus('project-1');
+      });
+      await flush();
+
+      expect(lastSubscription().spec.interval(undefined)).toBe(10000);
+
+      useAppSettings.setState({ fetchInterval: 2000 });
+      rerender();
+      await flush();
+
+      expect(lastSubscription().spec.interval(undefined)).toBe(Infinity);
+    });
+
+    it("onData from the subscription updates gitStatus silently, never touching loading", async () => {
+      vi.mocked(window.bridge.git.getStatus).mockResolvedValue({ success: true });
+
+      const { result } = renderHook(() => useGit());
+
+      act(() => {
+        result.current.getStatus('project-1');
+      });
+      await flush();
+
+      const { onData } = lastSubscription();
+      const tickStatus = { branchSummary: { current: 'main' }, success: true } as const;
+
+      act(() => {
+        onData(tickStatus as unknown as GitStatus);
       });
 
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(2);
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(10000);
-      });
-
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(3);
-      // Ticks are silent: loading never flips true for them.
+      expect(result.current.gitStatus).toEqual(tickStatus);
+      // A tick is a background refresh: it must never flip `loading` true.
       expect(result.current.loading).toBe(false);
     });
 
-    it('does not start a timer when the fetch interval is at or below 2 seconds', async () => {
-      vi.useFakeTimers();
-      useAppSettings.setState({ fetchInterval: 2000 });
+    it('unsubscribes the old key and subscribes the new key when the polled project id changes', async () => {
       vi.mocked(window.bridge.git.getStatus).mockResolvedValue({ success: true });
 
       const { result } = renderHook(() => useGit());
@@ -161,84 +236,21 @@ describe('useGit', () => {
         result.current.getStatus('project-1');
       });
       await flush();
-
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(1);
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(60000);
-      });
-
-      // Still just the one manual call — no interval was ever created.
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(1);
-    });
-
-    it('rebuilds the timer when the polled project id changes', async () => {
-      vi.useFakeTimers();
-      vi.mocked(window.bridge.git.getStatus).mockResolvedValue({ success: true });
-
-      const { result } = renderHook(() => useGit());
-
-      act(() => {
-        result.current.getStatus('project-1');
-      });
-      await flush();
-      expect(window.bridge.git.getStatus).toHaveBeenCalledWith('project-1');
+      expect(subscribeMock).toHaveBeenCalledTimes(1);
+      const [firstUnsubscribe] = unsubscribeMocks;
 
       act(() => {
         result.current.getStatus('project-2');
       });
       await flush();
-      expect(window.bridge.git.getStatus).toHaveBeenLastCalledWith('project-2');
 
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(10000);
-      });
-
-      expect(window.bridge.git.getStatus).toHaveBeenLastCalledWith('project-2');
+      expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(subscribeMock).toHaveBeenCalledTimes(2);
+      expect(lastSubscription().spec.key).toBe('gitStatus:project-2');
     });
 
-    it('stops polling while the window is hidden and resumes with an immediate refresh once visible again', async () => {
-      vi.useFakeTimers();
+    it('unsubscribes on unmount', async () => {
       vi.mocked(window.bridge.git.getStatus).mockResolvedValue({ success: true });
-
-      const { result } = renderHook(() => useGit());
-
-      act(() => {
-        result.current.getStatus('project-1');
-      });
-      await flush();
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(1);
-
-      Object.defineProperty(document, 'hidden', { configurable: true, value: true });
-      await act(async () => {
-        document.dispatchEvent(new Event('visibilitychange'));
-      });
-
-      // Hidden: the interval is cleared, so time passing fetches nothing more.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(30000);
-      });
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(1);
-
-      Object.defineProperty(document, 'hidden', { configurable: true, value: false });
-      await act(async () => {
-        document.dispatchEvent(new Event('visibilitychange'));
-      });
-
-      // Becoming visible triggers an immediate silent refresh and restarts the timer.
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(2);
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(10000);
-      });
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(3);
-    });
-
-    it('clears the timer and removes the visibility listener on unmount', async () => {
-      vi.useFakeTimers();
-      vi.mocked(window.bridge.git.getStatus).mockResolvedValue({ success: true });
-
-      const removeSpy = vi.spyOn(document, 'removeEventListener');
 
       const { result, unmount } = renderHook(() => useGit());
 
@@ -246,18 +258,11 @@ describe('useGit', () => {
         result.current.getStatus('project-1');
       });
       await flush();
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(1);
+      const [unsub] = unsubscribeMocks;
 
       unmount();
 
-      expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(60000);
-      });
-
-      // No further ticks after unmount — the interval was cleared.
-      expect(window.bridge.git.getStatus).toHaveBeenCalledTimes(1);
+      expect(unsub).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/renderer/hooks/useGit.ts
+++ b/src/renderer/hooks/useGit.ts
@@ -1,9 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { subscribe } from 'renderer/services/poller';
 import { appToaster } from 'renderer/utils/appToaster';
 import { type GitStatus } from 'types/project';
 
 import { useAppSettings } from './useAppSettings';
 import { useProjects } from './useProjects';
+
+const gitStatusKey = (id: string) => `gitStatus:${id}`;
 
 export const useGit = () => {
   const { fetchInterval } = useAppSettings();
@@ -11,11 +14,8 @@ export const useGit = () => {
   const [gitStatus, setGitStatus] = useState<GitStatus>();
   const [loading, setLoading] = useState(false);
   // Which project this hook keeps polling. State, not a ref, so changing the
-  // interval or hiding the window can rebuild the timer.
+  // project rebuilds the coordinator subscription below.
   const [polledId, setPolledId] = useState<string>();
-
-  const inFlight = useRef(false);
-  const unmounted = useRef(false);
 
   /**
    * `polling` asks the hook to keep this project's status fresh from now on.
@@ -24,59 +24,32 @@ export const useGit = () => {
    */
   const getStatus = async (id: string, polling = true, silent = false) => {
     if (polling) setPolledId(id);
-    if (inFlight.current) return;
 
-    inFlight.current = true;
     if (!silent) setLoading(true);
 
     const res = await window.bridge.git.getStatus(id);
-    inFlight.current = false;
-
-    if (unmounted.current) return;
 
     setGitStatus(res);
     if (!silent) setLoading(false);
   };
 
-  // One timer, rebuilt whenever the project or the interval changes, and idle
-  // while the window is hidden — a background window polling git and fetching
-  // from every remote every few seconds buys nothing.
+  // The shared poller coordinator owns the recurring timer, pausing while the
+  // window is hidden/offline and catching up on visible/focus/online — no
+  // more per-hook `setInterval` or `visibilitychange` listener. Ticks are
+  // always silent: they only refresh `gitStatus` in place, never `loading`.
   useEffect(() => {
-    if (!polledId || fetchInterval <= 2000) return;
+    if (!polledId) return;
 
-    let timer: null | number = null;
+    const unsubscribe = subscribe<GitStatus>(
+      {
+        fetch: () => window.bridge.git.getStatus(polledId),
+        interval: () => (fetchInterval <= 2000 ? Infinity : fetchInterval),
+        key: gitStatusKey(polledId)
+      },
+      (data) => setGitStatus(data)
+    );
 
-    const tick = () => getStatus(polledId, false, true);
-
-    const start = () => {
-      if (!timer) timer = window.setInterval(tick, fetchInterval);
-    };
-
-    const stop = () => {
-      if (timer) {
-        window.clearInterval(timer);
-        timer = null;
-      }
-    };
-
-    const onVisibility = () => {
-      if (document.hidden) {
-        stop();
-        return;
-      }
-
-      tick();
-      start();
-    };
-
-    start();
-    document.addEventListener('visibilitychange', onVisibility);
-
-    return () => {
-      stop();
-      document.removeEventListener('visibilitychange', onVisibility);
-    };
-     
+    return unsubscribe;
   }, [fetchInterval, polledId]);
 
   const checkout = async (id: string, branch: string) => {
@@ -139,10 +112,6 @@ export const useGit = () => {
       console.log(e, e.git, 'git');
     }
   };
-
-  useEffect(() => () => {
-      unmounted.current = true;
-    }, []);
 
   const addWorktree = async (id: string, repoName: string, branch: string, newBranch?: string) => {
     const res = await window.bridge.worktree.add(id, repoName, branch, newBranch);

--- a/src/renderer/services/poller/README.md
+++ b/src/renderer/services/poller/README.md
@@ -1,0 +1,81 @@
+# Poller
+
+A shared polling coordinator: one scheduler for the whole renderer instead of
+every component/hook running its own `setInterval`. It dedupes concurrent
+fetches, staggers refetches so they don't all fire at once, backs off on
+errors, and pauses while the window is hidden or offline.
+
+`coordinator.ts` is plain TypeScript (no React, safe to unit test in Node).
+`usePoll.ts` is a thin React hook wrapper over it. Import from `index.ts`.
+
+## API
+
+```ts
+type Priority = 'active' | 'background';
+
+type PollSpec<T> = {
+  key: string; // stable identity, e.g. `prChecks:${projectId}:${prNumber}`
+  fetch: () => Promise<T>;
+  interval: (data: T | undefined) => number; // ms until next poll; Infinity = stop auto-polling
+  priority?: Priority; // default 'active', reserved for future budget tiers
+};
+
+type Unsubscribe = () => void;
+
+function subscribe<T>(spec: PollSpec<T>, onData: (data: T) => void, onError?: (e: unknown) => void): Unsubscribe;
+function refresh(prefix?: string): void; // re-poll subscribed keys now (undefined/'' = all)
+function mutate<T>(key: string, action: () => Promise<T>): Promise<T>; // run action, then hot re-poll the key
+function getSnapshot<T>(key: string): T | undefined; // last cached data for a key, no side effects
+
+function usePoll<T>(spec: PollSpec<T>): { data: T | undefined; error: unknown; loading: boolean };
+```
+
+## Usage example
+
+```tsx
+const { data, error, loading } = usePoll({
+  key: `prChecks:${projectId}:${prNumber}`,
+  fetch: () => window.bridge.gitAPI.getPRChecks({ projectId, prNumber }),
+  interval: (data) => (data?.mergeableState === 'unknown' ? 4_000 : 60_000)
+});
+```
+
+`usePoll` subscribes once per `key`. Passing new `fetch`/`interval` closures
+on a re-render does **not** resubscribe — only a changed `key` does. That
+means it's safe to define `fetch`/`interval` inline on every render.
+
+## Key naming convention
+
+`<kind>:<projectId>[:<id>]`, e.g. `prChecks:42:1337`, `runs:42`,
+`branchStatus:42:main`. Use the same key across every subscriber of the same
+underlying data so they share one cache entry and one fetch — and so
+`refresh('prChecks:')` / `mutate('prChecks:42:1337', ...)` target exactly the
+keys you mean.
+
+## The adaptive interval idea
+
+`interval(data)` is called with the *last* fetched value (or `undefined`
+before the first fetch) and returns how long to wait before polling again.
+Return a small number while something is in flux and a large one once it has
+settled — e.g. a PR whose checks are still running polls every few seconds,
+but once every check is green (or the PR is merged) it can poll once a
+minute, or return `Infinity` to stop polling entirely until something calls
+`refresh()` or `mutate()` on that key again. This "heat" pattern is what
+keeps the app responsive without hammering the GitHub API.
+
+## Other behaviors worth knowing before migrating a component
+
+- Multiple subscribers on the same `key` share one entry: a second subscriber
+  gets the cached value instantly, and never causes a duplicate fetch.
+- Fetches for the same key are deduped — a `subscribe`/`refresh` while a
+  fetch is already in flight just waits for it, it never starts a second one.
+- Unsubscribing (e.g. on unmount) stops polling that key but keeps the last
+  cached value around for the next subscriber.
+- Polling pauses automatically while the tab is hidden or the browser is
+  offline, and catches up (re-polls anything stale) when it becomes visible,
+  regains focus, or comes back online.
+- `mutate(key, action)` is for user-initiated writes (merge a PR, rerun a
+  job, ...): it runs `action()`, then does a short burst of extra polls (now,
+  +800ms, +1500ms) so the UI catches up to the effect of the mutation quickly.
+- `__reset()` (exported from `coordinator.ts`, not `index.ts`) clears
+  everything and stops the loop — for test isolation only.

--- a/src/renderer/services/poller/coordinator.test.ts
+++ b/src/renderer/services/poller/coordinator.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { __reset, getSnapshot, mutate, refresh, subscribe } from './coordinator';
+
+type FakeTarget = {
+  addEventListener: (type: string, cb: () => void) => void;
+  dispatchEvent: (type: string) => void;
+  removeEventListener: (type: string, cb: () => void) => void;
+};
+
+function createFakeTarget(): FakeTarget {
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    addEventListener(type, cb) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)?.add(cb);
+    },
+    dispatchEvent(type) {
+      for (const cb of listeners.get(type) ?? []) cb();
+    },
+    removeEventListener(type, cb) {
+      listeners.get(type)?.delete(cb);
+    }
+  };
+}
+
+let win: FakeTarget;
+let doc: FakeTarget & { hidden: boolean };
+let nav: { onLine: boolean };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  win = createFakeTarget();
+  doc = Object.assign(createFakeTarget(), { hidden: false });
+  nav = { onLine: true };
+  vi.stubGlobal('window', win);
+  vi.stubGlobal('document', doc);
+  vi.stubGlobal('navigator', nav);
+  __reset();
+});
+
+afterEach(() => {
+  __reset();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('subscribe', () => {
+  it('performs an initial fetch, delivers data via onData, and schedules the next poll', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ n: 1 });
+    const intervalFn = vi.fn().mockReturnValue(2000);
+    const onData = vi.fn();
+
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k1' }, onData);
+
+    expect(fetchFn).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalledWith({ n: 1 });
+
+    // Not due again until ~2000ms after the fetch resolved (t=500 -> t=2500).
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('delivers cached data to a second subscriber instantly, without an extra fetch', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ n: 1 });
+    const intervalFn = vi.fn().mockReturnValue(60_000);
+    const onData1 = vi.fn();
+    const onData2 = vi.fn();
+
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k2' }, onData1);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k2' }, onData2);
+    expect(onData2).toHaveBeenCalledWith({ n: 1 });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent subscribers so only one fetch is in-flight for a key', async () => {
+    let resolveFetch: (v: { n: number }) => void = () => {};
+    const fetchFn = vi.fn(
+      () =>
+        new Promise<{ n: number }>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+    const intervalFn = vi.fn().mockReturnValue(5000);
+    const onData1 = vi.fn();
+    const onData2 = vi.fn();
+
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k3' }, onData1);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // A second subscriber arrives while the first fetch is still pending.
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k3' }, onData2);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    resolveFetch({ n: 42 });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(onData1).toHaveBeenCalledWith({ n: 42 });
+    expect(onData2).toHaveBeenCalledWith({ n: 42 });
+  });
+
+  it('drives refetch timing off the adaptive interval returned by spec.interval', async () => {
+    type Data = { state: 'done' | 'pending' };
+    const sequence: Data[] = [{ state: 'pending' }, { state: 'done' }];
+    let call = 0;
+    const fetchFn = vi.fn(() => Promise.resolve(sequence[Math.min(call++, sequence.length - 1)]));
+    const intervalFn = vi.fn((d?: Data) => (d?.state === 'pending' ? 1000 : 60_000));
+    const onData = vi.fn();
+
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k4' }, onData);
+
+    await vi.advanceTimersByTimeAsync(500); // fetch #1 -> pending, next due at t=1500
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000); // t=1500 -> fetch #2 -> done, next due far away
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('grows the retry backoff on repeated fetch failures', async () => {
+    const err = new Error('boom');
+    const fetchFn = vi.fn().mockRejectedValue(err);
+    const intervalFn = vi.fn().mockReturnValue(10_000);
+    const onData = vi.fn();
+    const onError = vi.fn();
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5); // neutralizes +/-20% jitter
+
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k5' }, onData, onError);
+
+    await vi.advanceTimersByTimeAsync(500); // failure #1 at t=500
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(err);
+
+    // base = DEFAULT_BACKOFF_BASE_MS (5000, no successful interval yet), failures=1 -> 10000ms
+    await vi.advanceTimersByTimeAsync(9999);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2); // failure #2 at t=10500
+
+    // failures=2 -> min(5000*4, 300000) = 20000ms
+    await vi.advanceTimersByTimeAsync(19_999);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+
+    randomSpy.mockRestore();
+  });
+
+  it('keeps the cache but stops polling after the last subscriber unsubscribes', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ n: 7 });
+    const intervalFn = vi.fn().mockReturnValue(1000);
+    const onData = vi.fn();
+
+    const unsubscribe = subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k9' }, onData);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(getSnapshot('k9')).toEqual({ n: 7 });
+
+    unsubscribe();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(getSnapshot('k9')).toEqual({ n: 7 });
+  });
+});
+
+describe('refresh', () => {
+  it('re-polls only subscribed keys matching the given prefix', async () => {
+    const fetchA = vi.fn().mockResolvedValue({ v: 'a' });
+    const fetchB = vi.fn().mockResolvedValue({ v: 'b' });
+    const bigInterval = vi.fn().mockReturnValue(60_000);
+
+    subscribe({ fetch: fetchA, interval: bigInterval, key: 'prChecks:1' }, vi.fn());
+    subscribe({ fetch: fetchB, interval: bigInterval, key: 'other:1' }, vi.fn());
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchA).toHaveBeenCalledTimes(1);
+    expect(fetchB).toHaveBeenCalledTimes(1);
+
+    refresh('prChecks:');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(fetchA).toHaveBeenCalledTimes(2);
+    expect(fetchB).toHaveBeenCalledTimes(1);
+  });
+
+  it('with no prefix re-polls every subscribed key', async () => {
+    const fetchA = vi.fn().mockResolvedValue({ v: 'a' });
+    const fetchB = vi.fn().mockResolvedValue({ v: 'b' });
+    const bigInterval = vi.fn().mockReturnValue(60_000);
+
+    subscribe({ fetch: fetchA, interval: bigInterval, key: 'x:1' }, vi.fn());
+    subscribe({ fetch: fetchB, interval: bigInterval, key: 'y:1' }, vi.fn());
+    await vi.advanceTimersByTimeAsync(500);
+
+    refresh();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(fetchA).toHaveBeenCalledTimes(2);
+    expect(fetchB).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('hidden/offline gating', () => {
+  it('skips starting new fetches while the document is hidden, then re-polls stale data once visible', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ n: 1 });
+    const intervalFn = vi.fn().mockReturnValue(1000);
+
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k7' }, vi.fn());
+    await vi.advanceTimersByTimeAsync(500); // fetch #1 at t=500, next due ~t=1500
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    doc.hidden = true;
+    await vi.advanceTimersByTimeAsync(3000); // would have been due, but tick skips while hidden
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    doc.hidden = false;
+    doc.dispatchEvent('visibilitychange'); // marks stale subscribed entries due
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips starting new fetches while offline, then re-polls stale data once back online', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ n: 1 });
+    const intervalFn = vi.fn().mockReturnValue(1000);
+
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k7b' }, vi.fn());
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    nav.onLine = false;
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    nav.onLine = true;
+    win.dispatchEvent('online');
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('mutate', () => {
+  it('runs the action, then hot re-polls the key at 0ms, 800ms and 1500ms', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ n: 1 });
+    const intervalFn = vi.fn().mockReturnValue(60_000);
+    const action = vi.fn().mockResolvedValue('done');
+
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k8' }, vi.fn());
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    const result = await mutate('k8', action);
+
+    expect(result).toBe('done');
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2); // immediate hot re-poll
+
+    await vi.advanceTimersByTimeAsync(800);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(700); // total 1500ms since mutate resolved
+    expect(fetchFn).toHaveBeenCalledTimes(4);
+  });
+
+  it('returns the action result without touching the poller when the key has no entry', async () => {
+    const action = vi.fn().mockResolvedValue('ok');
+
+    const result = await mutate('unregistered-key', action);
+
+    expect(result).toBe('ok');
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getSnapshot', () => {
+  it('returns undefined until the first fetch resolves', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ n: 3 });
+    const intervalFn = vi.fn().mockReturnValue(5000);
+
+    expect(getSnapshot('k11')).toBeUndefined();
+    subscribe({ fetch: fetchFn, interval: intervalFn, key: 'k11' }, vi.fn());
+    expect(getSnapshot('k11')).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(getSnapshot('k11')).toEqual({ n: 3 });
+  });
+});
+
+describe('__reset', () => {
+  it('clears the registry so a subsequent subscribe starts with a clean cache', async () => {
+    const fetchFn1 = vi.fn().mockResolvedValue({ n: 1 });
+    const intervalFn = vi.fn().mockReturnValue(1000);
+
+    subscribe({ fetch: fetchFn1, interval: intervalFn, key: 'k10' }, vi.fn());
+    await vi.advanceTimersByTimeAsync(500);
+    expect(getSnapshot('k10')).toEqual({ n: 1 });
+
+    __reset();
+    expect(getSnapshot('k10')).toBeUndefined();
+
+    const fetchFn2 = vi.fn().mockResolvedValue({ n: 2 });
+    subscribe({ fetch: fetchFn2, interval: intervalFn, key: 'k10' }, vi.fn());
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(fetchFn2).toHaveBeenCalledTimes(1);
+    expect(getSnapshot('k10')).toEqual({ n: 2 });
+  });
+});

--- a/src/renderer/services/poller/coordinator.ts
+++ b/src/renderer/services/poller/coordinator.ts
@@ -1,0 +1,310 @@
+/**
+ * Shared polling coordinator.
+ *
+ * A single self-scheduling loop that owns every "poll this on an interval"
+ * subscription in the renderer, instead of each component/hook running its
+ * own `setInterval`. See ./README.md for the intended usage and migration
+ * notes.
+ *
+ * This file is intentionally framework-agnostic (no React). The React
+ * wrapper lives in ./usePoll.ts.
+ */
+
+export type PollSpec<T> = {
+  /** Performs one fetch. Should wrap `window.bridge.*` (or similar) in real usage. */
+  fetch: () => Promise<T>;
+  /**
+   * Given the latest known data (or `undefined` before the first fetch),
+   * returns the number of ms to wait before the next poll. Return
+   * `Infinity` to stop auto-polling until something else re-heats the key
+   * (see `refresh` / `mutate`).
+   */
+  interval: (data: T | undefined) => number;
+  /** Stable identity for the poll, e.g. `prChecks:${projectId}:${prNumber}`. */
+  key: string;
+  /** Reserved for future budget tiers. Defaults to `'active'`. */
+  priority?: Priority;
+};
+
+export type Priority = 'active' | 'background';
+
+export type Unsubscribe = () => void;
+
+type Entry = {
+  failures: number;
+  inFlight?: Promise<unknown>;
+  lastData?: unknown;
+  lastFetched: number;
+  /** Last finite (clamped) interval this key resolved to; used as the backoff base. */
+  lastFiniteInterval?: number;
+  nextDue: number;
+  spec: PollSpec<unknown>;
+  subscribers: Set<Subscriber<unknown>>;
+};
+
+type Subscriber<T> = {
+  onData: (data: T) => void;
+  onError?: (e: unknown) => void;
+};
+
+const TICK_MS = 500;
+const MAX_CONCURRENCY = 4;
+const MIN_INTERVAL_MS = 1000;
+const MAX_BACKOFF_MS = 300_000;
+const DEFAULT_BACKOFF_BASE_MS = 5_000;
+const HOT_REPOLL_DELAYS_MS = [800, 1500];
+
+const registry = new Map<string, Entry>();
+
+let timer: ReturnType<typeof setInterval> | undefined;
+let gatesInstalled = false;
+let gateHandlers:
+  | undefined
+  | {
+      onFocus: () => void;
+      onOnline: () => void;
+      onVisibilityChange: () => void;
+    };
+
+/** Test-only: clears the registry and stops the loop so tests are isolated. */
+export function __reset(): void {
+  registry.clear();
+  stopLoop();
+  removeGatesIfInstalled();
+}
+
+export function getSnapshot<T>(key: string): T | undefined {
+  return registry.get(key)?.lastData as T | undefined;
+}
+
+export async function mutate<T>(key: string, action: () => Promise<T>): Promise<T> {
+  const result = await action();
+
+  const entry = registry.get(key);
+  if (entry) {
+    entry.nextDue = now();
+    scheduleHotRepoll(key);
+  }
+
+  return result;
+}
+
+export function refresh(prefix?: string): void {
+  const p = prefix ?? '';
+  const t = now();
+  for (const entry of registry.values()) {
+    if (entry.subscribers.size === 0) continue;
+    if (p === '' || entry.spec.key.startsWith(p)) {
+      entry.nextDue = t;
+    }
+  }
+}
+
+export function subscribe<T>(
+  spec: PollSpec<T>,
+  onData: (data: T) => void,
+  onError?: (e: unknown) => void
+): Unsubscribe {
+  ensureLoop();
+
+  const entry = getOrCreateEntry(spec);
+  const subscriber = { onData, onError } as unknown as Subscriber<unknown>;
+  entry.subscribers.add(subscriber);
+
+  if (entry.lastData !== undefined) {
+    // Cache hit: deliver instantly, no extra fetch.
+    onData(entry.lastData as T);
+  } else if (!entry.inFlight) {
+    entry.nextDue = now();
+  }
+
+  return () => {
+    entry.subscribers.delete(subscriber);
+    if (entry.subscribers.size === 0) {
+      // Keep the cache, stop polling until someone subscribes/refreshes again.
+      entry.nextDue = Infinity;
+    }
+  };
+}
+
+/** Floors at 1000ms; non-finite (including `Infinity`) means "never". */
+function clampInterval(ms: number): number {
+  if (!Number.isFinite(ms)) return Infinity;
+  return Math.max(MIN_INTERVAL_MS, ms);
+}
+
+function ensureLoop(): void {
+  if (timer !== undefined) return;
+  timer = setInterval(tick, TICK_MS);
+  installGatesOnce();
+}
+
+function getOrCreateEntry<T>(spec: PollSpec<T>): Entry {
+  const existing = registry.get(spec.key);
+  if (existing) {
+    // Always keep the latest spec (fresh closures) for this key.
+    existing.spec = spec as unknown as PollSpec<unknown>;
+    return existing;
+  }
+
+  const entry: Entry = {
+    failures: 0,
+    lastFetched: 0,
+    nextDue: Infinity,
+    spec: spec as unknown as PollSpec<unknown>,
+    subscribers: new Set()
+  };
+  registry.set(spec.key, entry);
+  return entry;
+}
+
+function hasDocument(): boolean {
+  return typeof document !== 'undefined';
+}
+
+function hasWindow(): boolean {
+  return typeof window !== 'undefined';
+}
+
+function installGatesOnce(): void {
+  if (gatesInstalled) return;
+  if (!hasWindow()) return;
+
+  const onVisibilityChange = (): void => {
+    if (!hasDocument() || !document.hidden) {
+      markStaleSubscribedEntriesDue();
+    }
+  };
+  const onOnline = (): void => markStaleSubscribedEntriesDue();
+  const onFocus = (): void => markStaleSubscribedEntriesDue();
+
+  gateHandlers = { onFocus, onOnline, onVisibilityChange };
+
+  if (hasDocument() && typeof document.addEventListener === 'function') {
+    document.addEventListener('visibilitychange', onVisibilityChange);
+  }
+  if (typeof window.addEventListener === 'function') {
+    window.addEventListener('online', onOnline);
+    window.addEventListener('focus', onFocus);
+  }
+
+  gatesInstalled = true;
+}
+
+function isHiddenOrOffline(): boolean {
+  const hidden = hasDocument() && Boolean(document.hidden);
+  const offline = typeof navigator !== 'undefined' && navigator.onLine === false;
+  return hidden || offline;
+}
+
+function markStaleSubscribedEntriesDue(): void {
+  const t = now();
+  for (const entry of registry.values()) {
+    if (entry.subscribers.size === 0) continue;
+
+    const interval = clampInterval(entry.spec.interval(entry.lastData));
+    if (interval === Infinity) continue;
+
+    const stale = t - entry.lastFetched >= interval;
+    if (stale) {
+      entry.nextDue = t;
+    }
+  }
+}
+
+function now(): number {
+  return Date.now();
+}
+
+function removeGatesIfInstalled(): void {
+  if (!gatesInstalled || !gateHandlers) {
+    gatesInstalled = false;
+    gateHandlers = undefined;
+    return;
+  }
+
+  if (hasDocument() && typeof document.removeEventListener === 'function') {
+    document.removeEventListener('visibilitychange', gateHandlers.onVisibilityChange);
+  }
+  if (hasWindow() && typeof window.removeEventListener === 'function') {
+    window.removeEventListener('online', gateHandlers.onOnline);
+    window.removeEventListener('focus', gateHandlers.onFocus);
+  }
+
+  gateHandlers = undefined;
+  gatesInstalled = false;
+}
+
+async function runFetch(key: string, entry: Entry): Promise<void> {
+  const promise = entry.spec.fetch();
+  entry.inFlight = promise;
+  try {
+    const data = await promise;
+    entry.lastData = data;
+    entry.lastFetched = now();
+    entry.failures = 0;
+
+    for (const sub of entry.subscribers) {
+      sub.onData(data);
+    }
+
+    const clamped = clampInterval(entry.spec.interval(data));
+    if (Number.isFinite(clamped)) {
+      entry.lastFiniteInterval = clamped;
+    }
+    entry.nextDue = clamped === Infinity ? Infinity : now() + clamped;
+  } catch (e) {
+    entry.failures += 1;
+
+    for (const sub of entry.subscribers) {
+      sub.onError?.(e);
+    }
+
+    const base = entry.lastFiniteInterval ?? DEFAULT_BACKOFF_BASE_MS;
+    const backoffBase = Math.min(base * 2 ** entry.failures, MAX_BACKOFF_MS);
+    const jitter = backoffBase * (Math.random() * 0.4 - 0.2); // +/- 20%
+    entry.nextDue = now() + backoffBase + jitter;
+  } finally {
+    entry.inFlight = undefined;
+  }
+}
+
+function scheduleHotRepoll(key: string): void {
+  const attempt = (): void => {
+    const entry = registry.get(key);
+    if (entry && !entry.inFlight) {
+      void runFetch(key, entry);
+    }
+  };
+
+  attempt();
+  for (const delayMs of HOT_REPOLL_DELAYS_MS) {
+    setTimeout(attempt, delayMs);
+  }
+}
+
+function stopLoop(): void {
+  if (timer !== undefined) {
+    clearInterval(timer);
+    timer = undefined;
+  }
+}
+
+function tick(): void {
+  if (isHiddenOrOffline()) return;
+
+  const t = now();
+  const due: [string, Entry][] = [];
+  for (const [key, entry] of registry) {
+    if (entry.subscribers.size > 0 && !entry.inFlight && entry.nextDue <= t) {
+      due.push([key, entry]);
+    }
+  }
+
+  // Anti-thundering-herd stagger: only start up to MAX_CONCURRENCY fetches
+  // per tick; the rest wait for the next tick.
+  const slice = due.slice(0, MAX_CONCURRENCY);
+  for (const [key, entry] of slice) {
+    void runFetch(key, entry);
+  }
+}

--- a/src/renderer/services/poller/index.ts
+++ b/src/renderer/services/poller/index.ts
@@ -1,0 +1,4 @@
+export { getSnapshot, mutate, refresh, subscribe } from './coordinator';
+export type { PollSpec, Priority, Unsubscribe } from './coordinator';
+export { usePoll } from './usePoll';
+export type { UsePollResult } from './usePoll';

--- a/src/renderer/services/poller/usePoll.test.tsx
+++ b/src/renderer/services/poller/usePoll.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { subscribeMock } = vi.hoisted(() => ({ subscribeMock: vi.fn() }));
+
+vi.mock('./coordinator', () => ({
+  subscribe: (...args: unknown[]) => subscribeMock(...args)
+}));
+
+import { usePoll } from './usePoll';
+
+type Spec = { fetch: () => Promise<unknown>; interval: (d?: unknown) => number; key: string };
+
+afterEach(() => {
+  subscribeMock.mockReset();
+});
+
+describe('usePoll', () => {
+  it('starts in a loading state and transitions to data once the coordinator delivers onData', () => {
+    let capturedOnData: ((d: unknown) => void) | undefined;
+    subscribeMock.mockImplementation((_spec: Spec, onData: (d: unknown) => void) => {
+      capturedOnData = onData;
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => usePoll({ fetch: vi.fn(), interval: vi.fn(), key: 'k1' }));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+
+    act(() => {
+      capturedOnData?.({ n: 1 });
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toEqual({ n: 1 });
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('transitions loading to false and sets error when the coordinator delivers onError', () => {
+    let capturedOnError: ((e: unknown) => void) | undefined;
+    subscribeMock.mockImplementation((_spec: Spec, _onData: unknown, onError: (e: unknown) => void) => {
+      capturedOnError = onError;
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => usePoll({ fetch: vi.fn(), interval: vi.fn(), key: 'k1e' }));
+
+    act(() => {
+      capturedOnError?.(new Error('nope'));
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it('does not resubscribe when spec.key is unchanged across re-renders, but the latest fetch/interval take effect', () => {
+    subscribeMock.mockImplementation(() => vi.fn());
+
+    const fetch1 = vi.fn().mockResolvedValue(undefined);
+    const interval1 = vi.fn().mockReturnValue(1000);
+    const { rerender } = renderHook((spec: Spec) => usePoll(spec), {
+      initialProps: { fetch: fetch1, interval: interval1, key: 'k2' }
+    });
+
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+    const liveSpec = subscribeMock.mock.calls[0][0] as Spec;
+
+    const fetch2 = vi.fn().mockResolvedValue(undefined);
+    const interval2 = vi.fn().mockReturnValue(2000);
+    rerender({ fetch: fetch2, interval: interval2, key: 'k2' });
+
+    // Same key -> still exactly one subscribe call.
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+
+    // But the spec object handed to the coordinator at subscribe-time proxies
+    // through to the *latest* fetch/interval closures.
+    liveSpec.fetch();
+    expect(fetch2).toHaveBeenCalledTimes(1);
+    expect(fetch1).not.toHaveBeenCalled();
+
+    liveSpec.interval(undefined);
+    expect(interval2).toHaveBeenCalledTimes(1);
+    expect(interval1).not.toHaveBeenCalled();
+  });
+
+  it('resubscribes when spec.key changes', () => {
+    subscribeMock.mockImplementation(() => vi.fn());
+
+    const { rerender } = renderHook((spec: Spec) => usePoll(spec), {
+      initialProps: { fetch: vi.fn(), interval: vi.fn(), key: 'k3a' }
+    });
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+
+    rerender({ fetch: vi.fn(), interval: vi.fn(), key: 'k3b' });
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('unsubscribes on unmount', () => {
+    const unsubscribe = vi.fn();
+    subscribeMock.mockImplementation(() => unsubscribe);
+
+    const { unmount } = renderHook(() => usePoll({ fetch: vi.fn(), interval: vi.fn(), key: 'k4' }));
+
+    expect(unsubscribe).not.toHaveBeenCalled();
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/services/poller/usePoll.ts
+++ b/src/renderer/services/poller/usePoll.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { PollSpec } from './coordinator';
+
+import { subscribe } from './coordinator';
+
+export type UsePollResult<T> = {
+  data: T | undefined;
+  error: unknown;
+  loading: boolean;
+};
+
+/**
+ * Thin React binding over the poller coordinator (./coordinator.ts).
+ *
+ * Subscribes once per `spec.key`. `spec.fetch` and `spec.interval` are kept
+ * fresh via refs on every render, so re-renders with new closures never
+ * force a resubscribe — only a change in `spec.key` does.
+ */
+export function usePoll<T>(spec: PollSpec<T>): UsePollResult<T> {
+  const specRef = useRef(spec);
+  specRef.current = spec;
+
+  const [state, setState] = useState<UsePollResult<T>>({
+    data: undefined,
+    error: undefined,
+    loading: true
+  });
+
+  useEffect(() => {
+    setState({ data: undefined, error: undefined, loading: true });
+
+    const liveSpec: PollSpec<T> = {
+      fetch: () => specRef.current.fetch(),
+      interval: (data) => specRef.current.interval(data),
+      key: specRef.current.key,
+      priority: specRef.current.priority
+    };
+
+    const unsubscribe = subscribe<T>(
+      liveSpec,
+      (data) => {
+        setState({ data, error: undefined, loading: false });
+      },
+      (error) => {
+        setState((prev) => ({ data: prev.data, error, loading: false }));
+      }
+    );
+
+    return unsubscribe;
+    // Only `spec.key` should trigger a resubscribe; fetch/interval stay live via specRef.
+     
+  }, [spec.key]);
+
+  return state;
+}

--- a/src/renderer/utils/refresh.ts
+++ b/src/renderer/utils/refresh.ts
@@ -1,7 +1,14 @@
+import { refresh as refreshPoller } from 'renderer/services/poller';
+
 // Broadcast a "refresh now" so every repo card re-fetches its data (runs,
 // pulls, git status) in place — a gentle update instead of a full app reload.
 export const refreshEvent = 'devkitty:refresh';
 
+// Bridges both worlds during the poller migration: components already moved
+// onto the shared coordinator refresh via `refreshPoller`, while any not yet
+// migrated still answer the legacy DOM event. A migrated component drops its
+// `refreshEvent` listener so it doesn't double-fetch.
 export const requestRefresh = () => {
   window.dispatchEvent(new Event(refreshEvent));
+  refreshPoller();
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
         'src/main/settings.ts',
         'src/preload/**/*.ts',
         'src/renderer/hooks/**/*.{ts,tsx}',
+        'src/renderer/services/**/*.ts',
         'src/renderer/utils/**/*.ts',
         'src/renderer/assets/gitHubStatusUtils.ts'
       ],


### PR DESCRIPTION
Replaces the app's scattered per-component `setInterval` pollers with one shared coordinator, and folds in two related fixes.

## Why
Each Project card, worktree card, PR row, and open workflow run owned its own timer. That meant duplicated timers, no cross-card dedupe, no backoff, polling while hidden/offline, and (worst) PR checks polling every 30s per row at ~5-8 GitHub calls each — enough visible PRs and it blows past GitHub's 5k/hr budget.

## What
**New shared coordinator** (`src/renderer/services/poller/`): one scheduler, a keyed registry with per-key in-flight dedupe + shared cache, error backoff, pause-when-hidden/offline, refetch-on-visible/focus/online, staggered drain, and adaptive per-key intervals via `interval(data)`. Public API: `subscribe` / `usePoll` / `refresh` / `mutate` / `getSnapshot`. Fully unit-tested (19 tests).

**All clients migrated onto it:**
- `useGit` -> `gitStatus:<id>`, `CheckoutCard` -> `worktreeStatus:<path>`
- `useRepoData` -> `runs:` / `pulls:` / `pinnedRuns:<id>` (notification arming + deep-on-refresh preserved)
- `PullRequest` -> `prChecks:<projectId>:<number>`, adaptive **8s while in flux / 60s when settled**, with update-branch/merge/auto-merge wrapped in `mutate()` (re-polls after the action, no hand-rolled retry loop)
- `Workflow` -> `jobs:<runId>` (5s while running, stops on conclude)
- `useClaudeUsage` -> `claudeUsage:<dir>`
- `requestRefresh()` now also drives the coordinator

**Two fixes bundled:**
- PR **Merge button** now appears: `getPRChecks` polls `pulls.get` until GitHub finishes computing `mergeable` (it returns `null`/`unknown` on the first read after a change).
- PR **unresolved-conversations popover** capped in width so long file paths truncate instead of triggering a horizontal scrollbar / content shift.

## Tests
659/659 passing (54 files), 0 type errors in the changed surface.

Follow-up (not in this PR): main-side ETag/conditional requests + rate-limit backoff, `.git` fs-watch push invalidation, and a single batched GraphQL PR query per repo.