### PR TITLE
feat(clipboard): auto-downscale screenshots for Claude Code

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import { fixPath } from './libs/fixPath';
 fixPath();
 
 import './ipcs';
+import { initClipboardDownscale, stopClipboardWatcher } from './libs/clipboardDownscale';
 import { updateEditorsAndShells } from './libs/integrations/integrations';
 import { loadWindowState, saveBounds } from './libs/window';
 
@@ -78,7 +79,10 @@ app.on('ready', async () => {
   if (isDev) await installReactDevTools();
 
   createWindow();
+  initClipboardDownscale();
 });
+
+app.on('will-quit', () => stopClipboardWatcher());
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/main/libs/clipboardDownscale.test.ts
+++ b/src/main/libs/clipboardDownscale.test.ts
@@ -1,0 +1,403 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockClipboard, mockGetAllWindows, mockNativeImage } = vi.hoisted(() => ({
+  mockClipboard: {
+    availableFormats: vi.fn(),
+    read: vi.fn(),
+    readBuffer: vi.fn(),
+    readImage: vi.fn(),
+    writeImage: vi.fn()
+  },
+  mockGetAllWindows: vi.fn(),
+  mockNativeImage: {
+    createFromBuffer: vi.fn()
+  }
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: mockGetAllWindows },
+  clipboard: mockClipboard,
+  nativeImage: mockNativeImage
+}));
+
+vi.mock('electron-log', () => ({
+  default: { info: vi.fn(), warn: vi.fn() }
+}));
+
+vi.mock('../settings', () => ({
+  settings: { get: vi.fn(), onDidChange: vi.fn() }
+}));
+
+import log from 'electron-log';
+import { type AppSettings } from 'types/appSettings';
+
+import { settings } from '../settings';
+import {
+  CLIPBOARD_MAX_EDGE,
+  CLIPBOARD_POLL_MS,
+  downscaleClipboard,
+  forgetSeenImages,
+  initClipboardDownscale,
+  pngDimensions,
+  pngDpi,
+  stopClipboardWatcher,
+  syncClipboardWatcher
+} from './clipboardDownscale';
+
+const mockSettings = vi.mocked(settings);
+const mockLog = vi.mocked(log);
+
+const chunk = (type: string, data: Buffer): Buffer => {
+  const out = Buffer.alloc(12 + data.length);
+  out.writeUInt32BE(data.length, 0);
+  out.write(type, 4);
+  data.copy(out, 8);
+  return out; // trailing CRC left as zeros — the parsers under test do not verify it
+};
+
+// Builds a minimal-but-valid PNG: IHDR with the pixel dimensions, then a pHYs
+// chunk at the given DPI (144 = Retina screenshot; 0 = omit the chunk entirely).
+const fakePng = (width: number, height: number, dpi = 144): Buffer => {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+
+  const parts = [Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), chunk('IHDR', ihdr)];
+
+  if (dpi > 0) {
+    const phys = Buffer.alloc(9);
+    const perMetre = Math.round(dpi / 0.0254);
+    phys.writeUInt32BE(perMetre, 0); // pixels per unit, X
+    phys.writeUInt32BE(perMetre, 4); // pixels per unit, Y
+    phys.writeUInt8(1, 8); // unit specifier: 1 = metre
+    parts.push(chunk('pHYs', phys));
+  }
+
+  return Buffer.concat(parts);
+};
+
+const emptyBuffer = Buffer.alloc(0);
+
+describe('clipboardDownscale', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stopClipboardWatcher();
+    forgetSeenImages();
+    mockClipboard.read.mockReturnValue(''); // no file-url on the pasteboard by default
+    vi.useRealTimers();
+  });
+
+  describe('pngDimensions', () => {
+    it('parses width and height from a valid PNG header', () => {
+      expect(pngDimensions(fakePng(4000, 2400))).toEqual({ height: 2400, width: 4000 });
+    });
+
+    it('returns null for a buffer shorter than 24 bytes', () => {
+      expect(pngDimensions(Buffer.alloc(10))).toBeNull();
+    });
+
+    it('returns null when the signature does not match', () => {
+      const buf = fakePng(100, 100);
+      buf[0] = 0x00;
+      expect(pngDimensions(buf)).toBeNull();
+    });
+  });
+
+  describe('pngDpi', () => {
+    it('reads 144 DPI from a Retina-screenshot pHYs chunk', () => {
+      expect(Math.round(pngDpi(fakePng(100, 100, 144)) ?? 0)).toBe(144);
+    });
+
+    it('returns null when the PNG has no pHYs chunk', () => {
+      expect(pngDpi(fakePng(100, 100, 0))).toBeNull();
+    });
+
+    it('returns null for a non-PNG buffer', () => {
+      expect(pngDpi(Buffer.alloc(2000))).toBeNull();
+    });
+  });
+
+  describe('screenshot gate', () => {
+    const bigOut = () => {
+      const resized = { toPNG: vi.fn(() => Buffer.alloc(100)) };
+      return { image: { resize: vi.fn(() => resized) }, resized };
+    };
+
+    it('skips a non-screenshot image (72 DPI, no screenshot file-url)', () => {
+      mockClipboard.availableFormats.mockReturnValue(['image/png']);
+      mockClipboard.readBuffer.mockReturnValue(fakePng(4000, 2400, 72));
+      mockNativeImage.createFromBuffer.mockReturnValue(bigOut().image);
+
+      expect(downscaleClipboard()).toBeNull();
+      expect(mockClipboard.writeImage).not.toHaveBeenCalled();
+    });
+
+    it('skips a browser Copy Image even at Retina DPI (text/html on the clipboard)', () => {
+      mockClipboard.availableFormats.mockReturnValue(['image/png', 'text/html']);
+      mockClipboard.readBuffer.mockReturnValue(fakePng(4000, 2400, 144));
+      mockNativeImage.createFromBuffer.mockReturnValue(bigOut().image);
+
+      expect(downscaleClipboard()).toBeNull();
+      expect(mockClipboard.writeImage).not.toHaveBeenCalled();
+    });
+
+    it('downscales a CleanShot file copy that has no DPI, via the screenshot file-url', () => {
+      const { image } = bigOut();
+      mockClipboard.availableFormats.mockReturnValue(['text/uri-list']);
+      mockClipboard.readBuffer.mockReturnValue(fakePng(4000, 2400, 0));
+      mockClipboard.read.mockReturnValue('file:///Users/x/Desktop/CleanShot%202026.png');
+      mockNativeImage.createFromBuffer.mockReturnValue(image);
+
+      expect(downscaleClipboard()).not.toBeNull();
+      expect(mockClipboard.writeImage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('downscaleClipboard', () => {
+    it('returns null and skips readImage when no image/* format is present', () => {
+      mockClipboard.availableFormats.mockReturnValue(['text/plain']);
+      mockClipboard.readBuffer.mockReturnValue(emptyBuffer);
+
+      expect(downscaleClipboard()).toBeNull();
+      expect(mockClipboard.readImage).not.toHaveBeenCalled();
+    });
+
+    it('returns null for a Finder file copy (text/uri-list present, no PNG buffer)', () => {
+      mockClipboard.availableFormats.mockReturnValue(['text/uri-list']);
+      mockClipboard.readBuffer.mockReturnValue(emptyBuffer);
+
+      expect(downscaleClipboard()).toBeNull();
+      expect(mockClipboard.readImage).not.toHaveBeenCalled();
+    });
+
+    it('skips an image it has already shrunk once (re-copied original stays full size)', () => {
+      const png = fakePng(4000, 2400);
+      const resized = { toPNG: vi.fn(() => Buffer.alloc(10)) };
+      const image = { resize: vi.fn(() => resized) };
+      mockClipboard.availableFormats.mockReturnValue(['image/png']);
+      mockClipboard.readBuffer.mockReturnValue(png);
+      mockNativeImage.createFromBuffer.mockReturnValue(image);
+
+      expect(downscaleClipboard()).not.toBeNull();
+      expect(downscaleClipboard()).toBeNull();
+      expect(mockClipboard.writeImage).toHaveBeenCalledTimes(1);
+
+      // A different original is still processed.
+      mockClipboard.readBuffer.mockReturnValue(fakePng(4000, 2401));
+      expect(downscaleClipboard()).not.toBeNull();
+      expect(mockClipboard.writeImage).toHaveBeenCalledTimes(2);
+    });
+
+    it('downscales a CleanShot screenshot (text/uri-list present, but a valid PNG buffer)', () => {
+      const png = fakePng(4000, 2400);
+      const out = Buffer.alloc(1000);
+      const resized = { toPNG: vi.fn(() => out) };
+      const image = { resize: vi.fn(() => resized) };
+      mockClipboard.availableFormats.mockReturnValue(['text/uri-list']);
+      mockClipboard.readBuffer.mockReturnValue(png);
+      mockNativeImage.createFromBuffer.mockReturnValue(image);
+
+      const result = downscaleClipboard();
+
+      expect(image.resize).toHaveBeenCalledWith({ height: 720, quality: 'best', width: 1200 });
+      expect(mockClipboard.writeImage).toHaveBeenCalledWith(resized);
+      expect(result).toEqual({
+        bytes: { from: png.length, to: out.length },
+        from: { height: 2400, width: 4000 },
+        to: { height: 720, width: 1200 }
+      });
+    });
+
+    it('downscales a landscape PNG proportionally and writes it back', () => {
+      const png = fakePng(4000, 2400);
+      const out = Buffer.alloc(1000);
+      const resized = { toPNG: vi.fn(() => out) };
+      const image = { resize: vi.fn(() => resized) };
+      mockClipboard.availableFormats.mockReturnValue(['image/png']);
+      mockClipboard.readBuffer.mockReturnValue(png);
+      mockNativeImage.createFromBuffer.mockReturnValue(image);
+
+      const result = downscaleClipboard();
+
+      expect(image.resize).toHaveBeenCalledWith({ height: 720, quality: 'best', width: 1200 });
+      expect(mockClipboard.writeImage).toHaveBeenCalledWith(resized);
+      expect(result).toEqual({
+        bytes: { from: png.length, to: out.length },
+        from: { height: 2400, width: 4000 },
+        to: { height: 720, width: 1200 }
+      });
+    });
+
+    it('downscales a portrait PNG proportionally', () => {
+      const png = fakePng(1000, 3000);
+      const out = Buffer.alloc(500);
+      const image = { resize: vi.fn(() => ({ toPNG: vi.fn(() => out) })) };
+      mockClipboard.availableFormats.mockReturnValue(['image/png']);
+      mockClipboard.readBuffer.mockReturnValue(png);
+      mockNativeImage.createFromBuffer.mockReturnValue(image);
+
+      const result = downscaleClipboard();
+
+      expect(image.resize).toHaveBeenCalledWith({ height: 1200, quality: 'best', width: 400 });
+      expect(result).toEqual({
+        bytes: { from: png.length, to: out.length },
+        from: { height: 3000, width: 1000 },
+        to: { height: 1200, width: 400 }
+      });
+    });
+
+    it('returns null and does not write when the image is already within the max edge', () => {
+      const png = fakePng(1200, 800);
+      mockClipboard.availableFormats.mockReturnValue(['image/png']);
+      mockClipboard.readBuffer.mockReturnValue(png);
+
+      expect(downscaleClipboard()).toBeNull();
+      expect(mockClipboard.writeImage).not.toHaveBeenCalled();
+    });
+
+    it('falls back to clipboard.readImage() when no public.png buffer is available', () => {
+      const out = Buffer.alloc(300);
+      const image = {
+        getSize: vi.fn(() => ({ height: 1000, width: 2500 })),
+        isEmpty: vi.fn(() => false),
+        resize: vi.fn(() => ({ toPNG: vi.fn(() => out) })),
+        toPNG: vi.fn(() => Buffer.alloc(2000))
+      };
+      mockClipboard.availableFormats.mockReturnValue(['image/png']);
+      mockClipboard.readBuffer.mockReturnValue(emptyBuffer);
+      mockClipboard.readImage.mockReturnValue(image);
+      mockClipboard.read.mockReturnValue('file:///Users/x/Desktop/CleanShot%202026.png');
+
+      const result = downscaleClipboard();
+
+      expect(image.resize).toHaveBeenCalledWith({ height: 480, quality: 'best', width: 1200 });
+      expect(result).toEqual({
+        bytes: { from: 2000, to: out.length },
+        from: { height: 1000, width: 2500 },
+        to: { height: 480, width: 1200 }
+      });
+    });
+
+    it('returns null when both the PNG buffer and the fallback image are empty', () => {
+      const image = { getSize: vi.fn(), isEmpty: vi.fn(() => true) };
+      mockClipboard.availableFormats.mockReturnValue(['image/png']);
+      mockClipboard.readBuffer.mockReturnValue(emptyBuffer);
+      mockClipboard.readImage.mockReturnValue(image);
+
+      expect(downscaleClipboard()).toBeNull();
+    });
+  });
+
+  describe('syncClipboardWatcher', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      mockClipboard.availableFormats.mockReturnValue(['text/plain']);
+      mockClipboard.readBuffer.mockReturnValue(emptyBuffer);
+    });
+
+    it('runs one tick immediately and then on each interval', () => {
+      syncClipboardWatcher(true);
+      expect(mockClipboard.availableFormats).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(CLIPBOARD_POLL_MS);
+      expect(mockClipboard.availableFormats).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(CLIPBOARD_POLL_MS);
+      expect(mockClipboard.availableFormats).toHaveBeenCalledTimes(3);
+    });
+
+    it('is idempotent — calling with true again does not create a second interval', () => {
+      syncClipboardWatcher(true);
+      syncClipboardWatcher(true);
+      mockClipboard.availableFormats.mockClear();
+
+      vi.advanceTimersByTime(CLIPBOARD_POLL_MS);
+      expect(mockClipboard.availableFormats).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops polling when called with false', () => {
+      syncClipboardWatcher(true);
+      mockClipboard.availableFormats.mockClear();
+
+      syncClipboardWatcher(false);
+      vi.advanceTimersByTime(CLIPBOARD_POLL_MS * 3);
+
+      expect(mockClipboard.availableFormats).not.toHaveBeenCalled();
+    });
+
+    it('sends clipboard:downscaled to every window on a successful downscale', () => {
+      const png = fakePng(4000, 2400);
+      const out = Buffer.alloc(100);
+      const image = { resize: vi.fn(() => ({ toPNG: vi.fn(() => out) })) };
+      mockClipboard.availableFormats.mockReturnValue(['image/png']);
+      mockClipboard.readBuffer.mockReturnValue(png);
+      mockNativeImage.createFromBuffer.mockReturnValue(image);
+      const send = vi.fn();
+      mockGetAllWindows.mockReturnValue([{ webContents: { send } }]);
+
+      syncClipboardWatcher(true);
+
+      expect(send).toHaveBeenCalledWith('clipboard:downscaled', {
+        bytes: { from: png.length, to: out.length },
+        from: { height: 2400, width: 4000 },
+        to: { height: 720, width: 1200 }
+      });
+    });
+
+    it('catches an error thrown mid-tick, logs it, and keeps the interval running', () => {
+      mockClipboard.availableFormats.mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      syncClipboardWatcher(true);
+
+      expect(mockLog.warn).toHaveBeenCalled();
+
+      mockClipboard.availableFormats.mockClear();
+      mockClipboard.availableFormats.mockReturnValue(['text/plain']);
+      vi.advanceTimersByTime(CLIPBOARD_POLL_MS);
+      expect(mockClipboard.availableFormats).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('initClipboardDownscale', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      mockClipboard.availableFormats.mockReturnValue(['text/plain']);
+      mockClipboard.readBuffer.mockReturnValue(emptyBuffer);
+    });
+
+    it('starts the watcher immediately when the stored setting is on', () => {
+      mockSettings.get.mockReturnValue({ clipboardDownscale: true } as unknown as AppSettings);
+
+      initClipboardDownscale();
+
+      expect(mockClipboard.availableFormats).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not start the watcher when the stored setting is off or missing', () => {
+      mockSettings.get.mockReturnValue({} as unknown as AppSettings);
+
+      initClipboardDownscale();
+
+      expect(mockClipboard.availableFormats).not.toHaveBeenCalled();
+    });
+
+    it('stops the watcher when settings change to disabled', () => {
+      mockSettings.get.mockReturnValue({ clipboardDownscale: true } as unknown as AppSettings);
+      initClipboardDownscale();
+      mockClipboard.availableFormats.mockClear();
+
+      const onDidChangeCallback = mockSettings.onDidChange.mock.calls[0][1] as (next: Partial<AppSettings>) => void;
+      onDidChangeCallback({ clipboardDownscale: false });
+
+      vi.advanceTimersByTime(CLIPBOARD_POLL_MS * 2);
+      expect(mockClipboard.availableFormats).not.toHaveBeenCalled();
+    });
+  });
+
+  it('exports the expected constants', () => {
+    expect(CLIPBOARD_MAX_EDGE).toBe(1200);
+    expect(CLIPBOARD_POLL_MS).toBe(1000);
+  });
+});

--- a/src/main/libs/clipboardDownscale.ts
+++ b/src/main/libs/clipboardDownscale.ts
@@ -1,0 +1,139 @@
+import { createHash } from 'crypto';
+import { BrowserWindow, clipboard, nativeImage, type NativeImage } from 'electron';
+import log from 'electron-log';
+import { type DownscaleResult, type ImageSize } from 'types/clipboard';
+
+import { settings } from '../settings';
+
+export const CLIPBOARD_MAX_EDGE = 1200;
+export const CLIPBOARD_POLL_MS = 1000;
+// Fingerprints of source images already shrunk once. Re-copying the same
+// original (e.g. from a clipboard manager) is a deliberate choice to use it at
+// full size, so it is left alone.
+const SEEN_LIMIT = 100;
+const seen = new Set<string>();
+
+const fingerprint = (bytes: Buffer): string => createHash('sha1').update(bytes).digest('hex');
+
+const remember = (hash: string): void => {
+  seen.add(hash);
+  if (seen.size > SEEN_LIMIT) seen.delete(seen.values().next().value as string);
+};
+
+export const forgetSeenImages = (): void => seen.clear();
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PHYS_CHUNK = Buffer.from('pHYs');
+const METRES_PER_INCH = 0.0254;
+// macOS tags Retina screenshots at 144 DPI; photos and web images sit at 72 or
+// carry no DPI at all. 120 cleanly separates the two.
+const RETINA_SCREENSHOT_DPI = 120;
+const SCREENSHOT_FILE = /screenshot|cleanshot/i;
+
+export const pngDimensions = (png: Buffer): ImageSize | null => {
+  if (png.length < 24 || !png.subarray(0, 8).equals(PNG_SIGNATURE)) return null;
+
+  return { height: png.readUInt32BE(20), width: png.readUInt32BE(16) };
+};
+
+// Horizontal DPI from the PNG pHYs chunk, or null when it is absent or not in metres.
+export const pngDpi = (png: Buffer): number | null => {
+  if (png.length < 8 || !png.subarray(0, 8).equals(PNG_SIGNATURE)) return null;
+
+  let offset = 8;
+  while (offset + 8 <= png.length) {
+    const length = png.readUInt32BE(offset);
+    if (png.subarray(offset + 4, offset + 8).equals(PHYS_CHUNK)) {
+      const data = offset + 8;
+      if (data + 9 > png.length || png.readUInt8(data + 8) !== 1) return null;
+      return png.readUInt32BE(data) * METRES_PER_INCH;
+    }
+    offset += 12 + length;
+  }
+
+  return null;
+};
+
+// Best effort: a macOS screenshot is a Retina-DPI PNG or a file dropped from a
+// screenshot tool. A browser "Copy Image" always brings HTML along — never a screenshot.
+const isScreenshot = (png: Buffer, formats: string[]): boolean => {
+  if (formats.includes('text/html')) return false;
+
+  const dpi = pngDpi(png);
+  if (dpi !== null && dpi >= RETINA_SCREENSHOT_DPI) return true;
+
+  return SCREENSHOT_FILE.test(clipboard.read('public.file-url'));
+};
+
+const readClipboardImage = (): null | { formats: string[]; image: NativeImage; size: ImageSize; source: Buffer } => {
+  const formats = clipboard.availableFormats();
+  const png = clipboard.readBuffer('public.png');
+  const dims = pngDimensions(png);
+  if (dims) return { formats, image: nativeImage.createFromBuffer(png), size: dims, source: png };
+
+  if (!formats.some((format) => format.startsWith('image/')) || formats.includes('text/uri-list')) return null;
+
+  const image = clipboard.readImage();
+  if (image.isEmpty()) return null;
+
+  return { formats, image, size: image.getSize(), source: image.toPNG() };
+};
+
+export const downscaleClipboard = (): DownscaleResult | null => {
+  const probe = readClipboardImage();
+  if (!probe) return null;
+
+  const { formats, image, size, source } = probe;
+  const longest = Math.max(size.width, size.height);
+  if (longest <= CLIPBOARD_MAX_EDGE) return null;
+
+  if (!isScreenshot(source, formats)) return null;
+
+  const hash = fingerprint(source);
+  if (seen.has(hash)) return null;
+  remember(hash);
+
+  const scale = CLIPBOARD_MAX_EDGE / longest;
+  const to: ImageSize = {
+    height: Math.max(1, Math.round(size.height * scale)),
+    width: Math.max(1, Math.round(size.width * scale))
+  };
+
+  const resized = image.resize({ height: to.height, quality: 'best', width: to.width });
+  const out = resized.toPNG();
+  clipboard.writeImage(resized);
+
+  return { bytes: { from: source.length, to: out.length }, from: size, to };
+};
+
+let timer: NodeJS.Timeout | null = null;
+
+const tick = (): void => {
+  try {
+    const result = downscaleClipboard();
+    if (result) {
+      log.info('[clipboard] downscaled', result);
+      BrowserWindow.getAllWindows().forEach((window) => window.webContents.send('clipboard:downscaled', result));
+    }
+  } catch (error) {
+    log.warn('[clipboard] downscale failed', error);
+  }
+};
+
+export const syncClipboardWatcher = (enabled: boolean): void => {
+  if (enabled && !timer) {
+    tick();
+    timer = setInterval(tick, CLIPBOARD_POLL_MS);
+  } else if (!enabled && timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+};
+
+export const stopClipboardWatcher = (): void => syncClipboardWatcher(false);
+
+export const initClipboardDownscale = (): void => {
+  syncClipboardWatcher(Boolean(settings.get('appSettings')?.clipboardDownscale));
+
+  settings.onDidChange('appSettings', (next) => syncClipboardWatcher(Boolean(next?.clipboardDownscale)));
+};

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -18,6 +18,7 @@ export const settings = new Store<Settings>({
   defaults: {
     appSettings: {
       claudeEnabled: true,
+      clipboardDownscale: false,
       editors: [],
       fetchInterval: 10000,
       gitHubActions: {

--- a/src/preload/demo/bridge.ts
+++ b/src/preload/demo/bridge.ts
@@ -55,6 +55,9 @@ export const demoBridge = {
     detect: () => Promise.resolve({ installed: true, version: '2.0.14' }),
     usage: (account: { dir: string }) => Promise.resolve(usageByDir[account.dir] ?? usageByDir[claudeAccounts[0].dir])
   },
+  clipboard: {
+    onDownscaled: () => () => {}
+  },
   darkMode: {
     on: noop,
     set: noop,

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockIpcRenderer = {
   invoke: vi.fn(),
-  on: vi.fn()
+  on: vi.fn(),
+  removeListener: vi.fn()
 };
 
 const mockContextBridge = {
@@ -25,10 +26,29 @@ describe('preload bridge', () => {
     // Only clear ipcRenderer mocks, not contextBridge (bridge was captured above)
     mockIpcRenderer.invoke.mockClear();
     mockIpcRenderer.on.mockClear();
+    mockIpcRenderer.removeListener.mockClear();
   });
 
   it('should expose bridge on window via contextBridge', () => {
     expect(mockContextBridge.exposeInMainWorld).toHaveBeenCalledWith('bridge', expect.any(Object));
+  });
+
+  describe('clipboard', () => {
+    it('should listen for clipboard:downscaled events and forward the result to the callback', () => {
+      const callback = vi.fn();
+
+      const unsubscribe = bridge.clipboard.onDownscaled(callback);
+
+      expect(mockIpcRenderer.on).toHaveBeenCalledWith('clipboard:downscaled', expect.any(Function));
+
+      const result = { from: { height: 2400, width: 4000 }, to: { height: 720, width: 1200 } };
+      mockIpcRenderer.on.mock.calls[0][1]({}, result);
+      expect(callback).toHaveBeenCalledWith(result);
+
+      expect(typeof unsubscribe).toBe('function');
+      unsubscribe();
+      expect(mockIpcRenderer.removeListener).toHaveBeenCalledWith('clipboard:downscaled', mockIpcRenderer.on.mock.calls[0][1]);
+    });
   });
 
   describe('darkMode', () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
 import { type AppSettings } from 'types/appSettings';
 import { type ClaudeAccount, type ClaudeDetection, type ClaudeUsage } from 'types/claudeUsage';
+import { type DownscaleResult } from 'types/clipboard';
 import { type FoundEditor } from 'types/foundEditor';
 import { type FoundShell } from 'types/foundShell';
 import { type pullTypes } from 'types/gitHub';
@@ -15,6 +16,13 @@ const bridge = {
     accounts: (): Promise<ClaudeAccount[]> => ipcRenderer.invoke('claude:accounts'),
     detect: (): Promise<ClaudeDetection> => ipcRenderer.invoke('claude:detect'),
     usage: (account: ClaudeAccount): Promise<ClaudeUsage> => ipcRenderer.invoke('claude:usage', account)
+  },
+  clipboard: {
+    onDownscaled: (callback: (result: DownscaleResult) => void) => {
+      const listener = (_: IpcRendererEvent, result: DownscaleResult) => callback(result);
+      ipcRenderer.on('clipboard:downscaled', listener);
+      return () => ipcRenderer.removeListener('clipboard:downscaled', listener);
+    }
   },
   darkMode: {
     on: (callback: (event: IpcRendererEvent, theme: ThemeSource) => void) => ipcRenderer.on('theme-changed', callback),

--- a/src/renderer/components/AppNavbar/AppNavbar.tsx
+++ b/src/renderer/components/AppNavbar/AppNavbar.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, Classes, Icon, Navbar, Tooltip } from '@blueprintjs/core';
+import { Button, ButtonGroup, Classes, Icon, Navbar, Popover, Tooltip } from '@blueprintjs/core';
 import clsx from 'clsx';
 import { useEffect, useRef, useState } from 'react';
 import { NavLink, useLocation } from 'react-router';
@@ -8,17 +8,88 @@ import { useClaudeUsage } from 'renderer/hooks/useClaudeUsage';
 import { useDarkMode } from 'renderer/hooks/useDarkMode';
 import { useFilter } from 'renderer/hooks/useFilter';
 import { useProjects } from 'renderer/hooks/useProjects';
+import { appToaster } from 'renderer/utils/appToaster';
 import { cn } from 'renderer/utils/cn';
+import { formatBytes } from 'renderer/utils/formatBytes';
 import { requestRefresh } from 'renderer/utils/refresh';
+import { type DownscaleResult } from 'types/clipboard';
 
 import { ClaudeMark } from '../ClaudeUsage';
 import { ShinyText } from '../ShinyText';
 import { PinIcon, SettingsGearIcon } from './NavIcons';
 import { SearchInput } from './SearchInput';
 
+const ClipboardDownscaleDetail = ({ enabled, last }: { enabled: boolean; last: DownscaleResult | null }) => (
+  <div className="w-[268px] p-4 text-bp-dark-gray-1 dark:text-bp-light-gray-5">
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-1.5">
+        <Icon
+          color={enabled ? '#F5854A' : undefined}
+          icon="media"
+          size={16}
+        />
+
+        <span className="text-sm font-semibold">Clipboard downscale</span>
+      </div>
+
+      <span
+        className="shrink-0 rounded bg-black/5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-bp-gray-1 dark:bg-white/10 dark:text-white/85"
+        style={enabled ? { color: '#F5854A' } : undefined}
+      >
+        {enabled ? 'ON' : 'OFF'}
+      </span>
+    </div>
+
+    <p
+      className="text-xs leading-snug text-bp-gray-1 dark:text-bp-gray-4"
+      style={{ marginTop: 14 }}
+    >
+      Watches for screenshots while on. A screenshot wider or taller than 1200 px is shrunk to 1200 px and re-copied
+      as PNG, so pasting into Claude Code costs fewer tokens. Photos, small images and text are left alone.
+    </p>
+
+    <div className="mt-3.5 border-t border-bp-light-gray-2 pt-3 dark:border-bp-dark-gray-3">
+      {last ? (
+        <div className="flex flex-col gap-2">
+          <span className="text-[10px] font-bold uppercase tracking-wider text-bp-gray-3">Last optimized</span>
+
+          <div className="flex items-center gap-2">
+            <div className="flex flex-1 flex-col gap-1 text-xs tabular-nums">
+              <div className="flex items-center gap-2">
+                <span className="w-8 shrink-0 text-bp-gray-3">From</span>
+                <span className="text-bp-gray-1 dark:text-bp-gray-4">
+                  {last.from.width}×{last.from.height} · {formatBytes(last.bytes.from)}
+                </span>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span className="w-8 shrink-0 text-bp-gray-3">To</span>
+                <span className="font-medium">
+                  {last.to.width}×{last.to.height} · {formatBytes(last.bytes.to)}
+                </span>
+              </div>
+            </div>
+
+            <span
+              className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold"
+              style={{ backgroundColor: 'rgba(245,133,74,0.15)', color: '#F5854A' }}
+            >
+              −{Math.round((1 - last.bytes.to / last.bytes.from) * 100)}%
+            </span>
+          </div>
+        </div>
+      ) : (
+        <span className="text-[11px] leading-snug text-bp-gray-2 dark:text-bp-gray-3">
+          {enabled ? 'Watching — nothing downscaled yet.' : 'Click to turn on.'}
+        </span>
+      )}
+    </div>
+  </div>
+);
+
 export const AppNavbar = () => {
   const { themeSource, toggleDarkMode } = useDarkMode();
-  const { claudeEnabled, set, showClaudeUsage, showLogo } = useAppSettings();
+  const { claudeEnabled, clipboardDownscale, set, showClaudeUsage, showLogo } = useAppSettings();
   const isSunset = useIsSunset();
   const claudeInstalled = useClaudeUsage((s) => s.detection.installed);
   const { addProject } = useProjects();
@@ -26,6 +97,7 @@ export const AppNavbar = () => {
   const searchRef = useRef<HTMLInputElement>(null);
   const onHome = useLocation().pathname === '/';
   const [alwaysOnTop, setAlwaysOnTop] = useState(false);
+  const [lastDownscale, setLastDownscale] = useState<DownscaleResult | null>(null);
 
   // Reflect the window's real pinned state on mount (it survives across
   // reloads within a session).
@@ -39,6 +111,57 @@ export const AppNavbar = () => {
     const next = await window.bridge.window.setAlwaysOnTop(target);
     setAlwaysOnTop(next);
   };
+
+  // Toast whenever the main process shrinks a clipboard image, wherever the
+  // toggle was flipped from.
+  useEffect(
+    () =>
+      window.bridge.clipboard.onDownscaled((result: DownscaleResult) => {
+        const { bytes, from, to } = result;
+        setLastDownscale(result);
+        const saved = bytes.from > 0 ? Math.round((1 - bytes.to / bytes.from) * 100) : 0;
+        appToaster.then((toaster) =>
+          toaster.show({
+            icon: (
+              <Icon
+                color="#F5854A"
+                icon="media"
+                size={16}
+              />
+            ),
+            message: (
+              <div className="flex flex-col gap-1 py-0.5">
+                <div className="text-sm font-semibold">Image optimized for Claude Code</div>
+
+                <div className="flex items-center gap-2 text-xs tabular-nums opacity-90">
+                  <span>
+                    {from.width}×{from.height} · {formatBytes(bytes.from)}
+                  </span>
+
+                  <Icon
+                    className="opacity-60"
+                    icon="arrow-right"
+                    size={12}
+                  />
+
+                  <span className="font-semibold">
+                    {to.width}×{to.height} · {formatBytes(bytes.to)}
+                  </span>
+
+                  {saved > 0 && (
+                    <span className="ml-1 rounded bg-black/5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[#F5854A] dark:bg-white/10">
+                      −{saved}%
+                    </span>
+                  )}
+                </div>
+              </div>
+            ),
+            timeout: 6000
+          })
+        );
+      }),
+    []
+  );
 
   // Leaving the project list drops the filter, so coming back is never
   // silently narrowed by something typed a page ago.
@@ -152,6 +275,27 @@ export const AppNavbar = () => {
               />
             </Tooltip>
           )}
+
+          <Popover
+            content={<ClipboardDownscaleDetail
+              enabled={clipboardDownscale}
+              last={lastDownscale}
+                     />}
+            hoverOpenDelay={300}
+            interactionKind="hover"
+            minimal
+            placement="bottom"
+          >
+            <Button
+              aria-label="Toggle clipboard downscale"
+              icon={<Icon color={clipboardDownscale ? '#F5854A' : undefined}
+                icon="media"
+                size={16}
+                    />}
+              minimal
+              onClick={() => set({ clipboardDownscale: !clipboardDownscale })}
+            />
+          </Popover>
 
           <Tooltip
             compact

--- a/src/renderer/hooks/useAppSettings.test.ts
+++ b/src/renderer/hooks/useAppSettings.test.ts
@@ -69,6 +69,13 @@ describe('useAppSettings', () => {
       expect(window.bridge.settings.set).toHaveBeenCalledWith('appSettings', { fetchInterval: 5000 }, undefined);
     });
 
+    it('should persist clipboardDownscale via bridge', () => {
+      useAppSettings.getState().set({ clipboardDownscale: true });
+
+      expect(useAppSettings.getState().clipboardDownscale).toBe(true);
+      expect(window.bridge.settings.set).toHaveBeenCalledWith('appSettings', { clipboardDownscale: true }, undefined);
+    });
+
     it('should pass safe flag when encrypting', () => {
       useAppSettings.getState().set({ gitHubToken: 'my-token' } as any, true);
 

--- a/src/renderer/hooks/useAppSettings.ts
+++ b/src/renderer/hooks/useAppSettings.ts
@@ -7,6 +7,7 @@ type Actions = {
 
 export const useAppSettings = create<Actions & AppSettings>((set) => ({
   claudeEnabled: true,
+  clipboardDownscale: false,
   editors: [],
   fetchInterval: 10000,
   gitHubActions: {

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -8,6 +8,9 @@ import { vi } from 'vitest';
 // The stores (useProjects, useGroups, useAppSettings, useDarkMode) have
 // top-level IIFEs that call window.bridge.* at import time
 const mockBridge = {
+  clipboard: {
+    onDownscaled: vi.fn(() => () => {})
+  },
   darkMode: {
     on: vi.fn(),
     set: vi.fn(),

--- a/src/renderer/utils/formatBytes.test.ts
+++ b/src/renderer/utils/formatBytes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatBytes } from './formatBytes';
+
+describe('formatBytes', () => {
+  it('formats bytes below 1 KB', () => {
+    expect(formatBytes(812)).toBe('812 B');
+  });
+
+  it('formats kilobytes as an integer', () => {
+    expect(formatBytes(240 * 1024)).toBe('240 KB');
+  });
+
+  it('formats megabytes with one decimal', () => {
+    expect(formatBytes(1.8 * 1024 * 1024)).toBe('1.8 MB');
+  });
+
+  it('formats zero bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+});

--- a/src/renderer/utils/formatBytes.ts
+++ b/src/renderer/utils/formatBytes.ts
@@ -1,0 +1,6 @@
+export const formatBytes = (n: number): string => {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
+
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+};

--- a/src/types/appSettings.ts
+++ b/src/types/appSettings.ts
@@ -5,6 +5,7 @@ import { type IgnoredWorkflow } from './ignoredWorkflow';
 export type AppSettings = {
   claudeAccountDir?: string; // config dir of the account shown in the usage footer
   claudeEnabled: boolean; // master switch for the Claude Code usage integration
+  clipboardDownscale: boolean; // header toggle: auto-shrink clipboard images > 1200px for Claude Code
   editors: FoundEditor[];
   fetchInterval: number;
   gitHubActions: {

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -1,0 +1,3 @@
+export type DownscaleResult = { bytes: { from: number; to: number }; from: ImageSize; to: ImageSize };
+
+export type ImageSize = { height: number; width: number };


### PR DESCRIPTION
## What

Adds a header toggle (media icon) that watches the clipboard and auto-downscales large **screenshots** to 1200 px, re-copied as PNG — so pasting into Claude Code costs far fewer vision tokens.

## Screenshot-only detection

There is no clipboard "screenshot" flag, so it uses signals:

- **Shrink** if the PNG is Retina (pHYs 144 DPI) **or** the file comes from a screenshot tool (CleanShot / Screenshot file URL).
- **Skip** a browser "Copy Image" (always carries `text/html`), and normal photos / small images / text.

## Details

- **No double-shrink:** each source image is fingerprinted (SHA-1); re-copying the same original leaves it at full size.
- **Retina-safe sizing:** reads true pixel dimensions from the PNG IHDR, not `getSize()` points.
- **UI:** hover popover with From/To size + byte savings and an ON/OFF pill; a lingering toast reports each optimization.
- Off by default; persisted in app settings.

## Tests

- `clipboardDownscale.test.ts` — 27 tests (detection, DPI parsing, dedupe, watcher lifecycle).
- `formatBytes`, `useAppSettings`, preload bridge tests updated. 71 touched tests green.

## Verified live

Real CleanShot screenshots shrank on the running app (e.g. 4812×2590 → 1200×646, −76%); a photo copied from a web page was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
