### PR TITLE
fix(worktree): force delete overrides locked worktrees

### DIFF
--- a/src/main/ipcs/ipcWorktree.test.ts
+++ b/src/main/ipcs/ipcWorktree.test.ts
@@ -247,12 +247,27 @@ describe('ipcWorktree', () => {
       expect(mockGit.raw).toHaveBeenCalledWith(['worktree', 'remove', '/path/to/worktree']);
     });
 
-    it('should add --force flag when force is true', async () => {
+    it('should add --force twice when force is true (overrides locks too)', async () => {
       mockGit.raw.mockResolvedValue(undefined);
 
       await handlers['git:worktree:remove']({}, 'proj-1', '/path/to/worktree', true);
 
-      expect(mockGit.raw).toHaveBeenCalledWith(['worktree', 'remove', '/path/to/worktree', '--force']);
+      expect(mockGit.raw).toHaveBeenCalledWith([
+        'worktree',
+        'remove',
+        '/path/to/worktree',
+        '--force',
+        '--force'
+      ]);
+    });
+
+    it('should indicate needsForce when worktree is locked', async () => {
+      mockGit.raw.mockRejectedValue(new Error('cannot remove a locked working tree, lock reason: ...'));
+
+      const result = await handlers['git:worktree:remove']({}, 'proj-1', '/path/to/worktree');
+
+      expect(result.success).toBe(false);
+      expect(result.needsForce).toBe(true);
     });
 
     it('should not add --force flag when force is false', async () => {

--- a/src/main/ipcs/ipcWorktree.ts
+++ b/src/main/ipcs/ipcWorktree.ts
@@ -85,12 +85,15 @@ ipcMain.handle('git:worktree:remove', async (_, id: string, worktreePath: string
   try {
     const git = await getGit(id);
     const args = ['worktree', 'remove', worktreePath];
-    if (force) args.push('--force');
+    // Force twice (-f -f) so it also overrides a locked worktree, not just dirty files.
+    if (force) args.push('--force', '--force');
     await git.raw(args);
 
     return { message: 'Worktree removed', success: true };
   } catch (e) {
-    const needsForce = e.message?.includes('contains modified or untracked files');
+    const needsForce =
+      e.message?.includes('contains modified or untracked files') ||
+      e.message?.includes('locked working tree');
     return { message: e.message, needsForce, success: false };
   }
 });


### PR DESCRIPTION
## What
Force-deleting a merged worktree failed when the worktree was locked (e.g. by a claude session):

> fatal: cannot remove a locked working tree, lock reason: claude session ... use 'remove -f -f' to override or unlock first

## Fix
- `git worktree remove` now passes `--force --force` (`-f -f`) when Force delete is on, so it overrides a lock, not just dirty files.
- Also detect the `locked working tree` error so the UI surfaces the Force option for locked worktrees too.

## Trade-off
Forcing past a lock removes a running claude session's worktree — intended: Force must always win.

## Tests
`src/main/ipcs/ipcWorktree.test.ts` updated; 20/20 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)