### PR TITLE
feat: opt-out GA4 telemetry via Measurement Protocol

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# GA4 Measurement Protocol API secret (keep this out of version control).
+MAIN_VITE_GA_API_SECRET=
+
+# Set to 'true' to force-enable telemetry sending and route events to the
+# GA4 debug endpoint (validate in GA DebugView) regardless of the telemetry setting.
+MAIN_VITE_GA_DEBUG=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CERTIFICATE_OSX_APPLICATION: ${{ secrets.CERTIFICATE_OSX_APPLICATION }}
           CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
+          MAIN_VITE_GA_API_SECRET: ${{ secrets.MAIN_VITE_GA_API_SECRET }}
 
       - name: Make (dry run)
         if: github.event.inputs.dry_run == 'true'

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'node:crypto';
+
+import { app } from 'electron';
+import log from 'electron-log';
+
+import { settings } from './settings';
+
+const MEASUREMENT_ID = 'G-KVS84N7CDJ';
+const COLLECT_URL = 'https://www.google-analytics.com/mp/collect';
+const DEBUG_COLLECT_URL = 'https://www.google-analytics.com/debug/mp/collect';
+
+// One session_id per app run.
+const sessionId = String(Date.now());
+
+const getClientId = (): string => {
+  const existing = settings.get('clientId');
+  if (existing) return existing;
+
+  const clientId = randomUUID();
+  settings.set('clientId', clientId);
+  return clientId;
+};
+
+export const track = async (name: string, params?: Record<string, unknown>): Promise<void> => {
+  try {
+    const apiSecret = import.meta.env.MAIN_VITE_GA_API_SECRET;
+    if (!apiSecret) return;
+
+    const debug = import.meta.env.MAIN_VITE_GA_DEBUG === 'true';
+    const enabled = debug || settings.get('appSettings')?.telemetry !== false;
+    if (!enabled) return;
+
+    const clientId = getClientId();
+    const url = debug ? DEBUG_COLLECT_URL : COLLECT_URL;
+
+    const collectUrl = `${url}?measurement_id=${MEASUREMENT_ID}&api_secret=${encodeURIComponent(apiSecret)}`;
+    const response = await fetch(collectUrl, {
+      body: JSON.stringify({
+        client_id: clientId,
+        events: [
+          {
+            name,
+            params: {
+              app_version: app.getVersion(),
+              engagement_time_msec: '100',
+              session_id: sessionId,
+              ...params
+            }
+          }
+        ]
+      }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST'
+    });
+
+    if (debug) {
+      log.info('[analytics] GA4 debug response:', await response.text());
+    }
+  } catch (error) {
+    log.error('[analytics] failed to send event', error);
+  }
+};

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import { fixPath } from './libs/fixPath';
 
 fixPath();
 
+import { track } from './analytics';
 import './ipcs';
 import { initClipboardDownscale, stopClipboardWatcher } from './libs/clipboardDownscale';
 import { updateEditorsAndShells } from './libs/integrations/integrations';
@@ -80,6 +81,7 @@ app.on('ready', async () => {
 
   createWindow();
   initClipboardDownscale();
+  void track('app_launch');
 });
 
 app.on('will-quit', () => stopClipboardWatcher());

--- a/src/main/ipcs/index.ts
+++ b/src/main/ipcs/index.ts
@@ -1,3 +1,4 @@
+import './ipcAnalytics';
 import './ipcDarkMode';
 import './ipcSettings';
 import './ipcProjects';

--- a/src/main/ipcs/ipcAnalytics.ts
+++ b/src/main/ipcs/ipcAnalytics.ts
@@ -1,0 +1,5 @@
+import { ipcMain } from 'electron';
+
+import { track } from '../analytics';
+
+ipcMain.handle('analytics:trackEvent', (_event, name: string, params?: Record<string, unknown>) => track(name, params));

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -36,6 +36,7 @@ export const settings = new Store<Settings>({
       showClaudeUsage: false,
       showLogo: true,
       showWorktrees: true,
+      telemetry: true,
       theme: 'sunset'
     },
     collapsedGroups: [],

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,6 +12,9 @@ import { type Settings } from 'types/settings';
 import { demoBridge } from './demo/bridge';
 
 const bridge = {
+  analytics: {
+    trackEvent: (name: string, params?: Record<string, unknown>) => ipcRenderer.invoke('analytics:trackEvent', name, params)
+  },
   claude: {
     accounts: (): Promise<ClaudeAccount[]> => ipcRenderer.invoke('claude:accounts'),
     detect: (): Promise<ClaudeDetection> => ipcRenderer.invoke('claude:detect'),

--- a/src/renderer/components/SettingsIntegrations/SettingsIntegrations.tsx
+++ b/src/renderer/components/SettingsIntegrations/SettingsIntegrations.tsx
@@ -7,7 +7,7 @@ import { type FoundEditor } from 'types/foundEditor';
 import { type FoundShell } from 'types/foundShell';
 
 export const SettingsIntegrations = () => {
-  const { claudeEnabled, editors, gitHubToken, selectedEditor, selectedShell, set, shells } = useAppSettings();
+  const { claudeEnabled, editors, gitHubToken, selectedEditor, selectedShell, set, shells, telemetry } = useAppSettings();
   const [token, setToken] = useState(gitHubToken ?? '');
 
   // Dev-only demo mode. The preload picks the fake bridge at startup from this
@@ -131,6 +131,13 @@ export const SettingsIntegrations = () => {
           </div>
         </>
       )}
+
+      <Switch
+        checked={telemetry !== false}
+        className="mt-4"
+        label="Google Analytics"
+        onChange={() => set({ telemetry: !(telemetry !== false) })}
+      />
     </div>
   );
 };

--- a/src/renderer/hooks/useAppSettings.ts
+++ b/src/renderer/hooks/useAppSettings.ts
@@ -31,6 +31,7 @@ export const useAppSettings = create<Actions & AppSettings>((set) => ({
   showClaudeUsage: false,
   showLogo: true,
   showWorktrees: true,
+  telemetry: true,
   theme: 'sunset'
 }));
 

--- a/src/types/appSettings.ts
+++ b/src/types/appSettings.ts
@@ -26,5 +26,6 @@ export type AppSettings = {
   showClaudeUsage: boolean; // whether the Claude Code usage footer is shown
   showLogo: boolean;
   showWorktrees: boolean;
+  telemetry: boolean;
   theme: 'default' | 'sunset'; // 'sunset' = new gradient/glass look, 'default' = previous solid look
 };

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -6,6 +6,7 @@ import { type Projects } from './project';
 
 export type Settings = {
   appSettings: AppSettings;
+  clientId?: string;
   collapsedGroups: Group['id'][];
   newGroups: Groups;
   projects: Projects;


### PR DESCRIPTION
## What
Adds Google Analytics 4 (GA4) telemetry to devkitty, sent from the Electron **main process** via the GA4 Measurement Protocol.

## Why
No usage analytics existed. Plain `gtag.js` doesn't work well in Electron (the renderer's `file://` origin breaks cookies/`client_id`, and CORS/ad-blockers get in the way), so this sends events server-side from the main process instead.

## How
- `src/main/analytics.ts` — `track(name, params?)`: POSTs events to GA4 Measurement Protocol. Persists a random `clientId` in `electron-store`. Non-blocking and wrapped in try/catch, so telemetry can never crash or slow the app. No-ops when the secret is missing.
- `analytics:trackEvent` IPC channel + `window.bridge.analytics.trackEvent` for future renderer-side events.
- Fires `app_launch` on startup.
- **Google Analytics** toggle in Settings → Integrations (stored in `appSettings`, **on by default**, treated as on unless explicitly turned off).
- Measurement ID `G-KVS84N7CDJ` (public) is hardcoded; the API secret is read from `MAIN_VITE_GA_API_SECRET` — kept in a gitignored `.env` locally and a GitHub Actions secret in CI, never committed.
- `.github/workflows/release.yml` passes `MAIN_VITE_GA_API_SECRET` to the Make step so release builds carry it.

## Verified
- Live event confirmed in GA4 **Realtime** (`app_launch`, 1 active user) against the devkitty property.
- Adversarial review: APPROVED, no correctness bugs. Targeted `tsc` clean for all touched files (repo baseline errors untouched).

## Note
Telemetry is **on by default** (opt-out), by request. For EU/GDPR you may want a first-run consent step later.

## Required before release
Add the repo secret `MAIN_VITE_GA_API_SECRET` (Settings → Secrets and variables → Actions). Without it, builds simply send nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cKwh7kXyeGmtudBgBmj9t
