### PR TITLE
fix(pr): dedupe check runs to the latest per name

### DIFF
--- a/src/main/ipcs/ipcGitHub.ts
+++ b/src/main/ipcs/ipcGitHub.ts
@@ -303,7 +303,19 @@ ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number) =>
       repo
     });
 
-    const checks = data.check_runs.map((check) => ({
+    // GitHub returns every check run for the head SHA, including stale ones a
+    // re-run (or a superseding push) replaced — an old "cancelled"/"failure" run
+    // sits next to the fresh "in_progress" one of the same name. GitHub's own PR
+    // UI shows only the latest run per check name, so dedupe to the newest run
+    // (highest id) per name — otherwise the card counts superseded runs as
+    // failures the PR doesn't actually have.
+    const latestByName = new Map<string, (typeof data.check_runs)[number]>();
+    for (const run of data.check_runs) {
+      const prev = latestByName.get(run.name);
+      if (!prev || run.id > prev.id) latestByName.set(run.name, run);
+    }
+
+    const checks = [...latestByName.values()].map((check) => ({
       conclusion: check.conclusion,
       id: check.id,
       name: check.name,


### PR DESCRIPTION
## Problem
A PR row showed a red ✗ with "3 failed" while GitHub reported 0 failed (just in-progress + skipped checks).

## Cause
`getPRChecks` mapped **every** check run `checks.listForRef` returns for the head SHA. When a check is re-run (or a push supersedes an earlier suite), the old cancelled/failed run stays in the list next to the fresh in-progress one. GitHub's own PR UI shows only the latest run per check name, so the card over-counted failures.

## Fix
Dedupe `check_runs` by name, keeping the newest run (highest `id`), before building the checks summary. Matrix shards (distinct names) stay separate; same-name re-runs collapse to the current run.

54 ipcGitHub tests pass, lint clean.

Note: this fix was briefly pushed straight to `main` by mistake, then reverted (b94db37) so it could go through review here.