### PR TITLE
Fix focused merged worktree filter

### DIFF
--- a/src/renderer/components/CommandPalette/useCommands.test.ts
+++ b/src/renderer/components/CommandPalette/useCommands.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({ navigate: vi.fn(), refresh: vi.fn(), refreshAI: vi.fn() }));
 const storage = new Map<string, string>();
@@ -53,6 +53,10 @@ describe('useCommands', () => {
     useFocus.setState({ focusedProjectId: null, focusedWorktreePath: null });
     useWorktrees.setState({ byProject: {} });
     useCommandPalette.setState({ isOpen: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('exposes provider-neutral usage commands searchable by either provider', () => {
@@ -156,6 +160,12 @@ describe('useCommands', () => {
     item?.perform();
 
     expect(window.bridge.settings.set).toHaveBeenCalledWith('appSettings', { showLogo: false }, undefined);
+  });
+
+  it('does not expose the global worktree visibility command', () => {
+    const { result } = renderHook(() => useCommands());
+
+    expect(result.current.some((item) => item.id === 'appearance-toggle-show-worktrees')).toBe(false);
   });
 
   it('spreads the whole gitHubActions object when toggling a nested field', () => {

--- a/src/renderer/components/CommandPalette/useCommands.ts
+++ b/src/renderer/components/CommandPalette/useCommands.ts
@@ -25,7 +25,6 @@ export const useCommands = (): CommandItem[] => {
     shells,
     showClaudeUsage,
     showLogo,
-    showWorktrees,
     theme
   } = useAppSettings();
   const { setTheme, themeSource } = useDarkMode();
@@ -74,15 +73,6 @@ export const useCommands = (): CommandItem[] => {
   }));
 
   const appearanceToggleItems: CommandItem[] = [
-    {
-      active: showWorktrees,
-      closeOnPerform: false,
-      icon: 'diagram-tree',
-      id: 'appearance-toggle-show-worktrees',
-      perform: () => set({ showWorktrees: !showWorktrees }),
-      section: 'Appearance',
-      title: 'Toggle Show worktrees'
-    },
     {
       active: showLogo,
       closeOnPerform: false,

--- a/src/renderer/components/Project/Project.test.tsx
+++ b/src/renderer/components/Project/Project.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { useAppSettings } from 'renderer/hooks/useAppSettings';
+import { useFilter } from 'renderer/hooks/useFilter';
+import { useFocus } from 'renderer/hooks/useFocus';
+import { type Pull } from 'types/gitHub';
+import { type Worktree } from 'types/worktree';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  focusedMerged: true,
+  getStatus: vi.fn(),
+  openModal: vi.fn(),
+  pull: vi.fn(),
+  refresh: vi.fn()
+}));
+const storage = new Map<string, string>();
+
+vi.mock('renderer/hooks/useGit', () => ({
+  useGit: () => ({
+    getStatus: mocks.getStatus,
+    gitStatus: {
+      organization: 'example',
+      success: true,
+      worktrees: [
+        { branch: 'main', isMain: true, path: '/repo' },
+        { branch: 'merged-focus', isMain: false, path: '/repo-focus' },
+        { branch: 'merged-other', isMain: false, path: '/repo-other' }
+      ]
+    },
+    loading: false,
+    pull: mocks.pull
+  })
+}));
+vi.mock('renderer/hooks/useModal', () => ({ useModal: () => ({ openModal: mocks.openModal }) }));
+vi.mock('./hooks/useRepoData', () => ({
+  useRepoData: () => {
+    const focusedPull = mocks.focusedMerged
+      ? { merged_at: '2026-09-01', state: 'closed' }
+      : { merged_at: null, state: 'open' };
+
+    return {
+      clearHiddenPulls: vi.fn(),
+      exhaustedHistory: new Set(),
+      getOrphanPulls: () => [],
+      getOrphanRuns: () => ({}),
+      hiddenPullCount: 0,
+      hiddenRunsByBranch: {},
+      hidePull: vi.fn(),
+      loadingHistory: null,
+      loadOlderRuns: vi.fn(),
+      pullsByBranch: {
+        'merged-focus': [{ pull: focusedPull as Pull, tags: [] }],
+        'merged-other': [{ pull: { merged_at: '2026-09-02', state: 'closed' } as Pull, tags: [] }]
+      },
+      refresh: mocks.refresh,
+      runsByBranch: {},
+      runsLoaded: true
+    };
+  }
+}));
+vi.mock('./components/CheckoutCard', () => ({
+  CheckoutCard: ({ worktree }: { worktree: Worktree }) => (
+    <div data-testid={`worktree-${worktree.branch}`}>{worktree.branch}</div>
+  )
+}));
+vi.mock('./components/Error', () => ({ Error: () => null }));
+vi.mock('./components/FoldDivider', () => ({ FoldDivider: () => null }));
+vi.mock('./components/ProjectMenu', () => ({ ProjectMenu: () => null }));
+vi.mock('./components/QuickActions', () => ({ QuickActions: () => null }));
+
+import { Project } from './Project';
+
+describe('Project focused merged worktree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storage.clear();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      removeItem: (key: string) => storage.delete(key),
+      setItem: (key: string, value: string) => storage.set(key, value)
+    });
+    mocks.focusedMerged = true;
+    useAppSettings.setState({ gitHubToken: 'token', showWorktrees: false });
+    useFilter.setState({ query: '' });
+    useFocus.setState({ focusedProjectId: 'project-1', focusedWorktreePath: '/repo-focus' });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows only the focused merged worktree when this repo hides worktrees', () => {
+    render(<Project project={{ filePath: '/repo', id: 'project-1', name: 'repo' }} />);
+
+    expect(screen.getByTestId('worktree-merged-focus')).toBeTruthy();
+    expect(screen.queryByTestId('worktree-merged-other')).toBeNull();
+    expect(screen.queryByTestId('worktree-main')).toBeNull();
+  });
+
+  it('shows only the focused merged worktree while the merged fold is closed', () => {
+    useAppSettings.setState({ showWorktrees: true });
+
+    render(<Project project={{ filePath: '/repo', id: 'project-1', name: 'repo' }} />);
+
+    expect(screen.getByTestId('worktree-merged-focus')).toBeTruthy();
+    expect(screen.queryByTestId('worktree-merged-other')).toBeNull();
+    expect(screen.queryByTestId('worktree-main')).toBeNull();
+  });
+
+  it('keeps the same focused card visible when its pull changes from open to merged', () => {
+    mocks.focusedMerged = false;
+    const { rerender } = render(<Project project={{ filePath: '/repo', id: 'project-1', name: 'repo' }} />);
+
+    expect(screen.getByTestId('worktree-merged-focus')).toBeTruthy();
+
+    mocks.focusedMerged = true;
+    rerender(<Project project={{ filePath: '/repo', id: 'project-1', name: 'repo' }} />);
+
+    expect(useFocus.getState().focusedWorktreePath).toBe('/repo-focus');
+    expect(useAppSettings.getState().showWorktrees).toBe(false);
+    expect(screen.getByTestId('worktree-merged-focus')).toBeTruthy();
+    expect(screen.queryByTestId('worktree-merged-other')).toBeNull();
+    expect(screen.queryByTestId('worktree-main')).toBeNull();
+  });
+
+  it('uses the normal repo view when the focused path is stale', () => {
+    useFocus.setState({ focusedProjectId: 'project-1', focusedWorktreePath: '/missing' });
+
+    render(<Project project={{ filePath: '/repo', id: 'project-1', name: 'repo' }} />);
+
+    expect(screen.getByTestId('worktree-main')).toBeTruthy();
+    expect(screen.queryByTestId('worktree-merged-focus')).toBeNull();
+    expect(screen.queryByTestId('worktree-merged-other')).toBeNull();
+  });
+
+  it('does not apply another repo focus to this repo', () => {
+    useFocus.setState({ focusedProjectId: 'project-2', focusedWorktreePath: '/repo-focus' });
+
+    render(<Project project={{ filePath: '/repo', id: 'project-1', name: 'repo' }} />);
+
+    expect(screen.getByTestId('worktree-main')).toBeTruthy();
+    expect(screen.queryByTestId('worktree-merged-focus')).toBeNull();
+    expect(screen.queryByTestId('worktree-merged-other')).toBeNull();
+  });
+
+  it('keeps an exact focused worktree visible when the text filter does not match it', () => {
+    useFilter.setState({ query: 'no-match' });
+
+    render(<Project project={{ filePath: '/repo', id: 'project-1', name: 'repo' }} />);
+
+    expect(screen.getByTestId('worktree-merged-focus')).toBeTruthy();
+    expect(screen.queryByTestId('worktree-merged-other')).toBeNull();
+    expect(screen.queryByTestId('worktree-main')).toBeNull();
+  });
+});

--- a/src/renderer/components/Project/Project.tsx
+++ b/src/renderer/components/Project/Project.tsx
@@ -202,6 +202,13 @@ export const Project: FC<Props> = ({ project }) => {
     [pullsByBranch, runsByBranch, visibleWorktrees]
   );
 
+  // Focus is an exact selection, so find it before repo visibility and text
+  // filters can remove it. A stale path keeps the normal repo view.
+  const focusedWorktree =
+    focusedProjectId === id && focusedWorktreePath
+      ? worktrees.find((worktree) => worktree.path === focusedWorktreePath)
+      : undefined;
+
   const updateProject = () => {
     refresh();
     getStatus(id);
@@ -263,23 +270,10 @@ export const Project: FC<Props> = ({ project }) => {
     ? sortedWorktrees.filter((worktree) => !worktree.isMain && isCheckoutDone(pullsByBranch[worktree.branch]))
     : [];
 
-  // Worktree focus mode (from the command palette): narrow this project's
-  // checkouts down to the one focused worktree. A focused path that matches
-  // nothing here (branch removed, worktree gone) falls back to showing them all.
-  const isWorktreeFocused =
-    focusedProjectId === id &&
-    Boolean(focusedWorktreePath) &&
-    sortedWorktrees.some((worktree) => worktree.path === focusedWorktreePath);
-  const applyWorktreeFocus = (list: Worktree[]) =>
-    isWorktreeFocused ? list.filter((worktree) => worktree.path === focusedWorktreePath) : list;
-
-  const focusedLiveWorktrees = applyWorktreeFocus(liveWorktrees);
-  const focusedMergedWorktrees = applyWorktreeFocus(mergedWorktrees);
-
   const behind = gitStatus?.status?.behind ?? 0;
 
   // Nothing in this repo answers the filter — drop it out of the list.
-  if (query.trim() && visibleWorktrees.length === 0) return null;
+  if (!focusedWorktree && query.trim() && visibleWorktrees.length === 0) return null;
 
   if (gitStatus && !gitStatus.success) {
     return (
@@ -295,7 +289,7 @@ export const Project: FC<Props> = ({ project }) => {
       done={isCheckoutDone(pullsByBranch[worktree.branch])}
       // Picking a worktree from ⌘K opens it — its contents (or the empty-state)
       // are the whole point of focusing it, so it never shows as a bare header.
-      expanded={isWorktreeFocused || Boolean(expandedPaths[worktree.path])}
+      expanded={Boolean(focusedWorktree) || Boolean(expandedPaths[worktree.path])}
       gitStatus={worktree.isMain ? gitStatus : undefined}
       groups={groupsFor(worktree)}
       hiddenRuns={hiddenRunsByBranch[worktree.branch] ?? []}
@@ -319,7 +313,7 @@ export const Project: FC<Props> = ({ project }) => {
       onToggleExpanded={() => toggleExpanded(worktree.path)}
       project={project}
       runsLoaded={runsLoaded}
-      solo={isWorktreeFocused}
+      solo={Boolean(focusedWorktree)}
       trailing={
           worktree.isMain ? (
             <div className={cn('flex items-center gap-2.5', !gitStatus && Classes.SKELETON)}>
@@ -392,16 +386,15 @@ export const Project: FC<Props> = ({ project }) => {
         </div>
       )}
 
-      {focusedLiveWorktrees.map(renderCheckout)}
-
-      {/* Focus mode is a filter: you asked for this one worktree, so show it
-          directly even when merged — no collapsed fold to hide it behind. The
-          fold (with its toggle) only makes sense in the full, unfiltered list. */}
-      {isWorktreeFocused ? (
-        focusedMergedWorktrees.map(renderCheckout)
+      {/* A valid focus is a direct selection. Repo visibility, text filters,
+          and the merged fold must not remove the selected raw worktree. */}
+      {focusedWorktree ? (
+        renderCheckout(focusedWorktree)
       ) : (
         <>
-          {focusedMergedWorktrees.length > 0 && (
+          {liveWorktrees.map(renderCheckout)}
+
+          {mergedWorktrees.length > 0 && (
             <FoldDivider
               className="px-6"
               icon="git-merge"
@@ -410,7 +403,7 @@ export const Project: FC<Props> = ({ project }) => {
             />
           )}
 
-          <Collapse isOpen={showMerged}>{focusedMergedWorktrees.map(renderCheckout)}</Collapse>
+          <Collapse isOpen={showMerged}>{mergedWorktrees.map(renderCheckout)}</Collapse>
         </>
       )}
     </>


### PR DESCRIPTION
## What changed

- Keep the focused worktree visible when repo worktrees are hidden.
- Keep the same focused card visible when its pull becomes merged.
- Show only the focused card while focus is active.
- Remove the misleading global worktree visibility command.

## Checks

- 20 focused tests passed.
- ESLint passed for all changed files.
- The production build passed.
- Live QA passed in light and dark mode.