### PR TITLE
feat: command palette (⌘K) with worktree focus, plus git pull fix

### DIFF
--- a/src/main/ipcs/ipcGit.ts
+++ b/src/main/ipcs/ipcGit.ts
@@ -5,6 +5,28 @@ import { type Worktree } from 'types/worktree';
 
 import { getGit, parseWorktreeList } from '../libs/git';
 
+// Serialize network git ops (fetch/pull) per repo. getGit() builds a fresh
+// simple-git instance per IPC call, so two handlers — the polled status fetch
+// and a Pull click, say — otherwise spawn concurrent `git` processes on the
+// same repo. Concurrent fetches scramble .git/FETCH_HEAD, which makes the very
+// next pull fail with "Cannot fast-forward to multiple branches". Chaining
+// every fetch/pull per repo id keeps them one-at-a-time. Errors are swallowed
+// in the chain so one failed op never blocks the next.
+const repoLocks = new Map<string, Promise<unknown>>();
+
+const withRepoLock = <T>(id: string, task: () => Promise<T>): Promise<T> => {
+  const run = (repoLocks.get(id) ?? Promise.resolve()).then(task, task);
+  repoLocks.set(
+    id,
+    run.then(
+      () => undefined,
+      () => undefined
+    )
+  );
+
+  return run;
+};
+
 ipcMain.handle('git:getStatus', async (_, id: string): Promise<GitStatus> => {
   try {
     const git = await getGit(id);
@@ -35,7 +57,8 @@ ipcMain.handle('git:getStatus', async (_, id: string): Promise<GitStatus> => {
       /* worktree list not supported or failed */
     }
 
-    git.fetch();
+    // Fire-and-forget, but serialized against any pull on this repo.
+    withRepoLock(id, () => git.fetch());
 
     return { branchSummary, organization, status: gitStatus, success: true, worktrees };
   } catch (e) {
@@ -61,8 +84,9 @@ ipcMain.handle('git:pull', async (e, id: string) => {
 
     // --ff-only, so a repo with no pull.rebase configured does not fail with
     // git's "need to specify how to reconcile divergent branches", and a button
-    // press never rewrites or merges history behind the user's back.
-    await git.pull(['--ff-only']);
+    // press never rewrites or merges history behind the user's back. Locked so
+    // it never runs while a background status fetch is in flight.
+    await withRepoLock(id, () => git.pull(['--ff-only']));
 
     return { message: 'Project pulled', success: true };
   } catch (e) {
@@ -101,7 +125,7 @@ ipcMain.handle('git:mergeTo', async (e, id: string, from: string, target: string
     const git = await getGit(id);
 
     await git.checkout(target);
-    await git.pull();
+    await withRepoLock(id, () => git.pull());
     await git.merge([from]);
     await git.push();
     await git.checkout(from);

--- a/src/main/ipcs/ipcNotification.test.ts
+++ b/src/main/ipcs/ipcNotification.test.ts
@@ -2,13 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const handlers: Record<string, (...args: any[]) => any> = {};
 
-const { NotificationMock, mockNotificationShow } = vi.hoisted(() => {
+const { mockNotificationShow, NotificationMock } = vi.hoisted(() => {
   const mockNotificationShow = vi.fn();
+  // Must be a constructable function (used with `new`); do not let --fix turn it into an arrow.
+  // eslint-disable-next-line prefer-arrow-callback
   const NotificationMock: any = vi.fn(function () {
     return { show: mockNotificationShow };
   });
   NotificationMock.isSupported = vi.fn();
-  return { NotificationMock, mockNotificationShow };
+  return { mockNotificationShow, NotificationMock };
 });
 
 vi.mock('electron', () => ({

--- a/src/main/libs/claude/accounts.test.ts
+++ b/src/main/libs/claude/accounts.test.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('fs', () => ({

--- a/src/main/libs/claude/lastUsage.test.ts
+++ b/src/main/libs/claude/lastUsage.test.ts
@@ -66,8 +66,8 @@ describe('readReportedUsage', () => {
       JSON.stringify({
         capturedAt: 1700000000,
         rate_limits: {
-          five_hour: { used_percentage: 42, resets_at: 1700003600 },
-          seven_day: { used_percentage: 87, resets_at: 1700600000 }
+          five_hour: { resets_at: 1700003600, used_percentage: 42 },
+          seven_day: { resets_at: 1700600000, used_percentage: 87 }
         }
       })
     );
@@ -86,7 +86,7 @@ describe('readReportedUsage', () => {
       JSON.stringify({
         capturedAt: 1700000000,
         rate_limits: {
-          five_hour: { used_percentage: 10, resets_at: 1700003600 }
+          five_hour: { resets_at: 1700003600, used_percentage: 10 }
         }
       })
     );
@@ -101,7 +101,7 @@ describe('readReportedUsage', () => {
       JSON.stringify({
         capturedAt: 1700000000,
         rate_limits: {
-          five_hour: { used_percentage: 10, resets_at: 1700003600 }
+          five_hour: { resets_at: 1700003600, used_percentage: 10 }
         }
       })
     );
@@ -120,7 +120,7 @@ describe('readReportedUsage', () => {
       JSON.stringify({
         capturedAt: 1700000000,
         rate_limits: {
-          five_hour: { used_percentage: 250, resets_at: 1700003600 }
+          five_hour: { resets_at: 1700003600, used_percentage: 250 }
         }
       })
     );
@@ -135,7 +135,7 @@ describe('readReportedUsage', () => {
       JSON.stringify({
         capturedAt: 1700000000,
         rate_limits: {
-          five_hour: { used_percentage: -20, resets_at: 1700003600 }
+          five_hour: { resets_at: 1700003600, used_percentage: -20 }
         }
       })
     );
@@ -150,7 +150,7 @@ describe('readReportedUsage', () => {
       JSON.stringify({
         capturedAt: 1700000000,
         rate_limits: {
-          five_hour: { used_percentage: 10, resets_at: 1700003600 }
+          five_hour: { resets_at: 1700003600, used_percentage: 10 }
         }
       })
     );
@@ -165,7 +165,7 @@ describe('readReportedUsage', () => {
       JSON.stringify({
         capturedAt: 1700000000,
         rate_limits: {
-          five_hour: { used_percentage: 10, resets_at: '2023-11-14T22:13:20.000Z' }
+          five_hour: { resets_at: '2023-11-14T22:13:20.000Z', used_percentage: 10 }
         }
       })
     );
@@ -180,7 +180,7 @@ describe('readReportedUsage', () => {
       JSON.stringify({
         capturedAt: 1700000000,
         rate_limits: {
-          five_hour: { used_percentage: 10, resets_at: 'not-a-real-date' }
+          five_hour: { resets_at: 'not-a-real-date', used_percentage: 10 }
         }
       })
     );
@@ -195,7 +195,7 @@ describe('readReportedUsage', () => {
       JSON.stringify({
         capturedAt: null,
         rate_limits: {
-          five_hour: { used_percentage: 10, resets_at: 1700003600 }
+          five_hour: { resets_at: 1700003600, used_percentage: 10 }
         }
       })
     );

--- a/src/main/libs/claude/transcripts.test.ts
+++ b/src/main/libs/claude/transcripts.test.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events';
-
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('fs', () => ({
@@ -19,9 +18,8 @@ vi.mock('readline', () => ({
 import fs from 'fs';
 import readline from 'readline';
 
-import { LOOKBACK_MS } from './usage';
-
 import { readEntries } from './transcripts';
+import { LOOKBACK_MS } from './usage';
 
 const mockReaddirSync = vi.mocked(fs.readdirSync);
 const mockStatSync = vi.mocked(fs.statSync);

--- a/src/main/libs/clipboardDownscale.ts
+++ b/src/main/libs/clipboardDownscale.ts
@@ -37,7 +37,7 @@ export const pngDimensions = (png: Buffer): ImageSize | null => {
 };
 
 // Horizontal DPI from the PNG pHYs chunk, or null when it is absent or not in metres.
-export const pngDpi = (png: Buffer): number | null => {
+export const pngDpi = (png: Buffer): null | number => {
   if (png.length < 8 || !png.subarray(0, 8).equals(PNG_SIGNATURE)) return null;
 
   let offset = 8;

--- a/src/main/libs/integrations/integrations.test.ts
+++ b/src/main/libs/integrations/integrations.test.ts
@@ -16,9 +16,9 @@ vi.mock('../../settings', () => ({
   }
 }));
 
+import { settings } from '../../settings';
 import { getInstalledApps } from './getInstalledApps';
 import { updateEditorsAndShells } from './integrations';
-import { settings } from '../../settings';
 
 const mockGetInstalledApps = vi.mocked(getInstalledApps);
 const mockSettings = vi.mocked(settings);

--- a/src/preload/demo/bridge.test.ts
+++ b/src/preload/demo/bridge.test.ts
@@ -102,10 +102,10 @@ describe('demoBridge darkMode', () => {
 
 describe('demoBridge git', () => {
   it('resolves canned success objects for the simple git mutations', async () => {
-    await expect(demoBridge.git.checkout()).resolves.toMatchObject({ success: true, message: 'Switched branch' });
-    await expect(demoBridge.git.mergeTo()).resolves.toMatchObject({ success: true, merges: [] });
-    await expect(demoBridge.git.pull()).resolves.toMatchObject({ success: true, message: 'Already up to date' });
-    await expect(demoBridge.git.reset()).resolves.toMatchObject({ success: true, message: 'Reset' });
+    await expect(demoBridge.git.checkout()).resolves.toMatchObject({ message: 'Switched branch', success: true });
+    await expect(demoBridge.git.mergeTo()).resolves.toMatchObject({ merges: [], success: true });
+    await expect(demoBridge.git.pull()).resolves.toMatchObject({ message: 'Already up to date', success: true });
+    await expect(demoBridge.git.reset()).resolves.toMatchObject({ message: 'Reset', success: true });
   });
 
   it('returns the rich git status for a known project id', async () => {
@@ -117,7 +117,7 @@ describe('demoBridge git', () => {
   });
 
   it('returns a not-found status for an unknown project id', async () => {
-    await expect(demoBridge.git.getStatus('nope')).resolves.toMatchObject({ success: false, message: 'Not found' });
+    await expect(demoBridge.git.getStatus('nope')).resolves.toMatchObject({ message: 'Not found', success: false });
   });
 });
 
@@ -130,10 +130,10 @@ describe('demoBridge gitAPI extra', () => {
     await expect(demoBridge.gitAPI.cancelRun()).resolves.toMatchObject({ success: true });
     await expect(demoBridge.gitAPI.rerunFailedJobs()).resolves.toMatchObject({ success: true });
     await expect(demoBridge.gitAPI.rerunWorkflow()).resolves.toMatchObject({ success: true });
-    await expect(demoBridge.gitAPI.reset()).resolves.toMatchObject({ success: true, message: 'Branch reset' });
-    await expect(demoBridge.gitAPI.getPinnedRuns()).resolves.toMatchObject({ success: true, runs: [] });
-    await expect(demoBridge.gitAPI.searchRuns()).resolves.toMatchObject({ success: true, runs: [] });
-    await expect(demoBridge.gitAPI.getRunsPage()).resolves.toMatchObject({ success: true, last: true, runs: [] });
+    await expect(demoBridge.gitAPI.reset()).resolves.toMatchObject({ message: 'Branch reset', success: true });
+    await expect(demoBridge.gitAPI.getPinnedRuns()).resolves.toMatchObject({ runs: [], success: true });
+    await expect(demoBridge.gitAPI.searchRuns()).resolves.toMatchObject({ runs: [], success: true });
+    await expect(demoBridge.gitAPI.getRunsPage()).resolves.toMatchObject({ last: true, runs: [], success: true });
   });
 
   it('returns the open pulls for a known project and an empty list for an unknown one', async () => {
@@ -247,10 +247,10 @@ describe('demoBridge settings', () => {
 
 describe('demoBridge worktree', () => {
   it('resolves canned success objects for the worktree mutations', async () => {
-    await expect(demoBridge.worktree.add()).resolves.toMatchObject({ success: true, message: 'Worktree added' });
-    await expect(demoBridge.worktree.pull()).resolves.toMatchObject({ success: true, message: 'Up to date' });
-    await expect(demoBridge.worktree.remove()).resolves.toMatchObject({ success: true, message: 'Worktree removed' });
-    await expect(demoBridge.worktree.getStatus()).resolves.toMatchObject({ success: true, status: { ahead: 0, behind: 0, modified: [] } });
+    await expect(demoBridge.worktree.add()).resolves.toMatchObject({ message: 'Worktree added', success: true });
+    await expect(demoBridge.worktree.pull()).resolves.toMatchObject({ message: 'Up to date', success: true });
+    await expect(demoBridge.worktree.remove()).resolves.toMatchObject({ message: 'Worktree removed', success: true });
+    await expect(demoBridge.worktree.getStatus()).resolves.toMatchObject({ status: { ahead: 0, behind: 0, modified: [] }, success: true });
   });
 
   it('lists worktrees for a known project and an empty list for an unknown one', async () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { cn } from 'renderer/utils/cn';
 
 import { AppNavbar } from './components/AppNavbar';
 import { ClaudeFooter } from './components/ClaudeUsage';
+import { CommandPalette } from './components/CommandPalette';
 import { Routing } from './Routing';
 
 FocusStyleManager.onlyShowFocusOnTabs();
@@ -47,6 +48,7 @@ export const App = () => {
       <AppNavbar />
       <Routing />
       <Modal />
+      <CommandPalette />
       {/* Kept mounted on the Settings route (it reads the route itself) so it
           slides down instead of vanishing. */}
       {claudeEnabled && <ClaudeFooter />}

--- a/src/renderer/components/AppNavbar/AppNavbar.tsx
+++ b/src/renderer/components/AppNavbar/AppNavbar.tsx
@@ -5,9 +5,12 @@ import { NavLink, useLocation } from 'react-router';
 import Devkitty from 'renderer/assets/devkitty.svg?react';
 import { useAppSettings, useIsSunset } from 'renderer/hooks/useAppSettings';
 import { useClaudeUsage } from 'renderer/hooks/useClaudeUsage';
+import { useCommandPalette } from 'renderer/hooks/useCommandPalette';
 import { useDarkMode } from 'renderer/hooks/useDarkMode';
 import { useFilter } from 'renderer/hooks/useFilter';
+import { useFocus } from 'renderer/hooks/useFocus';
 import { useProjects } from 'renderer/hooks/useProjects';
+import { useWorktrees } from 'renderer/hooks/useWorktrees';
 import { appToaster } from 'renderer/utils/appToaster';
 import { cn } from 'renderer/utils/cn';
 import { formatBytes } from 'renderer/utils/formatBytes';
@@ -57,6 +60,7 @@ const ClipboardDownscaleDetail = ({ enabled, last }: { enabled: boolean; last: D
             <div className="flex flex-1 flex-col gap-1 text-xs tabular-nums">
               <div className="flex items-center gap-2">
                 <span className="w-8 shrink-0 text-bp-gray-3">From</span>
+
                 <span className="text-bp-gray-1 dark:text-bp-gray-4">
                   {last.from.width}×{last.from.height} · {formatBytes(last.bytes.from)}
                 </span>
@@ -64,6 +68,7 @@ const ClipboardDownscaleDetail = ({ enabled, last }: { enabled: boolean; last: D
 
               <div className="flex items-center gap-2">
                 <span className="w-8 shrink-0 text-bp-gray-3">To</span>
+
                 <span className="font-medium">
                   {last.to.width}×{last.to.height} · {formatBytes(last.bytes.to)}
                 </span>
@@ -92,8 +97,19 @@ export const AppNavbar = () => {
   const { claudeEnabled, clipboardDownscale, set, showClaudeUsage, showLogo } = useAppSettings();
   const isSunset = useIsSunset();
   const claudeInstalled = useClaudeUsage((s) => s.detection.installed);
-  const { addProject } = useProjects();
-  const { clear, query, setQuery } = useFilter();
+  const { addProject, projects } = useProjects();
+  const { clear } = useFilter();
+  const { clearFocus, focusedProjectId, focusedWorktreePath } = useFocus();
+  const worktreesByProject = useWorktrees((state) => state.byProject);
+  const openPalette = useCommandPalette((state) => state.open);
+  // A focused worktree shows its branch; a focused whole repo shows the repo
+  // name. Fall back to the raw path if the worktree entry is not yet known.
+  const focusedName = focusedWorktreePath
+    ? worktreesByProject[focusedProjectId ?? '']?.find(({ path }) => path === focusedWorktreePath)?.branch ??
+      focusedWorktreePath
+    : focusedProjectId
+      ? projects.find(({ id }) => id === focusedProjectId)?.name
+      : undefined;
   const searchRef = useRef<HTMLInputElement>(null);
   const onHome = useLocation().pathname === '/';
   const [alwaysOnTop, setAlwaysOnTop] = useState(false);
@@ -169,26 +185,20 @@ export const AppNavbar = () => {
     if (!onHome) clear();
   }, [clear, onHome]);
 
-  // ⌘F jumps to the filter, Escape drops it — the shortcuts anything with a
-  // search field is expected to answer to.
+  // ⌘F opens the command palette — the header search box is now a palette
+  // opener, so the search shortcut routes to the same place.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key === 'f') {
         event.preventDefault();
-        searchRef.current?.focus();
-        searchRef.current?.select();
-      }
-
-      if (event.key === 'Escape' && document.activeElement === searchRef.current) {
-        clear();
-        searchRef.current?.blur();
+        openPalette();
       }
     };
 
     document.addEventListener('keydown', onKeyDown);
 
     return () => document.removeEventListener('keydown', onKeyDown);
-  }, [clear]);
+  }, [openPalette]);
 
   const [refreshing, setRefreshing] = useState(false);
 
@@ -241,9 +251,11 @@ export const AppNavbar = () => {
           <div className="flex items-center self-center mr-2">
             <SearchInput
               inputRef={searchRef}
-              onChange={setQuery}
-              onClear={clear}
-              value={query}
+              label={focusedName}
+              onActivate={openPalette}
+              onClear={clearFocus}
+              placeholder="⌘ + K"
+              readOnly
             />
           </div>
         )}

--- a/src/renderer/components/AppNavbar/SearchInput.tsx
+++ b/src/renderer/components/AppNavbar/SearchInput.tsx
@@ -3,65 +3,134 @@ import { type FC, type RefObject } from 'react';
 import { useIsSunset } from 'renderer/hooks/useAppSettings';
 import { cn } from 'renderer/utils/cn';
 
+// Gentle keycap: smaller than the search icon, low-contrast, thin border.
+const kbdClass = (isSunset: boolean) =>
+  cn(
+    'inline-flex items-center justify-center h-[15px] min-w-[15px] px-1 rounded-[4px] border text-[10px] leading-none font-medium',
+    isSunset
+      ? 'border-white/15 bg-white/5 text-black/55 dark:text-white/55'
+      : 'border-bp-light-gray-1 bg-black/[0.03] text-bp-gray-2 dark:border-white/10 dark:bg-white/5 dark:text-white/50'
+  );
+
 type Props = {
   inputRef: RefObject<HTMLInputElement | null>;
-  onChange: (value: string) => void;
-  onClear: () => void;
-  value: string;
+  label?: string;
+  onActivate?: () => void;
+  onChange?: (value: string) => void;
+  onClear?: () => void;
+  placeholder?: string;
+  readOnly?: boolean;
+  value?: string;
 };
 
 // Hand-rolled rather than a Blueprint InputGroup: the navbar wants a compact
 // pill that grows on focus, and every part of that fought the component's own
 // height, border and icon sizing.
-export const SearchInput: FC<Props> = ({ inputRef, onChange, onClear, value }) => {
+export const SearchInput: FC<Props> = ({ inputRef, label, onActivate, onChange, onClear, placeholder = 'Filter…', readOnly, value = '' }) => {
   const isSunset = useIsSunset();
+  // Opener mode: nothing but the centred ⌘K hint. It gets a compact pill with
+  // symmetric padding and no clear button, so the hint sits dead centre.
+  const isOpener = readOnly && !label;
 
   return (
     <div
       className={cn(
-        'group flex items-center h-[26px] gap-1.5 pl-2.5 pr-1 rounded-full box-border',
+        'group flex items-center h-[26px] gap-2 rounded-full box-border',
+        isOpener ? 'px-2' : 'pl-3.5 pr-1.5',
         isSunset
           ? 'backdrop-blur-sm border border-black/10 dark:border-white/15 bg-black/5 dark:bg-white/10 hover:border-black/20 dark:hover:border-white/25 focus-within:border-black/30 dark:focus-within:border-white/40 focus-within:shadow-[0_0_0_3px_rgba(255,255,255,0.12)]'
           : 'border border-bp-light-gray-1 dark:border-bp-dark-gray-4 bg-bp-light-gray-5 dark:bg-bp-dark-gray-2 hover:border-bp-gray-4 dark:hover:border-bp-dark-gray-5 focus-within:border-bp-gray-3 dark:focus-within:border-bp-gray-2 focus-within:shadow-[0_0_0_3px_rgba(143,153,168,0.15)]',
-        'w-[140px] focus-within:w-[220px] transition-all duration-200 ease-out'
+        'transition-all duration-200 ease-out',
+        // A selected worktree name is long, so the pill is wide when it holds a
+        // label; otherwise it stays compact and grows on focus.
+        readOnly ? (label ? 'w-fit max-w-[280px] cursor-pointer' : 'w-[86px] cursor-pointer') : 'w-[140px] focus-within:w-[220px]'
       )}
+      // Opener mode: the pill is a button that opens the command palette.
+      // Use mousedown + preventDefault so the input never takes focus (which
+      // would fight the palette's own focus and loop on close).
+      onMouseDown={
+        readOnly
+          ? (event) => {
+              event.preventDefault();
+              onActivate?.();
+            }
+          : undefined
+      }
     >
-      <Icon
-        className={cn(isSunset ? 'text-bp-gray-2 dark:text-white/50 shrink-0' : 'text-bp-gray-2 dark:text-bp-gray-3 shrink-0')}
-        icon="search"
-        size={12}
-      />
+      {/* Search icon only in the live filter input. The ⌘K opener shows just
+          the centred keycap hint, and a focused repo/worktree shows just its
+          name — no icon in either. */}
+      {!readOnly && (
+        <Icon
+          className={cn(isSunset ? 'text-bp-gray-2 dark:text-white/50 shrink-0' : 'text-bp-gray-2 dark:text-bp-gray-3 shrink-0')}
+          icon="search"
+          size={12}
+        />
+      )}
 
-      <input
-        className={cn(
-          'flex-1 min-w-0 bg-transparent border-none outline-none p-0 text-xs leading-none',
-          isSunset ? 'text-black dark:text-white' : 'text-black dark:text-bp-light-gray-5',
-          isSunset ? 'placeholder:text-bp-gray-2 dark:placeholder:text-white/50' : 'placeholder:text-bp-gray-2 dark:placeholder:text-bp-gray-3'
-        )}
-        onChange={(event) => onChange(event.target.value)}
-        placeholder="Filter…"
-        ref={inputRef}
-        type="text"
-        value={value}
-      />
+      {readOnly ? (
+        label ? (
+          // Focused mode: show the selected repo name in the header pill.
+          <span
+            className={cn(
+              'flex flex-1 items-center min-w-0 text-xs font-medium leading-none pointer-events-none',
+              isSunset ? 'text-black dark:text-white' : 'text-black dark:text-bp-light-gray-5'
+            )}
+          >
+            <span className="truncate">{label}</span>
+          </span>
+        ) : (
+          // Opener mode: ⌘ as a gentle keycap, "+ K" as plain muted text, all
+          // on one vertically-centred line, smaller than the search icon.
+          <span
+            className={cn(
+              'flex flex-1 items-center justify-center gap-1 pointer-events-none text-[10px] leading-none',
+              isSunset ? 'text-bp-gray-2/80 dark:text-white/45' : 'text-bp-gray-2 dark:text-white/45'
+            )}
+          >
+            <kbd className={kbdClass(isSunset)}>⌘</kbd>
+            <span>+ K</span>
+          </span>
+        )
+      ) : (
+        <input
+          className={cn(
+            'flex-1 min-w-0 bg-transparent border-none outline-none p-0 text-xs leading-none',
+            isSunset ? 'text-black dark:text-white' : 'text-black dark:text-bp-light-gray-5',
+            isSunset ? 'placeholder:text-bp-gray-2 dark:placeholder:text-white/50' : 'placeholder:text-bp-gray-2 dark:placeholder:text-bp-gray-3'
+          )}
+          onChange={(event) => onChange?.(event.target.value)}
+          placeholder={placeholder}
+          ref={inputRef}
+          type="text"
+          value={value}
+        />
+      )}
 
-      {/* Holds the slot open so the input does not jump when the button appears. */}
-      <button
-        aria-label="Clear filter"
-        className={cn(
+      {/* Holds the slot open so the input does not jump when the button appears.
+          Omitted in opener mode, which has nothing to clear and must stay
+          compact and centred. */}
+      {!isOpener && (
+        <button
+          aria-label={readOnly ? 'Clear selection' : 'Clear filter'}
+          className={cn(
           'flex items-center justify-center w-[18px] h-[18px] shrink-0 rounded-full',
           'bg-transparent border-none cursor-pointer p-0',
           isSunset ? 'text-bp-gray-2 dark:text-white/60 hover:bg-black/10 dark:hover:bg-white/15' : 'text-bp-gray-2 dark:text-bp-gray-3 hover:bg-bp-light-gray-2 dark:hover:bg-bp-dark-gray-4',
-          !value && 'invisible'
+          !(readOnly ? label : value) && 'invisible'
         )}
-        onClick={onClear}
-        tabIndex={value ? 0 : -1}
-        type="button"
-      >
-        <Icon icon="cross"
-          size={10}
-        />
-      </button>
+          onClick={onClear}
+        // Stop the pill's mousedown-to-open handler so clearing does not also
+        // open the palette.
+          onMouseDown={(event) => event.stopPropagation()}
+          tabIndex={(readOnly ? label : value) ? 0 : -1}
+          type="button"
+        >
+          <Icon icon="cross"
+            size={10}
+          />
+        </button>
+      )}
     </div>
   );
 };

--- a/src/renderer/components/CommandPalette/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,275 @@
+import { Classes, Icon, Menu, MenuDivider, MenuItem } from '@blueprintjs/core';
+import { type IconName } from '@blueprintjs/icons';
+import { Omnibar } from '@blueprintjs/select';
+import { type FC, Fragment, useEffect, useMemo, useState } from 'react';
+import { useIsSunset } from 'renderer/hooks/useAppSettings';
+import { useCommandPalette } from 'renderer/hooks/useCommandPalette';
+import { useDarkMode } from 'renderer/hooks/useDarkMode';
+import { useFocus } from 'renderer/hooks/useFocus';
+import { toEnglishLayout } from 'renderer/utils/keyboardLayout';
+
+import { type CommandItem } from './types';
+import { useCommands } from './useCommands';
+
+// Synthetic tiles shown at the top level of the palette (empty query, no group
+// drilled into): the category tiles, plus a "clear selection" row when a repo
+// or worktree is focused. Section is a free string so these can sit under their
+// own dividers ("Categories", "Selection") ahead of the real command sections.
+type GroupItem = {
+  active?: boolean;
+  closeOnPerform?: boolean;
+  icon?: IconName;
+  id: string;
+  keywords?: string;
+  perform: () => void;
+  section: string;
+  subtitle?: string;
+  title: string;
+};
+
+type PaletteItem = CommandItem | GroupItem;
+
+const CommandOmnibar = Omnibar.ofType<PaletteItem>();
+
+// Fixed display order for the top-level category list; any section not
+// listed here (none exist today, but keeps this future-proof) is appended in
+// first-seen order.
+const SECTION_ORDER: CommandItem['section'][] = [
+  'Appearance',
+  'Integrations',
+  'GitHub',
+  'Projects',
+  'Worktrees',
+  'Navigation',
+];
+
+const SECTION_ICONS: Record<string, IconName> = {
+  Appearance: 'style',
+  GitHub: 'git-repo',
+  Integrations: 'application',
+  Navigation: 'link',
+  Projects: 'projects',
+  Worktrees: 'git-branch',
+};
+
+const buildGroupItems = (allItems: CommandItem[], setGroup: (section: string) => void): GroupItem[] => {
+  const counts = new Map<string, number>();
+  const order: string[] = [];
+
+  allItems.forEach((item) => {
+    counts.set(item.section, (counts.get(item.section) ?? 0) + 1);
+
+    if (!order.includes(item.section)) order.push(item.section);
+  });
+
+  const sections = [
+    ...SECTION_ORDER.filter((section) => counts.has(section)),
+    ...order.filter((section) => !SECTION_ORDER.includes(section as CommandItem['section'])),
+  ];
+
+  return sections.map((section) => {
+    const count = counts.get(section) ?? 0;
+
+    return {
+      closeOnPerform: false,
+      icon: SECTION_ICONS[section] ?? 'folder-close',
+      id: `group-${section}`,
+      perform: () => setGroup(section),
+      section: 'Categories',
+      subtitle: `${count} item${count === 1 ? '' : 's'}`,
+      title: section,
+    };
+  });
+};
+
+const filterCommand = (query: string, item: PaletteItem) => {
+  const normalizedQuery = query.toLowerCase();
+  const haystack = [item.title, item.subtitle, item.keywords, item.section]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  // Also match what the same physical keys type on a US layout, so search works
+  // no matter which keyboard layout is active.
+  return haystack.includes(normalizedQuery) || haystack.includes(toEnglishLayout(normalizedQuery));
+};
+
+export const CommandPalette: FC = () => {
+  const close = useCommandPalette((state) => state.close);
+  const isOpen = useCommandPalette((state) => state.isOpen);
+  const clearFocus = useFocus((state) => state.clearFocus);
+  const focusedProjectId = useFocus((state) => state.focusedProjectId);
+  const allItems = useCommands();
+  const { darkMode } = useDarkMode();
+  const isSunset = useIsSunset();
+  const [query, setQuery] = useState('');
+  const [group, setGroup] = useState<null | string>(null);
+
+  // Start every open with an empty search box and back at the top level.
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('');
+      setGroup(null);
+    }
+  }, [isOpen]);
+
+  // A focused repo/worktree gets a "clear selection" row so the palette can
+  // undo the focus, shown first — above the category tiles.
+  const clearItem: GroupItem = {
+    icon: 'cross',
+    id: 'clear-selection',
+    perform: clearFocus,
+    section: 'Selection',
+    subtitle: 'Show everything',
+    title: 'Clear selection',
+  };
+
+  // Drill-down: an empty query with no group shows the clear row (when focused)
+  // then one synthetic tile per section; picking one narrows to that section;
+  // typing anything searches flat across every item regardless of the group.
+  // Memoised so the array reference only changes when the visible list does —
+  // allItems is already reference-stable, so a background poll that leaves the
+  // list unchanged won't hand Blueprint a new array and snap the highlight back
+  // to the top mid-navigation.
+  const displayItems: PaletteItem[] = useMemo(
+    () =>
+      query.trim() !== ''
+        ? allItems
+        : group !== null
+          ? allItems.filter((item) => item.section === group)
+          : [...(focusedProjectId ? [clearItem] : []), ...buildGroupItems(allItems, setGroup)],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [allItems, focusedProjectId, group, query]
+  );
+
+  // Omnibar portals to document.body, outside the App root that carries the
+  // theme classes, so the theme must be mirrored onto the Omnibar itself or it
+  // renders in the default (light) Blueprint theme.
+  const themeClassName =
+    [darkMode && Classes.DARK, isSunset && 'theme-sunset'].filter(Boolean).join(' ') || undefined;
+
+  // Global ⌘K listener: must work even while another input (e.g. the ⌘F
+  // search field) is focused, so this is a document-level keydown rather than
+  // an input-scoped handler. Read the store via getState() so `toggle` stays
+  // out of the dependency array and the listener is registered exactly once.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        event.preventDefault();
+        useCommandPalette.getState().toggle();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  return (
+    <CommandOmnibar
+      className={themeClassName}
+      inputProps={{
+        onKeyDown: (event) => {
+          if (event.key === 'Backspace' && query === '' && group !== null) {
+            event.preventDefault();
+            setGroup(null);
+          }
+        },
+        placeholder:
+          group !== null && query === '' ? `${group} — Backspace to go back` : 'Search settings and repos…',
+      }}
+      isOpen={isOpen}
+      itemListRenderer={({ filteredItems, itemsParentRef, menuProps, renderItem }) => {
+        if (filteredItems.length === 0) {
+          return (
+            <Menu
+              id={menuProps?.id}
+              ulRef={itemsParentRef}
+            >
+              <MenuItem
+                disabled
+                roleStructure="listoption"
+                text="No results."
+              />
+            </Menu>
+          );
+        }
+
+        const sections: string[] = [];
+        const bySection = new Map<string, { index: number; item: PaletteItem }[]>();
+
+        filteredItems.forEach((item, index) => {
+          if (!bySection.has(item.section)) {
+            bySection.set(item.section, []);
+            sections.push(item.section);
+          }
+
+          bySection.get(item.section)?.push({ index, item });
+        });
+
+        return (
+          <Menu
+            id={menuProps?.id}
+            ulRef={itemsParentRef}
+          >
+            {sections.map((section) => (
+              <Fragment key={section}>
+                <MenuDivider title={section} />
+                {bySection.get(section)?.map(({ index, item }) => renderItem(item, index))}
+              </Fragment>
+            ))}
+          </Menu>
+        );
+      }}
+      itemPredicate={filterCommand}
+      itemRenderer={(item, { handleClick, index, modifiers: { active, disabled } }) => (
+        <MenuItem
+          active={active}
+          disabled={disabled}
+          icon={item.icon}
+          key={item.id ?? index}
+          label={item.subtitle}
+          labelElement={
+            item.active ? (
+              <Icon
+                icon="small-tick"
+                intent="primary"
+              />
+            ) : undefined
+          }
+          onClick={handleClick}
+          roleStructure="listoption"
+          // Blueprint's index-based auto-scroll gets thrown off by the
+          // MenuDivider elements injected between sections, so scroll the
+          // active item into view directly instead of trusting it.
+          text={
+            active ? (
+              <span ref={(el) => el?.scrollIntoView({ block: 'nearest' })}>{item.title}</span>
+            ) : (
+              item.title
+            )
+          }
+        />
+      )}
+      items={displayItems}
+      // Toggling an item rebuilds the list with fresh objects; without an
+      // identity check the active row is no longer reference-equal and the
+      // highlight snaps back to the top. Match by id so it stays put.
+      itemsEqual={(a, b) => a.id === b.id}
+      onClose={close}
+      onItemSelect={(item) => {
+        // The controlled active item can be a stale object from before a toggle
+        // rebuilt the list, whose perform() closes over old state. Re-fetch the
+        // current row by id so the action always runs against live state.
+        const current = displayItems.find(({ id }) => id === item.id) ?? item;
+        current.perform();
+
+        if (current.closeOnPerform !== false) {
+          close();
+        }
+      }}
+      onQueryChange={setQuery}
+      query={query}
+    />
+  );
+};

--- a/src/renderer/components/CommandPalette/index.ts
+++ b/src/renderer/components/CommandPalette/index.ts
@@ -1,0 +1,1 @@
+export { CommandPalette } from './CommandPalette';

--- a/src/renderer/components/CommandPalette/types.ts
+++ b/src/renderer/components/CommandPalette/types.ts
@@ -1,0 +1,13 @@
+import { type IconName } from '@blueprintjs/icons';
+
+export type CommandItem = {
+  active?: boolean;
+  closeOnPerform?: boolean; // default true; toggles pass false to stay open
+  icon?: IconName;
+  id: string;
+  keywords?: string; // extra search text
+  perform: () => void;
+  section: 'Appearance' | 'GitHub' | 'Integrations' | 'Navigation' | 'Projects' | 'Worktrees';
+  subtitle?: string; // current value / file path
+  title: string;
+};

--- a/src/renderer/components/CommandPalette/useCommands.test.ts
+++ b/src/renderer/components/CommandPalette/useCommands.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const navigateMock = vi.fn();
+vi.mock('react-router', () => ({
+  useNavigate: () => navigateMock
+}));
+
+import { useAppSettings } from 'renderer/hooks/useAppSettings';
+import { useCommandPalette } from 'renderer/hooks/useCommandPalette';
+import { useFocus } from 'renderer/hooks/useFocus';
+import { useProjects } from 'renderer/hooks/useProjects';
+import { useWorktrees } from 'renderer/hooks/useWorktrees';
+
+import { useCommands } from './useCommands';
+
+describe('useCommands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useAppSettings.setState({
+      claudeEnabled: true,
+      clipboardDownscale: false,
+      editors: [],
+      gitHubActions: {
+        all: true,
+        count: 5,
+        ignoreDependabot: false,
+        ignoredWorkflows: [],
+        notifications: true,
+        pinnedWorkflows: []
+      },
+      selectedEditor: undefined,
+      selectedShell: undefined,
+      shells: [],
+      showClaudeUsage: false,
+      showLogo: true,
+      showWorktrees: true,
+      theme: 'sunset'
+    });
+
+    useProjects.setState({ projects: [] });
+    useFocus.setState({ focusedProjectId: null, focusedWorktreePath: null });
+    useWorktrees.setState({ byProject: {} });
+    useCommandPalette.setState({ isOpen: true });
+  });
+
+  it('builds one Projects item per project with subtitle and keywords', () => {
+    useProjects.setState({
+      projects: [
+        { filePath: '/path/a', id: '1', name: 'project-a' },
+        { filePath: '/path/b', id: '2', name: 'project-b' }
+      ]
+    });
+
+    const { result } = renderHook(() => useCommands());
+
+    const projectItems = result.current.filter((item) => item.section === 'Projects');
+    expect(projectItems).toHaveLength(2);
+    expect(projectItems[0]).toMatchObject({
+      keywords: 'project-a /path/a',
+      subtitle: '/path/a',
+      title: 'project-a'
+    });
+  });
+
+  it('builds one Worktrees item per worktree with the project name as subtitle', () => {
+    useProjects.setState({ projects: [{ filePath: '/path/a', id: '1', name: 'project-a' }] });
+    useWorktrees.setState({
+      byProject: {
+        '1': [
+          { branch: 'main', isMain: true, path: '/path/a', searchText: 'main' },
+          {
+            branch: 'HERO-10251/affected-entities-fallback',
+            isMain: false,
+            path: '/path/a-wt',
+            searchText: 'HERO-10251/affected-entities-fallback Fix affected entities fallback'
+          }
+        ]
+      }
+    });
+
+    const { result } = renderHook(() => useCommands());
+
+    const worktreeItems = result.current.filter((item) => item.section === 'Worktrees');
+    expect(worktreeItems).toHaveLength(2);
+    expect(worktreeItems[1]).toMatchObject({
+      keywords: 'HERO-10251/affected-entities-fallback Fix affected entities fallback',
+      subtitle: 'project-a',
+      title: 'HERO-10251/affected-entities-fallback'
+    });
+  });
+
+  it('calls setWorktreeFocus and navigates home when a Worktrees item is performed', () => {
+    useProjects.setState({ projects: [{ filePath: '/path/a', id: '1', name: 'project-a' }] });
+    useWorktrees.setState({
+      byProject: { '1': [{ branch: 'main', isMain: true, path: '/path/a', searchText: 'main' }] }
+    });
+
+    const { result } = renderHook(() => useCommands());
+
+    const item = result.current.find((i) => i.id === 'worktree-1-/path/a');
+    item?.perform();
+
+    expect(useFocus.getState().focusedProjectId).toBe('1');
+    expect(useFocus.getState().focusedWorktreePath).toBe('/path/a');
+    expect(navigateMock).toHaveBeenCalledWith('/');
+  });
+
+  it('calls setFocus and navigates home when a Projects item is performed', () => {
+    useProjects.setState({ projects: [{ filePath: '/path/a', id: '1', name: 'project-a' }] });
+
+    const { result } = renderHook(() => useCommands());
+
+    const item = result.current.find((i) => i.id === 'projects-focus-1');
+    item?.perform();
+
+    expect(useFocus.getState().focusedProjectId).toBe('1');
+    expect(navigateMock).toHaveBeenCalledWith('/');
+  });
+
+  it('calls useAppSettings.set with the correct partial for a simple toggle', () => {
+    const { result } = renderHook(() => useCommands());
+
+    const item = result.current.find((i) => i.id === 'appearance-toggle-show-logo');
+    item?.perform();
+
+    expect(window.bridge.settings.set).toHaveBeenCalledWith('appSettings', { showLogo: false }, undefined);
+  });
+
+  it('spreads the whole gitHubActions object when toggling a nested field', () => {
+    const { result } = renderHook(() => useCommands());
+
+    const item = result.current.find((i) => i.id === 'github-toggle-notifications');
+    item?.perform();
+
+    expect(window.bridge.settings.set).toHaveBeenCalledWith(
+      'appSettings',
+      {
+        gitHubActions: {
+          all: true,
+          count: 5,
+          ignoreDependabot: false,
+          ignoredWorkflows: [],
+          notifications: false,
+          pinnedWorkflows: []
+        }
+      },
+      undefined
+    );
+  });
+
+  it('does not clobber sibling gitHubActions fields when toggling ignoreDependabot', () => {
+    const { result } = renderHook(() => useCommands());
+
+    const item = result.current.find((i) => i.id === 'github-toggle-ignore-dependabot');
+    item?.perform();
+
+    expect(window.bridge.settings.set).toHaveBeenCalledWith(
+      'appSettings',
+      expect.objectContaining({
+        gitHubActions: expect.objectContaining({ ignoreDependabot: true, notifications: true })
+      }),
+      undefined
+    );
+  });
+
+  it('calls navigate for navigate items', () => {
+    const { result } = renderHook(() => useCommands());
+
+    const tokenItem = result.current.find((i) => i.id === 'github-navigate-token');
+    tokenItem?.perform();
+    expect(navigateMock).toHaveBeenCalledWith('/settings/integrations');
+
+    const countItem = result.current.find((i) => i.id === 'github-navigate-actions-count');
+    countItem?.perform();
+    expect(navigateMock).toHaveBeenCalledWith('/settings/github');
+
+    const navItem = result.current.find((i) => i.id === 'navigation-settings-appearance');
+    navItem?.perform();
+    expect(navigateMock).toHaveBeenCalledWith('/settings/appearance');
+  });
+
+  it('omits editor and shell items when none are configured', () => {
+    const { result } = renderHook(() => useCommands());
+
+    expect(result.current.some((item) => item.id.startsWith('integrations-select-editor-'))).toBe(false);
+    expect(result.current.some((item) => item.id.startsWith('integrations-select-shell-'))).toBe(false);
+  });
+
+  it('builds a select item per editor and shell', () => {
+    useAppSettings.setState({
+      editors: [{ editor: 'VS Code', path: '/usr/bin/code' }],
+      shells: [{ path: '/bin/zsh', shell: 'zsh' }]
+    });
+
+    const { result } = renderHook(() => useCommands());
+
+    const editorItem = result.current.find((i) => i.id === 'integrations-select-editor-VS Code-0');
+    expect(editorItem).toBeDefined();
+
+    editorItem?.perform();
+    expect(window.bridge.settings.set).toHaveBeenCalledWith(
+      'appSettings',
+      { selectedEditor: { editor: 'VS Code', path: '/usr/bin/code' } },
+      undefined
+    );
+
+    const shellItem = result.current.find((i) => i.id === 'integrations-select-shell-zsh-0');
+    expect(shellItem).toBeDefined();
+  });
+});

--- a/src/renderer/components/CommandPalette/useCommands.ts
+++ b/src/renderer/components/CommandPalette/useCommands.ts
@@ -1,0 +1,257 @@
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router';
+import { useAppSettings } from 'renderer/hooks/useAppSettings';
+import { useCommandPalette } from 'renderer/hooks/useCommandPalette';
+import { useDarkMode } from 'renderer/hooks/useDarkMode';
+import { useFocus } from 'renderer/hooks/useFocus';
+import { useProjects } from 'renderer/hooks/useProjects';
+import { useWorktrees } from 'renderer/hooks/useWorktrees';
+import { type ThemeSource } from 'types/Modal';
+
+import { type CommandItem } from './types';
+
+export const useCommands = (): CommandItem[] => {
+  const isOpen = useCommandPalette((state) => state.isOpen);
+  const {
+    claudeEnabled,
+    clipboardDownscale,
+    editors,
+    gitHubActions,
+    selectedEditor,
+    selectedShell,
+    set,
+    shells,
+    showClaudeUsage,
+    showLogo,
+    showWorktrees,
+    theme
+  } = useAppSettings();
+  const { setTheme, themeSource } = useDarkMode();
+  const { projects } = useProjects();
+  const { setFocus, setWorktreeFocus } = useFocus();
+  const { byProject } = useWorktrees();
+  const navigate = useNavigate();
+
+  const appearanceThemeItems: CommandItem[] = [
+    {
+      active: theme === 'default',
+      closeOnPerform: false,
+      icon: 'style',
+      id: 'appearance-theme-default',
+      perform: () => set({ theme: 'default' }),
+      section: 'Appearance',
+      title: 'Theme: Default'
+    },
+    {
+      active: theme === 'sunset',
+      closeOnPerform: false,
+      icon: 'style',
+      id: 'appearance-theme-sunset',
+      perform: () => set({ theme: 'sunset' }),
+      section: 'Appearance',
+      title: 'Theme: Sunset'
+    }
+  ];
+
+  const appearanceSourceItems: CommandItem[] = (['system', 'light', 'dark'] as ThemeSource[]).map((source) => ({
+    active: themeSource === source,
+    closeOnPerform: false,
+    icon: 'contrast',
+    id: `appearance-source-${source}`,
+    perform: () => setTheme(source),
+    section: 'Appearance',
+    title: `Appearance: ${source.charAt(0).toUpperCase()}${source.slice(1)}`
+  }));
+
+  const appearanceToggleItems: CommandItem[] = [
+    {
+      active: showWorktrees,
+      closeOnPerform: false,
+      icon: 'diagram-tree',
+      id: 'appearance-toggle-show-worktrees',
+      perform: () => set({ showWorktrees: !showWorktrees }),
+      section: 'Appearance',
+      title: 'Toggle Show worktrees'
+    },
+    {
+      active: showLogo,
+      closeOnPerform: false,
+      icon: 'media',
+      id: 'appearance-toggle-show-logo',
+      perform: () => set({ showLogo: !showLogo }),
+      section: 'Appearance',
+      title: 'Toggle Show logo'
+    }
+  ];
+
+  const integrationToggleItems: CommandItem[] = [
+    {
+      active: claudeEnabled,
+      closeOnPerform: false,
+      icon: 'code',
+      id: 'integrations-toggle-claude-enabled',
+      perform: () => set({ claudeEnabled: !claudeEnabled }),
+      section: 'Integrations',
+      title: 'Toggle Claude integration'
+    },
+    {
+      active: showClaudeUsage,
+      closeOnPerform: false,
+      icon: 'timeline-bar-chart',
+      id: 'integrations-toggle-claude-usage',
+      perform: () => set({ showClaudeUsage: !showClaudeUsage }),
+      section: 'Integrations',
+      title: 'Toggle Claude usage footer'
+    },
+    {
+      active: clipboardDownscale,
+      closeOnPerform: false,
+      icon: 'clipboard',
+      id: 'integrations-toggle-clipboard-downscale',
+      perform: () => set({ clipboardDownscale: !clipboardDownscale }),
+      section: 'Integrations',
+      title: 'Toggle Clipboard downscale'
+    }
+  ];
+
+  const editorItems: CommandItem[] = editors.map((editor, index) => ({
+    active: selectedEditor?.editor === editor.editor,
+    closeOnPerform: false,
+    icon: 'application',
+    id: `integrations-select-editor-${editor.editor}-${index}`,
+    perform: () => set({ selectedEditor: editor }),
+    section: 'Integrations',
+    title: `Select editor: ${editor.editor}`
+  }));
+
+  const shellItems: CommandItem[] = shells.map((shell, index) => ({
+    active: selectedShell?.shell === shell.shell,
+    closeOnPerform: false,
+    icon: 'console',
+    id: `integrations-select-shell-${shell.shell}-${index}`,
+    perform: () => set({ selectedShell: shell }),
+    section: 'Integrations',
+    title: `Select shell: ${shell.shell}`
+  }));
+
+  const gitHubToggleItems: CommandItem[] = [
+    {
+      active: gitHubActions.notifications,
+      closeOnPerform: false,
+      icon: 'notifications',
+      id: 'github-toggle-notifications',
+      perform: () => set({ gitHubActions: { ...gitHubActions, notifications: !gitHubActions.notifications } }),
+      section: 'GitHub',
+      title: 'Toggle GitHub Actions notifications'
+    },
+    {
+      active: gitHubActions.ignoreDependabot,
+      closeOnPerform: false,
+      icon: 'filter',
+      id: 'github-toggle-ignore-dependabot',
+      perform: () =>
+        set({ gitHubActions: { ...gitHubActions, ignoreDependabot: !gitHubActions.ignoreDependabot } }),
+      section: 'GitHub',
+      title: 'Toggle Ignore Dependabot'
+    }
+  ];
+
+  const gitHubNavigateItems: CommandItem[] = [
+    {
+      icon: 'numerical',
+      id: 'github-navigate-actions-count',
+      perform: () => navigate('/settings/github'),
+      section: 'GitHub',
+      title: 'Actions count…'
+    },
+    {
+      icon: 'key',
+      id: 'github-navigate-token',
+      perform: () => navigate('/settings/integrations'),
+      section: 'GitHub',
+      title: 'GitHub token…'
+    }
+  ];
+
+  const projectItems: CommandItem[] = projects.map((project) => ({
+    icon: 'git-repo',
+    id: `projects-focus-${project.id}`,
+    keywords: `${project.name} ${project.filePath}`,
+    perform: () => {
+      setFocus(project.id);
+      navigate('/');
+    },
+    section: 'Projects',
+    subtitle: project.filePath,
+    title: project.name
+  }));
+
+  const worktreeItems: CommandItem[] = projects.flatMap((project) =>
+    (byProject[project.id] ?? []).map((worktree) => ({
+      icon: 'git-branch' as const,
+      id: `worktree-${project.id}-${worktree.path}`,
+      keywords: worktree.searchText,
+      perform: () => {
+        setWorktreeFocus(project.id, worktree.path);
+        navigate('/');
+      },
+      section: 'Worktrees' as const,
+      subtitle: project.name,
+      title: worktree.branch
+    }))
+  );
+
+  const navigationItems: CommandItem[] = [
+    {
+      icon: 'cog',
+      id: 'navigation-settings-appearance',
+      perform: () => navigate('/settings/appearance'),
+      section: 'Navigation',
+      title: 'Open Settings › Appearance'
+    },
+    {
+      icon: 'cog',
+      id: 'navigation-settings-integrations',
+      perform: () => navigate('/settings/integrations'),
+      section: 'Navigation',
+      title: 'Open Settings › Integrations'
+    },
+    {
+      icon: 'cog',
+      id: 'navigation-settings-github',
+      perform: () => navigate('/settings/github'),
+      section: 'Navigation',
+      title: 'Open Settings › GitHub'
+    }
+  ];
+
+  const items: CommandItem[] = isOpen
+    ? [
+        ...appearanceThemeItems,
+        ...appearanceSourceItems,
+        ...appearanceToggleItems,
+        ...integrationToggleItems,
+        ...editorItems,
+        ...shellItems,
+        ...gitHubToggleItems,
+        ...gitHubNavigateItems,
+        ...projectItems,
+        ...worktreeItems,
+        ...navigationItems
+      ]
+    : [];
+
+  // Keep the array REFERENCE stable across renders that don't change what the
+  // list shows. Background git polls tick the project/worktree stores every few
+  // seconds, re-running this hook; a fresh array each time makes Blueprint's
+  // QueryList reset its highlight to the first row (it re-filters whenever the
+  // `items` prop identity changes), which snaps the keyboard selection back to
+  // the top mid-navigation. Rebuild only when the visible content — ids, titles,
+  // subtitles, and the active tick — actually changes.
+  const signature = items
+    .map((item) => `${item.id}:${item.active ? 1 : 0}:${item.title}:${item.subtitle ?? ''}`)
+    .join('|');
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => items, [signature]);
+};

--- a/src/renderer/components/GroupCollapse/GroupCollapse.tsx
+++ b/src/renderer/components/GroupCollapse/GroupCollapse.tsx
@@ -154,7 +154,6 @@ export const GroupCollapse: FC<Props> = ({ collapsed, group, index, onClick, pro
         >
           <div className={Classes.ALIGN_LEFT}>
             <Icon icon={group.icon ?? 'folder-open'} />{' '}
-
             <span>{group.fullName}</span>
           </div>
 

--- a/src/renderer/components/Project/Project.tsx
+++ b/src/renderer/components/Project/Project.tsx
@@ -2,9 +2,11 @@ import { Button, ButtonGroup, Classes, Collapse, Popover } from '@blueprintjs/co
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppSettings } from 'renderer/hooks/useAppSettings';
 import { useFilter } from 'renderer/hooks/useFilter';
+import { useFocus } from 'renderer/hooks/useFocus';
 import { useGit } from 'renderer/hooks/useGit';
 import { useModal } from 'renderer/hooks/useModal';
 import { useMountEffect } from 'renderer/hooks/useMountEffect';
+import { useWorktrees, type WorktreeEntry } from 'renderer/hooks/useWorktrees';
 import { cn } from 'renderer/utils/cn';
 import { filterGroups, filterWorktrees, matchesQuery, worktreeHaystack } from 'renderer/utils/filter';
 import { type Project as IProject } from 'types/project';
@@ -40,6 +42,7 @@ export const Project: FC<Props> = ({ project }) => {
   const { gitHubToken, showWorktrees: showWorktreesDefault } = useAppSettings();
   const { openModal } = useModal();
   const { query } = useFilter();
+  const { focusedProjectId, focusedWorktreePath } = useFocus();
 
   const { filePath, groupId, id, name } = project;
 
@@ -85,6 +88,25 @@ export const Project: FC<Props> = ({ project }) => {
     runsByBranch,
     runsLoaded
   } = useRepoData(project, anyExpanded, worktreeBranches, mainBranch, query);
+
+  // Publish this card's worktrees to the shared, app-wide store so the
+  // command palette (which never fetches git status itself) can list them —
+  // findable by branch, run name, and pull request title.
+  useEffect(() => {
+    const entries: WorktreeEntry[] = worktrees.map((worktree) => {
+      const searchText = [
+        worktree.branch,
+        ...(runsByBranch[worktree.branch] ?? []).map((run) => run.name ?? ''),
+        ...(pullsByBranch[worktree.branch] ?? []).map(({ pull }) => pull.title ?? '')
+      ]
+        .filter(Boolean)
+        .join(' ');
+
+      return { ...worktree, searchText };
+    });
+
+    useWorktrees.getState().setWorktrees(id, entries);
+  }, [id, pullsByBranch, runsByBranch, worktrees]);
 
   // Worktrees arrive asynchronously — seed each new card from its saved state,
   // defaulting to open when the checkout has an open pull request.
@@ -240,6 +262,20 @@ export const Project: FC<Props> = ({ project }) => {
   const mergedWorktrees = showWorktrees
     ? sortedWorktrees.filter((worktree) => !worktree.isMain && isCheckoutDone(pullsByBranch[worktree.branch]))
     : [];
+
+  // Worktree focus mode (from the command palette): narrow this project's
+  // checkouts down to the one focused worktree. A focused path that matches
+  // nothing here (branch removed, worktree gone) falls back to showing them all.
+  const isWorktreeFocused =
+    focusedProjectId === id &&
+    Boolean(focusedWorktreePath) &&
+    sortedWorktrees.some((worktree) => worktree.path === focusedWorktreePath);
+  const applyWorktreeFocus = (list: Worktree[]) =>
+    isWorktreeFocused ? list.filter((worktree) => worktree.path === focusedWorktreePath) : list;
+
+  const focusedLiveWorktrees = applyWorktreeFocus(liveWorktrees);
+  const focusedMergedWorktrees = applyWorktreeFocus(mergedWorktrees);
+
   const behind = gitStatus?.status?.behind ?? 0;
 
   // Nothing in this repo answers the filter — drop it out of the list.
@@ -257,7 +293,9 @@ export const Project: FC<Props> = ({ project }) => {
   const renderCheckout = (worktree: Worktree) => (
     <CheckoutCard
       done={isCheckoutDone(pullsByBranch[worktree.branch])}
-      expanded={Boolean(expandedPaths[worktree.path])}
+      // Picking a worktree from ⌘K opens it — its contents (or the empty-state)
+      // are the whole point of focusing it, so it never shows as a bare header.
+      expanded={isWorktreeFocused || Boolean(expandedPaths[worktree.path])}
       gitStatus={worktree.isMain ? gitStatus : undefined}
       groups={groupsFor(worktree)}
       hiddenRuns={hiddenRunsByBranch[worktree.branch] ?? []}
@@ -281,6 +319,7 @@ export const Project: FC<Props> = ({ project }) => {
       onToggleExpanded={() => toggleExpanded(worktree.path)}
       project={project}
       runsLoaded={runsLoaded}
+      solo={isWorktreeFocused}
       trailing={
           worktree.isMain ? (
             <div className={cn('flex items-center gap-2.5', !gitStatus && Classes.SKELETON)}>
@@ -353,18 +392,27 @@ export const Project: FC<Props> = ({ project }) => {
         </div>
       )}
 
-      {liveWorktrees.map(renderCheckout)}
+      {focusedLiveWorktrees.map(renderCheckout)}
 
-      {mergedWorktrees.length > 0 && (
-        <FoldDivider
-          className="px-6"
-          icon="git-merge"
-          label="Merged worktrees"
-          onToggle={() => setShowMerged((prev) => !prev)}
-        />
+      {/* Focus mode is a filter: you asked for this one worktree, so show it
+          directly even when merged — no collapsed fold to hide it behind. The
+          fold (with its toggle) only makes sense in the full, unfiltered list. */}
+      {isWorktreeFocused ? (
+        focusedMergedWorktrees.map(renderCheckout)
+      ) : (
+        <>
+          {focusedMergedWorktrees.length > 0 && (
+            <FoldDivider
+              className="px-6"
+              icon="git-merge"
+              label="Merged worktrees"
+              onToggle={() => setShowMerged((prev) => !prev)}
+            />
+          )}
+
+          <Collapse isOpen={showMerged}>{focusedMergedWorktrees.map(renderCheckout)}</Collapse>
+        </>
       )}
-
-      <Collapse isOpen={showMerged}>{mergedWorktrees.map(renderCheckout)}</Collapse>
     </>
   );
 };

--- a/src/renderer/components/Project/components/CheckoutCard/CheckoutCard.tsx
+++ b/src/renderer/components/Project/components/CheckoutCard/CheckoutCard.tsx
@@ -41,6 +41,9 @@ type Props = {
   onToggleExpanded: () => void;
   project: Project;
   runsLoaded: boolean;
+  // Shown on its own (worktree focus mode) with no main header above it, so it
+  // pins to the very top instead of leaving a gap for a header that isn't there.
+  solo?: boolean;
   trailing?: ReactNode;
   worktree: Worktree;
 };
@@ -60,6 +63,7 @@ export const CheckoutCard: FC<Props> = ({
   onToggleExpanded,
   project,
   runsLoaded,
+  solo,
   trailing,
   worktree
 }) => {
@@ -245,7 +249,7 @@ export const CheckoutCard: FC<Props> = ({
           isSunset ? 'dk-sunset-sticky' : 'bg-bp-light-gray-4 dark:bg-bp-dark-gray-2',
           // The main checkout IS the repo header, so it is taller and pins to
           // the top; worktrees pin just beneath it while their contents scroll.
-          isMain ? 'h-[55px] sticky top-0 z-20' : 'h-[45px] sticky top-[55px] z-10',
+          isMain ? 'h-[55px] sticky top-0 z-20' : solo ? 'h-[45px] sticky top-0 z-20' : 'h-[45px] sticky top-[55px] z-10',
           expanded && 'shadow-[0_2px_6px_-1px_rgba(0,0,0,0.20)] dark:shadow-[0_2px_6px_-1px_rgba(0,0,0,0.6)]',
           deleting && 'opacity-50 pointer-events-none'
         )}
@@ -440,7 +444,7 @@ export const CheckoutCard: FC<Props> = ({
                 onRefresh={onRefresh}
                 project={project}
                 runs={hiddenRuns}
-                stickyTop={isMain ? 55 : 100}
+                stickyTop={isMain ? 55 : solo ? 45 : 100}
               />
             </div>
           )}

--- a/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
+++ b/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
@@ -18,9 +18,9 @@ type Check = {
 };
 
 type ChecksResult = Awaited<ReturnType<typeof window.bridge.gitAPI.getPRChecks>>;
-type MutationResult = { message?: string; success: boolean };
-
 type MergeMethod = 'merge' | 'rebase' | 'squash';
+
+type MutationResult = { message?: string; success: boolean };
 
 type Props = {
   onHide?: (pullId: number, label: string) => void;

--- a/src/renderer/components/Projects/Projects.tsx
+++ b/src/renderer/components/Projects/Projects.tsx
@@ -1,6 +1,7 @@
 import { Button, NonIdealState } from '@blueprintjs/core';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import Devkitty from 'renderer/assets/devkitty.svg?react';
+import { useFocus } from 'renderer/hooks/useFocus';
 import { useGroups } from 'renderer/hooks/useGroups';
 import { useProjects } from 'renderer/hooks/useProjects';
 import { type Group } from 'types/Group';
@@ -13,15 +14,40 @@ const others: Group = { fullName: 'Ungrouped', icon: 'folder-open', id: 'ungroup
 export const Projects = () => {
   const { collapsedGroups, groupIds, groups, toggleCollapsed } = useGroups();
   const { addProject, projects } = useProjects();
+  const { clearFocus, focusedProjectId } = useFocus();
+
+  const focusedProject = focusedProjectId ? projects.find(({ id }) => id === focusedProjectId) : undefined;
+
+  // Escape drops focus mode — but only when nothing else (e.g. the ⌘F filter) has focus.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const tag = document.activeElement?.tagName;
+
+      if (event.key === 'Escape' && tag !== 'INPUT' && tag !== 'TEXTAREA' && focusedProjectId) {
+        clearFocus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [clearFocus, focusedProjectId]);
+
+  // The focused repo may have been removed since focus was set — fall back to the full list.
+  useEffect(() => {
+    if (focusedProjectId && !focusedProject) clearFocus();
+  }, [clearFocus, focusedProject, focusedProjectId]);
+
+  const visibleProjects = focusedProjectId ? projects.filter(({ id }) => id === focusedProjectId) : projects;
 
   const sortedProjects = useMemo(() => [...groups, others].map((group) => ({
       ...group,
-      projects: projects.filter(
+      projects: visibleProjects.filter(
         ({ groupId }) => groupId === group.id || (group.id === 'ungrouped' && (!groupId || !groupIds.includes(groupId)))
       )
-    })), [groupIds, groups, projects]);
+    })), [groupIds, groups, visibleProjects]);
 
-  const withGroups = groups.length > 0 && projects.length > 0 && sortedProjects.length > 1;
+  const withGroups = !focusedProjectId && groups.length > 0 && projects.length > 0 && sortedProjects.length > 1;
 
   return (
     <div className="flex relative flex-col h-[calc(100vh-50px-var(--claude-footer-h))]">
@@ -43,7 +69,7 @@ export const Projects = () => {
         )}
 
         {!withGroups &&
-          projects.map((project) => (
+          visibleProjects.map((project) => (
             <Project
               key={project.id}
               project={project}

--- a/src/renderer/components/SettingsAppearance/SettingsAppearance.tsx
+++ b/src/renderer/components/SettingsAppearance/SettingsAppearance.tsx
@@ -15,9 +15,7 @@ export const SettingsAppearance = () => {
       <ThemeSelector />
       <Divider className="my-6!" />
       <h3 className="text-sm font-semibold mt-4 mb-2.5">Style</h3>
-
       <StyleSelector />
-
       <Divider className="my-6!" />
       <h3 className="text-sm font-semibold mt-4 mb-2.5">Git</h3>
 

--- a/src/renderer/hooks/useCommandPalette.ts
+++ b/src/renderer/hooks/useCommandPalette.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+type CommandPaletteStore = {
+  close: () => void;
+  isOpen: boolean;
+  open: () => void;
+  toggle: () => void;
+};
+
+// Global ⌘K command palette visibility. Ephemeral, not persisted.
+export const useCommandPalette = create<CommandPaletteStore>((set) => ({
+  close: () => set({ isOpen: false }),
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  toggle: () => set((state) => ({ isOpen: !state.isOpen }))
+}));

--- a/src/renderer/hooks/useFocus.test.ts
+++ b/src/renderer/hooks/useFocus.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useFocus } from './useFocus';
+
+describe('useFocus', () => {
+  beforeEach(() => {
+    useFocus.setState({ focusedProjectId: null, focusedWorktreePath: null });
+  });
+
+  it('should start with no focused project or worktree', () => {
+    expect(useFocus.getState().focusedProjectId).toBe(null);
+    expect(useFocus.getState().focusedWorktreePath).toBe(null);
+  });
+
+  it('should set the focused project when setFocus is called', () => {
+    useFocus.getState().setFocus('foo');
+
+    expect(useFocus.getState().focusedProjectId).toBe('foo');
+  });
+
+  it('should clear the focused worktree when setFocus is called', () => {
+    useFocus.getState().setWorktreeFocus('foo', '/path/a');
+
+    useFocus.getState().setFocus('foo');
+
+    expect(useFocus.getState().focusedProjectId).toBe('foo');
+    expect(useFocus.getState().focusedWorktreePath).toBe(null);
+  });
+
+  it('should set both the focused project and worktree when setWorktreeFocus is called', () => {
+    useFocus.getState().setWorktreeFocus('foo', '/path/a');
+
+    expect(useFocus.getState().focusedProjectId).toBe('foo');
+    expect(useFocus.getState().focusedWorktreePath).toBe('/path/a');
+  });
+
+  it('should reset the focused project and worktree to null when clearFocus is called', () => {
+    useFocus.getState().setWorktreeFocus('foo', '/path/a');
+
+    useFocus.getState().clearFocus();
+
+    expect(useFocus.getState().focusedProjectId).toBe(null);
+    expect(useFocus.getState().focusedWorktreePath).toBe(null);
+  });
+});

--- a/src/renderer/hooks/useFocus.ts
+++ b/src/renderer/hooks/useFocus.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+
+type FocusStore = {
+  clearFocus: () => void;
+  focusedProjectId: null | string;
+  focusedWorktreePath: null | string;
+  setFocus: (id: string) => void;
+  setWorktreeFocus: (projectId: string, worktreePath: string) => void;
+};
+
+// Focus mode: narrows the main list to a single project, and optionally to a
+// single worktree within it. Ephemeral, not persisted.
+export const useFocus = create<FocusStore>((set) => ({
+  clearFocus: () => set({ focusedProjectId: null, focusedWorktreePath: null }),
+  focusedProjectId: null,
+  focusedWorktreePath: null,
+  setFocus: (id) => set({ focusedProjectId: id, focusedWorktreePath: null }),
+  setWorktreeFocus: (projectId, worktreePath) =>
+    set({ focusedProjectId: projectId, focusedWorktreePath: worktreePath })
+}));

--- a/src/renderer/hooks/useWorktrees.test.ts
+++ b/src/renderer/hooks/useWorktrees.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useWorktrees } from './useWorktrees';
+
+describe('useWorktrees', () => {
+  beforeEach(() => {
+    useWorktrees.setState({ byProject: {} });
+  });
+
+  it('should start with no worktrees', () => {
+    expect(useWorktrees.getState().byProject).toEqual({});
+  });
+
+  it('should set the worktrees for a project', () => {
+    const worktrees = [{ branch: 'main', isMain: true, path: '/path/a', searchText: 'main' }];
+
+    useWorktrees.getState().setWorktrees('1', worktrees);
+
+    expect(useWorktrees.getState().byProject).toEqual({ '1': worktrees });
+  });
+
+  it('should not clobber other projects when setting one project', () => {
+    useWorktrees
+      .getState()
+      .setWorktrees('1', [{ branch: 'main', isMain: true, path: '/path/a', searchText: 'main' }]);
+    useWorktrees
+      .getState()
+      .setWorktrees('2', [{ branch: 'main', isMain: true, path: '/path/b', searchText: 'main' }]);
+
+    expect(Object.keys(useWorktrees.getState().byProject)).toEqual(['1', '2']);
+  });
+
+  it('should overwrite a project`s previous worktrees', () => {
+    useWorktrees
+      .getState()
+      .setWorktrees('1', [{ branch: 'main', isMain: true, path: '/path/a', searchText: 'main' }]);
+    useWorktrees
+      .getState()
+      .setWorktrees('1', [{ branch: 'feature', isMain: false, path: '/path/b', searchText: 'feature' }]);
+
+    expect(useWorktrees.getState().byProject['1']).toEqual([
+      { branch: 'feature', isMain: false, path: '/path/b', searchText: 'feature' }
+    ]);
+  });
+});

--- a/src/renderer/hooks/useWorktrees.ts
+++ b/src/renderer/hooks/useWorktrees.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+
+export type WorktreeEntry = {
+  branch: string;
+  isMain: boolean;
+  path: string;
+  // Everything the command palette should be able to find this worktree by:
+  // its branch, its runs' names, and its pull requests' titles, pre-joined so
+  // the palette never has to know about runs/pulls itself.
+  searchText: string;
+};
+
+type WorktreesStore = {
+  byProject: Record<string, WorktreeEntry[]>;
+  setWorktrees: (projectId: string, worktrees: WorktreeEntry[]) => void;
+};
+
+// Shared, app-wide view of each project's worktrees. Each Project card owns
+// its own git polling and pushes its results in here so the command palette
+// (which never fetches git status itself) can list every worktree.
+export const useWorktrees = create<WorktreesStore>((set) => ({
+  byProject: {},
+  setWorktrees: (projectId, worktrees) =>
+    set((state) => ({ byProject: { ...state.byProject, [projectId]: worktrees } }))
+}));

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1,6 +1,7 @@
 @import 'normalize.css';
 @import '@blueprintjs/core/lib/css/blueprint.css';
 @import '@blueprintjs/icons/lib/css/blueprint-icons.css';
+@import '@blueprintjs/select/lib/css/blueprint-select.css';
 @import 'tailwindcss';
 
 /* Configure dark mode to use class selector */
@@ -406,6 +407,29 @@
 .theme-sunset .dark .bp6-menu-item:hover,
 .theme-sunset .bp6-dark .bp6-menu-item:hover {
   background-color: rgba(255, 255, 255, 0.09) !important;
+}
+
+/* Command palette (Omnibar) — unify the search header with the results list.
+   The results already pick up the theme via .bp6-menu above, but the input kept
+   Blueprint's default grey, reading as a disconnected bar. Make the input blend
+   into one continuous palette surface. */
+.bp6-dark .bp6-omnibar .bp6-input,
+.bp6-dark.bp6-omnibar .bp6-input {
+  background: transparent !important;
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.08) !important;
+}
+.theme-sunset .dark .bp6-omnibar,
+.theme-sunset .bp6-dark .bp6-omnibar,
+.theme-sunset .bp6-dark.bp6-omnibar {
+  background-color: #2a1230 !important;
+  background-image: linear-gradient(160deg, rgba(77, 20, 16, 0.96) 0%, rgba(54, 15, 54, 0.97) 52%, rgba(36, 16, 63, 0.98) 100%) !important;
+}
+.theme-sunset .dark .bp6-omnibar .bp6-menu,
+.theme-sunset .bp6-dark .bp6-omnibar .bp6-menu,
+.theme-sunset .bp6-dark.bp6-omnibar .bp6-menu {
+  background: transparent !important;
+  background-image: none !important;
+  box-shadow: none !important;
 }
 
 /* Sunset toasts — the default Blueprint intent colours (orange warning, red

--- a/src/renderer/utils/keyboardLayout.ts
+++ b/src/renderer/utils/keyboardLayout.ts
@@ -1,0 +1,18 @@
+// Search shouldn't care which keyboard layout is active. When someone types on
+// a non-Latin layout (Russian today), each character is mapped back to the
+// Latin letter on the SAME physical key, so "рудз" matches "help". The two
+// strings below are the QWERTY key positions in the same order — extend both to
+// add another layout.
+const RU = 'йцукенгшщзхъфывапролджэячсмитьбюё';
+const EN = "qwertyuiop[]asdfghjkl;'zxcvbnm,.`";
+
+const layoutToQwerty: Record<string, string> = Object.fromEntries(
+  Array.from(RU).map((char, index) => [char, EN.charAt(index)])
+);
+
+// Rewrites text as if the same physical keys were pressed on a US-QWERTY
+// layout. Latin characters (and anything unmapped) pass through unchanged.
+export const toEnglishLayout = (text: string): string =>
+  Array.from(text.toLowerCase())
+    .map((char) => layoutToQwerty[char] ?? char)
+    .join('');


### PR DESCRIPTION
## What

- **⌘K command palette** (Blueprint Omnibar) to jump to settings, repos, and worktrees.
  - Layout-independent search — typing on a non-Latin keyboard still matches (same physical keys).
  - Header opener pill: compact centered **⌘ + K**, no search icon.
- **Focus a repo/worktree** from the palette; the header pill shows the selected branch name and hugs its width.
- **Worktree card polish**: a focused worktree expands (shows content or empty state); merged worktrees render uncollapsed with no toggle in filter mode; removed the sticky gap above a solo worktree.
- **Palette stability fix**: the command list keeps a stable reference across background git polls, so keyboard navigation no longer snaps back to the top mid-scroll.
- **Git pull fix**: per-repo lock serializes fetch/pull so a pull no longer fails with *"Cannot fast-forward to multiple branches."*
- Misc lint/formatting cleanups across touched files.

## Testing

- `vitest run` on touched areas: **108 tests pass** (hooks, command palette, and all touched main-process test files).
- Scoped ESLint on changed files: no new lint issues (6 pre-existing `no-explicit-any` in `ipcNotification.test.ts` predate this branch, left out of scope).
- Manual: ⌘K open/close, search, focus/clear, arrow navigation during a poll, header pill in light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)