### PR TITLE
Add real opacity control for pinned windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,7 +12,7 @@ import { track } from './analytics';
 import './ipcs';
 import { initClipboardDownscale, stopClipboardWatcher } from './libs/clipboardDownscale';
 import { updateEditorsAndShells } from './libs/integrations/integrations';
-import { loadWindowState, saveBounds } from './libs/window';
+import { loadWindowState, saveBounds, WINDOW_MINIMUM_SIZE } from './libs/window';
 
 log.initialize({ preload: true, spyRendererConsole: false });
 
@@ -39,8 +39,8 @@ const installReactDevTools = async () => {
 const createWindow = (): void => {
   const mainWindow = new BrowserWindow({
     backgroundColor: nativeTheme.shouldUseDarkColors ? '#141414' : '#ffffff',
-    minHeight: 600,
-    minWidth: 800,
+    minHeight: WINDOW_MINIMUM_SIZE.height,
+    minWidth: WINDOW_MINIMUM_SIZE.width,
     show: false,
     titleBarStyle: 'hidden',
     trafficLightPosition: { x: 15, y: 17 },

--- a/src/main/ipcs/ipcWindow.test.ts
+++ b/src/main/ipcs/ipcWindow.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const handlers: Record<string, (...args: any[]) => any> = {};
+type IpcHandler = (...args: unknown[]) => unknown;
 
-const win = {
+const handlers: Record<string, IpcHandler> = {};
+
+const makeWindow = () => ({
   isAlwaysOnTop: vi.fn(() => false),
   setAlwaysOnTop: vi.fn(),
+  setOpacity: vi.fn(),
   setVisibleOnAllWorkspaces: vi.fn()
-};
+});
 
+let win = makeWindow();
 let fromWebContentsResult: null | typeof win = win;
 
 vi.mock('electron', () => ({
@@ -15,13 +19,12 @@ vi.mock('electron', () => ({
     fromWebContents: vi.fn(() => fromWebContentsResult)
   },
   ipcMain: {
-    handle: vi.fn((channel: string, handler: any) => {
+    handle: vi.fn((channel: string, handler: IpcHandler) => {
       handlers[channel] = handler;
     })
   }
 }));
 
-// Import after mocks so the module registers its handlers against them.
 await import('./ipcWindow');
 
 const event = { sender: {} };
@@ -29,54 +32,73 @@ const event = { sender: {} };
 describe('ipcWindow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    win = makeWindow();
     fromWebContentsResult = win;
-    win.isAlwaysOnTop.mockReturnValue(false);
   });
 
-  describe('window:setAlwaysOnTop', () => {
-    it('pins the window at the screen-saver level so it floats over full-screen apps', () => {
-      handlers['window:setAlwaysOnTop'](event, true);
+  describe('window:getPinnedAppearance', () => {
+    it.each([true, false])('uses the native pin state %s and full opacity for a new window', (alwaysOnTop) => {
+      win.isAlwaysOnTop.mockReturnValue(alwaysOnTop);
 
-      expect(win.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver');
+      expect(handlers['window:getPinnedAppearance'](event)).toEqual({ alwaysOnTop, opacity: 1 });
     });
 
-    it('skips the process-type transform so macOS keeps the Dock icon', () => {
-      handlers['window:setAlwaysOnTop'](event, true);
+    it('returns the stored logical opacity after the window is unpinned', () => {
+      handlers['window:setPinnedAppearance'](event, true, 0.62);
+      handlers['window:setPinnedAppearance'](event, false, 0.62);
 
+      expect(handlers['window:getPinnedAppearance'](event)).toEqual({ alwaysOnTop: false, opacity: 0.62 });
+    });
+
+    it('returns the safe state when there is no window', () => {
+      fromWebContentsResult = null;
+
+      expect(handlers['window:getPinnedAppearance'](event)).toEqual({ alwaysOnTop: false, opacity: 1 });
+    });
+  });
+
+  describe('window:setPinnedAppearance', () => {
+    it.each([0.4, 0.73, 1])('pins with allowed opacity %s', (opacity) => {
+      expect(handlers['window:setPinnedAppearance'](event, true, opacity)).toEqual({
+        alwaysOnTop: true,
+        opacity
+      });
+      expect(win.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver');
       expect(win.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(true, {
         skipTransformProcessType: true,
         visibleOnFullScreen: true
       });
+      expect(win.setOpacity).toHaveBeenCalledWith(opacity);
     });
 
-    it('reports back the flag it applied, not isAlwaysOnTop() which can read stale', () => {
-      // The window lies and says it is not on top right after the call; the
-      // handler must still report the flag it was asked to apply.
-      win.isAlwaysOnTop.mockReturnValue(false);
-
-      expect(handlers['window:setAlwaysOnTop'](event, true)).toBe(true);
-      expect(handlers['window:setAlwaysOnTop'](event, false)).toBe(false);
+    it('keeps the saved opacity but disables glass when it unpins', () => {
+      expect(handlers['window:setPinnedAppearance'](event, false, 0.47)).toEqual({
+        alwaysOnTop: false,
+        opacity: 0.47
+      });
+      expect(win.setAlwaysOnTop).toHaveBeenCalledWith(false, 'screen-saver');
+      expect(win.setOpacity).toHaveBeenCalledWith(1);
     });
 
-    it('returns false and touches nothing when there is no window', () => {
-      fromWebContentsResult = null;
-
-      expect(handlers['window:setAlwaysOnTop'](event, true)).toBe(false);
+    it.each(['true', 0, 1, null, undefined])('rejects invalid pin flag %s', (flag) => {
+      expect(() => handlers['window:setPinnedAppearance'](event, flag, 0.5)).toThrow('Invalid always-on-top flag');
       expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
     });
-  });
 
-  describe('window:getAlwaysOnTop', () => {
-    it('reflects the real pinned state of the window', () => {
-      win.isAlwaysOnTop.mockReturnValue(true);
+    it.each([0, 0.39, 1.01, 2, NaN, Infinity, -Infinity, '0.5', null, undefined])(
+      'rejects invalid opacity %s',
+      (opacity) => {
+        expect(() => handlers['window:setPinnedAppearance'](event, true, opacity)).toThrow('Invalid window opacity');
+        expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+      }
+    );
 
-      expect(handlers['window:getAlwaysOnTop'](event)).toBe(true);
-    });
-
-    it('returns false when there is no window', () => {
+    it('returns the safe state and touches nothing when there is no window', () => {
       fromWebContentsResult = null;
 
-      expect(handlers['window:getAlwaysOnTop'](event)).toBe(false);
+      expect(handlers['window:setPinnedAppearance'](event, true, 0.5)).toEqual({ alwaysOnTop: false, opacity: 1 });
+      expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+      expect(win.setOpacity).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/main/ipcs/ipcWindow.ts
+++ b/src/main/ipcs/ipcWindow.ts
@@ -1,27 +1,66 @@
 import { BrowserWindow, ipcMain } from 'electron';
+import {
+  WINDOW_OPACITY_DEFAULT,
+  WINDOW_OPACITY_MAX,
+  WINDOW_OPACITY_MIN,
+  type WindowAppearance,
+  type WindowOpacity
+} from 'types/window';
 
-// Keep the app window pinned above every other window (all spaces / full-screen
-// too), toggled from the navbar. `screen-saver` level floats over full-screen
-// apps, which the default `floating` level does not.
-ipcMain.handle('window:setAlwaysOnTop', (event, flag: boolean) => {
-  const win = BrowserWindow.fromWebContents(event.sender);
-  if (!win) return false;
+const isWindowOpacity = (opacity: unknown): opacity is WindowOpacity =>
+  typeof opacity === 'number'
+  && Number.isFinite(opacity)
+  && opacity >= WINDOW_OPACITY_MIN
+  && opacity <= WINDOW_OPACITY_MAX;
 
-  win.setAlwaysOnTop(flag, 'screen-saver');
-  // skipTransformProcessType: setVisibleOnAllWorkspaces otherwise flips the app
-  // between UIElement/Foreground process types on macOS, which drops the Dock
-  // icon (electron/electron#26350). Skipping the transform keeps the icon put.
-  win.setVisibleOnAllWorkspaces(flag, {
-    skipTransformProcessType: true,
-    visibleOnFullScreen: true,
-  });
-  // Report back the flag we applied, not isAlwaysOnTop() — on macOS the latter
-  // can momentarily read false right after setVisibleOnAllWorkspaces, which
-  // would leave the navbar toggle stuck looking off.
-  return flag;
+const fallbackAppearance = (): WindowAppearance => ({
+  alwaysOnTop: false,
+  opacity: WINDOW_OPACITY_DEFAULT
 });
 
-ipcMain.handle('window:getAlwaysOnTop', (event) => {
+const appearanceByWindow = new WeakMap<BrowserWindow, WindowAppearance>();
+
+const getStoredAppearance = (win: BrowserWindow): WindowAppearance => {
+  const storedAppearance = appearanceByWindow.get(win);
+  if (storedAppearance) return storedAppearance;
+
+  const initialAppearance = {
+    alwaysOnTop: win.isAlwaysOnTop(),
+    opacity: WINDOW_OPACITY_DEFAULT
+  };
+  appearanceByWindow.set(win, initialAppearance);
+  return initialAppearance;
+};
+
+ipcMain.handle('window:getPinnedAppearance', (event): WindowAppearance => {
   const win = BrowserWindow.fromWebContents(event.sender);
-  return win ? win.isAlwaysOnTop() : false;
+  if (!win) return fallbackAppearance();
+
+  return getStoredAppearance(win);
+});
+
+ipcMain.handle('window:setPinnedAppearance', (
+  event,
+  alwaysOnTop: unknown,
+  pinnedOpacity: unknown
+): WindowAppearance => {
+  if (typeof alwaysOnTop !== 'boolean') throw new TypeError('Invalid always-on-top flag');
+  if (!isWindowOpacity(pinnedOpacity)) throw new TypeError('Invalid window opacity');
+
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return fallbackAppearance();
+
+  win.setAlwaysOnTop(alwaysOnTop, 'screen-saver');
+  win.setVisibleOnAllWorkspaces(alwaysOnTop, {
+    skipTransformProcessType: true,
+    visibleOnFullScreen: true
+  });
+  win.setOpacity(alwaysOnTop ? pinnedOpacity : WINDOW_OPACITY_DEFAULT);
+
+  const appearance = {
+    alwaysOnTop,
+    opacity: pinnedOpacity
+  };
+  appearanceByWindow.set(win, appearance);
+  return appearance;
 });

--- a/src/main/libs/window.test.ts
+++ b/src/main/libs/window.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../main/settings', () => ({
 import { screen } from 'electron';
 
 import { settings } from '../../main/settings';
-import { loadWindowState, saveBounds } from './window';
+import { loadWindowState, saveBounds, WINDOW_MINIMUM_SIZE } from './window';
 
 const mockScreen = vi.mocked(screen);
 const mockSettings = vi.mocked(settings);
@@ -24,6 +24,10 @@ const mockSettings = vi.mocked(settings);
 describe('window', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('should use a minimum window size of 800 by 300 pixels', () => {
+    expect(WINDOW_MINIMUM_SIZE).toEqual({ height: 300, width: 800 });
   });
 
   describe('loadWindowState', () => {

--- a/src/main/libs/window.ts
+++ b/src/main/libs/window.ts
@@ -2,6 +2,8 @@ import { type BrowserWindow, type Rectangle, screen } from 'electron';
 
 import { settings } from '../../main/settings';
 
+export const WINDOW_MINIMUM_SIZE = { height: 300, width: 800 } as const;
+
 const getArea = (bounds: Rectangle) => screen.getDisplayMatching(bounds).workArea;
 
 const isSizeValid = (bounds: Rectangle) => {

--- a/src/preload/demo/bridge.test.ts
+++ b/src/preload/demo/bridge.test.ts
@@ -56,12 +56,12 @@ describe('demoBridge window', () => {
     vi.clearAllMocks();
   });
 
-  it('routes always-on-top through the real window IPC so the pin works in demo', () => {
-    demoBridge.window.setAlwaysOnTop(true);
-    expect(invoke).toHaveBeenCalledWith('window:setAlwaysOnTop', true);
+  it('routes pinned appearance through the real window IPC so it works in demo', () => {
+    demoBridge.window.setPinnedAppearance(true, 0.73);
+    expect(invoke).toHaveBeenCalledWith('window:setPinnedAppearance', true, 0.73);
 
-    demoBridge.window.getAlwaysOnTop();
-    expect(invoke).toHaveBeenCalledWith('window:getAlwaysOnTop');
+    demoBridge.window.getPinnedAppearance();
+    expect(invoke).toHaveBeenCalledWith('window:getPinnedAppearance');
   });
 });
 

--- a/src/preload/demo/bridge.ts
+++ b/src/preload/demo/bridge.ts
@@ -6,6 +6,7 @@
 // through IPC so the pin works while demoing.
 
 import { ipcRenderer } from 'electron';
+import { type WindowOpacity } from 'types/window';
 
 import {
   authoredPRNumbers,
@@ -133,8 +134,9 @@ export const demoBridge = {
     add: noop
   },
   window: {
-    getAlwaysOnTop: () => ipcRenderer.invoke('window:getAlwaysOnTop'),
-    setAlwaysOnTop: (flag: boolean) => ipcRenderer.invoke('window:setAlwaysOnTop', flag)
+    getPinnedAppearance: () => ipcRenderer.invoke('window:getPinnedAppearance'),
+    setPinnedAppearance: (alwaysOnTop: boolean, pinnedOpacity: WindowOpacity) =>
+      ipcRenderer.invoke('window:setPinnedAppearance', alwaysOnTop, pinnedOpacity)
   },
   worktree: {
     add: () => ok({ message: 'Worktree added' }),

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -19,7 +19,8 @@ vi.mock('electron', () => ({
 await import('./index');
 
 // Capture the bridge object that was passed to exposeInMainWorld
-const bridge: Record<string, any> = mockContextBridge.exposeInMainWorld.mock.calls[0][1];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const [[, bridge]] = mockContextBridge.exposeInMainWorld.mock.calls as [[string, Record<string, any>]];
 
 describe('preload bridge', () => {
   beforeEach(() => {
@@ -178,6 +179,18 @@ describe('preload bridge', () => {
     it('should invoke sticker:add with text', () => {
       bridge.sticker.add('Hello World');
       expect(mockIpcRenderer.invoke).toHaveBeenCalledWith('sticker:add', 'Hello World');
+    });
+  });
+
+  describe('window', () => {
+    it('should invoke window:getPinnedAppearance', () => {
+      bridge.window.getPinnedAppearance();
+      expect(mockIpcRenderer.invoke).toHaveBeenCalledWith('window:getPinnedAppearance');
+    });
+
+    it('should invoke window:setPinnedAppearance with the pin and opacity', () => {
+      bridge.window.setPinnedAppearance(true, 0.73);
+      expect(mockIpcRenderer.invoke).toHaveBeenCalledWith('window:setPinnedAppearance', true, 0.73);
     });
   });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,7 @@ import { type pullTypes } from 'types/gitHub';
 import { type ThemeSource } from 'types/Modal';
 import { type GitStatus, type Project } from 'types/project';
 import { type Settings } from 'types/settings';
+import { type WindowAppearance, type WindowOpacity } from 'types/window';
 
 import { demoBridge } from './demo/bridge';
 
@@ -91,8 +92,9 @@ const bridge = {
     add: (text: string) => ipcRenderer.invoke('sticker:add', text)
   },
   window: {
-    getAlwaysOnTop: (): Promise<boolean> => ipcRenderer.invoke('window:getAlwaysOnTop'),
-    setAlwaysOnTop: (flag: boolean): Promise<boolean> => ipcRenderer.invoke('window:setAlwaysOnTop', flag)
+    getPinnedAppearance: (): Promise<WindowAppearance> => ipcRenderer.invoke('window:getPinnedAppearance'),
+    setPinnedAppearance: (alwaysOnTop: boolean, pinnedOpacity: WindowOpacity): Promise<WindowAppearance> =>
+      ipcRenderer.invoke('window:setPinnedAppearance', alwaysOnTop, pinnedOpacity)
   },
   worktree: {
     add: (id: string, repoName: string, branch: string, newBranch?: string, copyEnvLocal?: boolean) =>

--- a/src/renderer/App.pinnedAppearance.test.tsx
+++ b/src/renderer/App.pinnedAppearance.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('renderer/hooks/useAppSettings', (): object => ({
+  useAppSettings: () => ({ claudeEnabled: false }),
+  useIsSunset: () => false
+}));
+vi.mock('renderer/hooks/useDarkMode', (): object => ({ useDarkMode: () => ({ darkMode: false }) }));
+vi.mock('renderer/hooks/useModal', (): object => ({ useModal: () => ({ Modal: (): null => null }) }));
+vi.mock('./components/AppNavbar', (): object => ({ AppNavbar: (): null => null }));
+vi.mock('./components/ClaudeUsage', (): object => ({ ClaudeFooter: (): null => null }));
+vi.mock('./components/CommandPalette', (): object => ({ CommandPalette: (): null => null }));
+vi.mock('./Routing', (): object => ({ Routing: (): null => null }));
+
+import { App } from './App';
+
+describe('App pinned glass state', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not apply renderer opacity or glass state', () => {
+    const { container } = render(<App />);
+    const root = container.firstElementChild as HTMLElement;
+
+    expect(root.hasAttribute('data-dk-pinned-glass')).toBe(false);
+    expect(root.classList.contains('dk-pinned-glass-surface')).toBe(false);
+    expect(document.documentElement.hasAttribute('data-dk-pinned-glass')).toBe(false);
+    expect(document.documentElement.style.getPropertyValue('--dk-glass-opacity')).toBe('');
+  });
+});

--- a/src/renderer/components/AppNavbar/AlwaysOnTopControl.test.tsx
+++ b/src/renderer/components/AppNavbar/AlwaysOnTopControl.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import type * as Blueprint from '@blueprintjs/core';
+import type { PopoverProps } from '@blueprintjs/core';
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { usePinnedAppearance } from 'renderer/hooks/usePinnedAppearance';
+import type { WindowOpacity } from 'types/window';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const capturedPopoverProps = vi.hoisted<{ current?: PopoverProps }>(() => ({}));
+
+vi.mock('@blueprintjs/core', async (importOriginal) => {
+  const actual = await importOriginal() as typeof Blueprint;
+  const React = await import('react');
+  return {
+    ...actual,
+    Popover: (props: PopoverProps) => {
+      capturedPopoverProps.current = props;
+      return React.createElement(actual.Popover, props);
+    }
+  };
+});
+
+import { AlwaysOnTopControl } from './AlwaysOnTopControl';
+
+const windowBridge = window.bridge.window;
+
+const flush = async () => {
+  await act(() => Promise.resolve());
+};
+
+const pin = async () => {
+  fireEvent.click(screen.getByRole('button', { name: 'Toggle always on top' }));
+  await flush();
+};
+
+const openSlider = async (event: 'focus' | 'hover' = 'hover') => {
+  const pinButton = screen.getByRole('button', { name: 'Toggle always on top' });
+  if (event === 'focus') fireEvent.focus(pinButton);
+  else fireEvent.mouseEnter(pinButton);
+  await act(() => vi.advanceTimersByTimeAsync(300));
+  return screen.getByRole('slider', { name: 'Window opacity' });
+};
+
+describe('AlwaysOnTopControl', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    usePinnedAppearance.setState({
+      alwaysOnTop: false,
+      initialized: false,
+      opacity: 1
+    });
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: false, opacity: 1 });
+    vi.mocked(windowBridge.setPinnedAppearance).mockImplementation((alwaysOnTop: boolean, opacity: WindowOpacity) => Promise.resolve({
+      alwaysOnTop,
+      opacity
+    }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('keeps the pin icon and hides the slider while unpinned', async () => {
+    render(<AlwaysOnTopControl />);
+    await flush();
+
+    const pinButton = screen.getByRole('button', { name: 'Toggle always on top' });
+    expect(pinButton.querySelector('svg')).toBeTruthy();
+    fireEvent.mouseEnter(pinButton);
+    await act(() => vi.advanceTimersByTimeAsync(300));
+    expect(screen.queryByRole('slider', { name: 'Window opacity' })).toBeNull();
+  });
+
+  it('shows the mounted pinned opacity on hover and focus', async () => {
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: true, opacity: 0.73 });
+    const { unmount } = render(<AlwaysOnTopControl />);
+    await flush();
+
+    const slider = await openSlider();
+    expect(slider.getAttribute('aria-valuenow')).toBe('73');
+    expect(screen.getByText('Window opacity')).toBeTruthy();
+    expect(screen.getByText('40%')).toBeTruthy();
+    expect(screen.getByText('100%')).toBeTruthy();
+
+    unmount();
+    render(<AlwaysOnTopControl />);
+    await flush();
+    expect(await openSlider('focus')).toBeTruthy();
+  });
+
+  it('hides the popover on unpin and restores the chosen opacity on repin', async () => {
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: true, opacity: 0.65 });
+    render(<AlwaysOnTopControl />);
+    await flush();
+    await openSlider();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle always on top' }));
+    await flush();
+    await act(() => vi.advanceTimersByTimeAsync(500));
+    expect(windowBridge.setPinnedAppearance).toHaveBeenLastCalledWith(false, 0.65);
+    expect(screen.queryByRole('slider', { name: 'Window opacity' })).toBeNull();
+
+    await pin();
+    expect(windowBridge.setPinnedAppearance).toHaveBeenLastCalledWith(true, 0.65);
+  });
+
+  it('sends live slider changes and supports arrow keys', async () => {
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: true, opacity: 0.5 });
+    render(<AlwaysOnTopControl />);
+    await flush();
+    const slider = await openSlider();
+
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+
+    expect(slider.getAttribute('aria-valuenow')).toBe('51');
+    expect(windowBridge.setPinnedAppearance).toHaveBeenCalledWith(true, 0.51);
+  });
+
+  it('keeps the real Blueprint popover open while a drag leaves it', async () => {
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: true, opacity: 0.5 });
+    render(<AlwaysOnTopControl />);
+    await flush();
+    const slider = await openSlider();
+
+    fireEvent.mouseDown(slider, { clientX: 0 });
+    fireEvent.mouseMove(document, { clientX: 1 });
+    expect(windowBridge.setPinnedAppearance).toHaveBeenCalledWith(true, 1);
+    fireEvent.mouseLeave(slider);
+    await act(() => vi.advanceTimersByTimeAsync(400));
+    expect(screen.getByRole('slider', { name: 'Window opacity' })).toBeTruthy();
+  });
+
+  it('closes normally after a press outside the slider', async () => {
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: true, opacity: 0.5 });
+    render(<AlwaysOnTopControl />);
+    await flush();
+    await openSlider();
+
+    const title = screen.getByText('Window opacity');
+    fireEvent.mouseDown(title);
+    act(() => capturedPopoverProps.current?.onInteraction?.(false));
+    await act(() => vi.advanceTimersByTimeAsync(401));
+
+    expect(screen.queryByRole('slider', { name: 'Window opacity' })).toBeNull();
+  });
+
+  it('locks the popover below the pin with flip off and an eight pixel offset', async () => {
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: true, opacity: 1 });
+    render(<AlwaysOnTopControl />);
+    await flush();
+    await openSlider();
+
+    expect(capturedPopoverProps.current?.placement).toBe('bottom');
+    expect(capturedPopoverProps.current?.modifiers).toEqual({
+      flip: { enabled: false },
+      offset: { enabled: true, options: { offset: [0, 8] } }
+    });
+  });
+});

--- a/src/renderer/components/AppNavbar/AlwaysOnTopControl.tsx
+++ b/src/renderer/components/AppNavbar/AlwaysOnTopControl.tsx
@@ -1,0 +1,140 @@
+import { Button, Popover, Slider } from '@blueprintjs/core';
+import { useEffect, useRef, useState } from 'react';
+import { usePinnedAppearance } from 'renderer/hooks/usePinnedAppearance';
+import {
+  WINDOW_OPACITY_MAX,
+  WINDOW_OPACITY_MIN,
+  WINDOW_OPACITY_STEP,
+  type WindowOpacity
+} from 'types/window';
+
+import { PinIcon } from './NavIcons';
+
+const HOVER_CLOSE_DELAY = 200;
+const opacityToPercent = (opacity: WindowOpacity) => Math.round(opacity * 100);
+const percentToOpacity = (percent: number): WindowOpacity => percent / 100;
+const percentLabel = (percent: number) => `${percent}%`;
+
+export const AlwaysOnTopControl = () => {
+  const {
+    alwaysOnTop,
+    initialize,
+    opacity,
+    setOpacity,
+    togglePin
+  } = usePinnedAppearance();
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const draggingRef = useRef(false);
+  const releaseGuardRef = useRef(false);
+  const closeRequestedRef = useRef(false);
+  const releaseTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    void initialize();
+
+    return () => {
+      if (releaseTimerRef.current) clearTimeout(releaseTimerRef.current);
+    };
+  }, [initialize]);
+
+  useEffect(() => {
+    if (!alwaysOnTop) setPopoverOpen(false);
+  }, [alwaysOnTop]);
+
+  const changeOpacity = (percent: number) => {
+    setOpacity(percentToOpacity(percent));
+  };
+
+  const beginSliderInteraction = (event: { target: EventTarget }) => {
+    if (!(event.target instanceof Element) || !event.target.closest('.bp6-slider')) return;
+
+    if (releaseTimerRef.current) clearTimeout(releaseTimerRef.current);
+    draggingRef.current = true;
+    releaseGuardRef.current = false;
+    closeRequestedRef.current = false;
+    setPopoverOpen(true);
+  };
+
+  const finishSliderInteraction = () => {
+    draggingRef.current = false;
+    releaseGuardRef.current = true;
+    releaseTimerRef.current = setTimeout(() => {
+      releaseGuardRef.current = false;
+      if (closeRequestedRef.current) setPopoverOpen(false);
+    }, HOVER_CLOSE_DELAY);
+  };
+
+  const handlePopoverInteraction = (nextOpen: boolean) => {
+    if (nextOpen) {
+      closeRequestedRef.current = false;
+      setPopoverOpen(true);
+    } else if (draggingRef.current || releaseGuardRef.current) {
+      closeRequestedRef.current = true;
+    } else {
+      setPopoverOpen(false);
+    }
+  };
+
+  const opacitySlider = (
+    <div
+      className="w-56 px-4 py-3"
+      onMouseDownCapture={beginSliderInteraction}
+      onTouchStartCapture={beginSliderInteraction}
+    >
+      <div className="mb-3 flex items-center justify-between gap-4 text-sm font-semibold">
+        <span>Window opacity</span>
+        <span className="tabular-nums">{percentLabel(opacityToPercent(opacity))}</span>
+      </div>
+
+      <Slider
+        handleHtmlProps={{
+          'aria-label': 'Window opacity'
+        }}
+        labelRenderer={false}
+        max={opacityToPercent(WINDOW_OPACITY_MAX)}
+        min={opacityToPercent(WINDOW_OPACITY_MIN)}
+        onChange={changeOpacity}
+        onRelease={finishSliderInteraction}
+        stepSize={opacityToPercent(WINDOW_OPACITY_STEP)}
+        value={opacityToPercent(opacity)}
+      />
+
+      <div className="mt-1 flex justify-between text-xs text-bp-gray-1 dark:text-bp-gray-4">
+        <span>{percentLabel(opacityToPercent(WINDOW_OPACITY_MIN))}</span>
+        <span>{percentLabel(opacityToPercent(WINDOW_OPACITY_MAX))}</span>
+      </div>
+
+    </div>
+  );
+
+  return (
+    <Popover
+      content={opacitySlider}
+      disabled={!alwaysOnTop}
+      hoverCloseDelay={HOVER_CLOSE_DELAY}
+      hoverOpenDelay={300}
+      interactionKind="hover"
+      isOpen={alwaysOnTop && popoverOpen}
+      minimal
+      modifiers={{
+        flip: { enabled: false },
+        offset: { enabled: true, options: { offset: [0, 8] } }
+      }}
+      onInteraction={handlePopoverInteraction}
+      placement="bottom"
+    >
+      <Button
+        aria-label="Toggle always on top"
+        aria-pressed={alwaysOnTop}
+        icon={(
+          <PinIcon
+            size={16}
+            style={alwaysOnTop ? { color: '#F5854A' } : undefined}
+          />
+        )}
+        minimal
+        onClick={togglePin}
+      />
+    </Popover>
+  );
+};

--- a/src/renderer/components/AppNavbar/AppNavbar.tsx
+++ b/src/renderer/components/AppNavbar/AppNavbar.tsx
@@ -19,7 +19,8 @@ import { type DownscaleResult } from 'types/clipboard';
 
 import { ClaudeMark } from '../ClaudeUsage';
 import { ShinyText } from '../ShinyText';
-import { PinIcon, SettingsGearIcon } from './NavIcons';
+import { AlwaysOnTopControl } from './AlwaysOnTopControl';
+import { SettingsGearIcon } from './NavIcons';
 import { SearchInput } from './SearchInput';
 
 const ClipboardDownscaleDetail = ({ enabled, last }: { enabled: boolean; last: DownscaleResult | null }) => (
@@ -113,21 +114,7 @@ export const AppNavbar = () => {
       : undefined;
   const searchRef = useRef<HTMLInputElement>(null);
   const onHome = useLocation().pathname === '/';
-  const [alwaysOnTop, setAlwaysOnTop] = useState(false);
   const [lastDownscale, setLastDownscale] = useState<DownscaleResult | null>(null);
-
-  // Reflect the window's real pinned state on mount (it survives across
-  // reloads within a session).
-  useEffect(() => {
-    window.bridge.window.getAlwaysOnTop().then(setAlwaysOnTop);
-  }, []);
-
-  const toggleAlwaysOnTop = async () => {
-    const target = !alwaysOnTop;
-    setAlwaysOnTop(target); // optimistic — instant feedback on the icon
-    const next = await window.bridge.window.setAlwaysOnTop(target);
-    setAlwaysOnTop(next);
-  };
 
   // Toast whenever the main process shrinks a clipboard image, wherever the
   // toggle was flipped from.
@@ -314,22 +301,7 @@ export const AppNavbar = () => {
             />
           </Popover>
 
-          <Tooltip
-            compact
-            content={alwaysOnTop ? 'Always on top: on' : 'Keep window always on top'}
-            hoverOpenDelay={500}
-            placement="bottom"
-          >
-            <Button
-              aria-label="Toggle always on top"
-              icon={<PinIcon
-                size={16}
-                style={alwaysOnTop ? { color: '#F5854A' } : undefined}
-                    />}
-              minimal
-              onClick={toggleAlwaysOnTop}
-            />
-          </Tooltip>
+          <AlwaysOnTopControl />
 
           {themeSource !== 'system' && (
             <Tooltip compact

--- a/src/renderer/components/ClaudeUsage/UsageMeter.test.tsx
+++ b/src/renderer/components/ClaudeUsage/UsageMeter.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { render, screen, within } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@blueprintjs/core', () => ({
+  Icon: (): null => null,
+  Popover: ({ children, content }: { children: ReactNode; content: ReactNode }) => <div>{children}{content}</div>
+}));
+
+import { UsageMeter } from './UsageMeter';
+
+describe('UsageMeter', () => {
+  beforeEach(() => {
+    vi.mocked(window.matchMedia).mockReturnValue({ matches: true } as MediaQueryList);
+  });
+
+  it('labels reported Codex model totals as local and keeps all local rows sorted', () => {
+    render(
+      <UsageMeter
+        label="7D"
+        now={1_000_000}
+        provider="codex"
+        reportedAt={940_000}
+        title="Codex · 7D usage"
+        window={{
+          active: true,
+          cap: 0,
+          models: [
+            { model: 'gpt-5.6-luna', tokens: 222_100 },
+            { model: 'gpt-5.6-sol', tokens: 94_400_000 },
+            { model: 'codex-auto-review', tokens: 2_300_000 },
+            { model: 'gpt-5.6-terra', tokens: 5_400_000 }
+          ],
+          pct: 0.49,
+          reported: true,
+          resetsAt: 605_800_000,
+          startsAt: 1,
+          tokens: 102_322_100
+        }}
+      />
+    );
+
+    expect(screen.getByText('Local by model')).toBeDefined();
+    expect(screen.getByText('ran 102.3M locally')).toBeDefined();
+    expect(screen.getByText('Quota can include use not recorded in local sessions.')).toBeDefined();
+    expect(screen.queryByText('gpt-6-astra')).toBeNull();
+
+    const modelList = screen.getByText('gpt-5.6-sol').parentElement?.parentElement;
+    expect(modelList).not.toBeNull();
+    expect(within(modelList as HTMLElement).getAllByText(/^(gpt-|codex-)/).map((row) => row.textContent)).toEqual([
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'codex-auto-review',
+      'gpt-5.6-luna'
+    ]);
+  });
+});

--- a/src/renderer/components/ClaudeUsage/UsageMeter.tsx
+++ b/src/renderer/components/ClaudeUsage/UsageMeter.tsx
@@ -51,7 +51,9 @@ const Detail = ({ now, provider, reportedAt, title, window }: Omit<Props, 'label
   const known = window.reported || window.cap > 0;
   const pct = Math.round(window.pct * 100);
   const color = meterColor(window.pct);
-  const modelTotal = window.models.reduce((sum, m) => sum + m.tokens, 0);
+  const localModels = [...window.models].sort((a, b) => b.tokens - a.tokens || a.model.localeCompare(b.model));
+  const modelTotal = localModels.reduce((sum, m) => sum + m.tokens, 0);
+  const reportedCodex = provider === 'codex' && window.reported;
 
   return (
     <div className="w-[268px] p-4 text-bp-dark-gray-1 dark:text-bp-light-gray-5">
@@ -81,15 +83,20 @@ const Detail = ({ now, provider, reportedAt, title, window }: Omit<Props, 'label
           : 'Idle — no activity in this window'}
       </div>
 
-      {window.models.length > 0 && (
+      {localModels.length > 0 && (
         <div className="mt-3.5 border-t border-bp-light-gray-2 pt-3 dark:border-bp-dark-gray-3">
           <div className="mb-2 flex items-baseline justify-between">
-            <span className="text-[11px] font-semibold uppercase tracking-wide text-bp-gray-2">By model</span>
-            <span className="text-[11px] tabular-nums text-bp-gray-2">ran {formatTokens(window.tokens)}</span>
+            <span className="text-[11px] font-semibold uppercase tracking-wide text-bp-gray-2">
+              {reportedCodex ? 'Local by model' : 'By model'}
+            </span>
+
+            <span className="text-[11px] tabular-nums text-bp-gray-2">
+              ran {formatTokens(window.tokens)}{reportedCodex ? ' locally' : ''}
+            </span>
           </div>
 
           <div className="flex flex-col gap-1.5">
-            {window.models.map((m) => (
+            {localModels.map((m) => (
               <div
                 className="flex items-baseline justify-between gap-3 text-xs"
                 key={m.model}
@@ -106,6 +113,12 @@ const Detail = ({ now, provider, reportedAt, title, window }: Omit<Props, 'label
               </div>
             ))}
           </div>
+        </div>
+      )}
+
+      {reportedCodex && (
+        <div className="mt-3 text-[11px] leading-snug text-bp-gray-2">
+          Quota can include use not recorded in local sessions.
         </div>
       )}
 

--- a/src/renderer/hooks/usePinnedAppearance.test.ts
+++ b/src/renderer/hooks/usePinnedAppearance.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WindowAppearance, WindowOpacity } from 'types/window';
+
+import { usePinnedAppearance } from './usePinnedAppearance';
+
+const windowBridge = window.bridge.window;
+
+const deferred = <T,>() => {
+  let reject!: (reason?: unknown) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    reject = promiseReject;
+    resolve = promiseResolve;
+  });
+  return { promise, reject, resolve };
+};
+
+const flush = async () => {
+  await act(() => Promise.resolve());
+};
+
+describe('usePinnedAppearance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePinnedAppearance.setState({
+      alwaysOnTop: false,
+      initialized: false,
+      opacity: 1
+    });
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: false, opacity: 1 });
+    vi.mocked(windowBridge.setPinnedAppearance).mockImplementation((alwaysOnTop: boolean, opacity: WindowOpacity) => Promise.resolve({
+      alwaysOnTop,
+      opacity
+    }));
+  });
+
+  it('initializes once and exposes the native appearance', async () => {
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: true, opacity: 0.73 });
+    const { result } = renderHook(() => usePinnedAppearance());
+
+    await act(async () => Promise.all([result.current.initialize(), result.current.initialize()]));
+
+    expect(windowBridge.getPinnedAppearance).toHaveBeenCalledTimes(1);
+    expect(result.current).toMatchObject({ alwaysOnTop: true, initialized: true, opacity: 0.73 });
+  });
+
+  it('keeps one request in flight and sends only the latest pending value', async () => {
+    const first = deferred<WindowAppearance>();
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: true, opacity: 0.5 });
+    vi.mocked(windowBridge.setPinnedAppearance)
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementation((alwaysOnTop: boolean, opacity: WindowOpacity) => Promise.resolve({ alwaysOnTop, opacity }));
+    const { result } = renderHook(() => usePinnedAppearance());
+    await act(() => result.current.initialize());
+
+    act(() => {
+      result.current.setOpacity(0.51);
+      result.current.setOpacity(0.52);
+      result.current.setOpacity(0.53);
+    });
+    expect(windowBridge.setPinnedAppearance).toHaveBeenCalledTimes(1);
+
+    first.resolve({ alwaysOnTop: true, opacity: 0.51 });
+    await flush();
+    await flush();
+
+    expect(windowBridge.setPinnedAppearance).toHaveBeenCalledTimes(2);
+    expect(windowBridge.setPinnedAppearance).toHaveBeenLastCalledWith(true, 0.53);
+    expect(result.current.opacity).toBe(0.53);
+  });
+
+  it('resyncs after the latest request fails', async () => {
+    vi.mocked(windowBridge.getPinnedAppearance)
+      .mockResolvedValueOnce({ alwaysOnTop: true, opacity: 0.5 })
+      .mockResolvedValueOnce({ alwaysOnTop: true, opacity: 0.4 });
+    vi.mocked(windowBridge.setPinnedAppearance).mockRejectedValue(new Error('IPC failed'));
+    const { result } = renderHook(() => usePinnedAppearance());
+    await act(() => result.current.initialize());
+
+    act(() => result.current.setOpacity(0.51));
+    await flush();
+    await flush();
+
+    expect(windowBridge.getPinnedAppearance).toHaveBeenCalledTimes(2);
+    expect(result.current.opacity).toBe(0.4);
+  });
+
+  it('does not overwrite a newer choice during failure resync', async () => {
+    const first = deferred<WindowAppearance>();
+    const resync = deferred<WindowAppearance>();
+    vi.mocked(windowBridge.getPinnedAppearance)
+      .mockResolvedValueOnce({ alwaysOnTop: true, opacity: 0.5 })
+      .mockImplementationOnce(() => resync.promise);
+    vi.mocked(windowBridge.setPinnedAppearance)
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementation((alwaysOnTop: boolean, opacity: WindowOpacity) => Promise.resolve({ alwaysOnTop, opacity }));
+    const { result } = renderHook(() => usePinnedAppearance());
+    await act(() => result.current.initialize());
+
+    act(() => result.current.setOpacity(0.51));
+    first.reject(new Error('IPC failed'));
+    await flush();
+    act(() => result.current.setOpacity(0.52));
+    resync.resolve({ alwaysOnTop: true, opacity: 0.4 });
+    await flush();
+    await flush();
+
+    expect(result.current.opacity).toBe(0.52);
+    expect(windowBridge.setPinnedAppearance).toHaveBeenLastCalledWith(true, 0.52);
+  });
+
+  it('remembers logical opacity while unpinned', async () => {
+    vi.mocked(windowBridge.getPinnedAppearance).mockResolvedValue({ alwaysOnTop: true, opacity: 0.65 });
+    const { result } = renderHook(() => usePinnedAppearance());
+    await act(() => result.current.initialize());
+
+    act(() => result.current.togglePin());
+    await flush();
+    expect(result.current).toMatchObject({ alwaysOnTop: false, opacity: 0.65 });
+
+    act(() => result.current.togglePin());
+    await flush();
+    expect(windowBridge.setPinnedAppearance).toHaveBeenLastCalledWith(true, 0.65);
+  });
+});

--- a/src/renderer/hooks/usePinnedAppearance.ts
+++ b/src/renderer/hooks/usePinnedAppearance.ts
@@ -1,0 +1,96 @@
+import {
+  WINDOW_OPACITY_DEFAULT,
+  type WindowAppearance,
+  type WindowOpacity
+} from 'types/window';
+import { create } from 'zustand';
+
+type PinnedAppearanceState = WindowAppearance & {
+  initialize: () => Promise<void>;
+  initialized: boolean;
+  setOpacity: (opacity: WindowOpacity) => void;
+  togglePin: () => void;
+};
+
+const initialAppearance: WindowAppearance = {
+  alwaysOnTop: false,
+  opacity: WINDOW_OPACITY_DEFAULT
+};
+
+let desiredAppearance = initialAppearance;
+let pendingAppearance: undefined | WindowAppearance;
+let requestInFlight = false;
+let initializePromise: Promise<void> | undefined;
+let interactionVersion = 0;
+
+const sameAppearance = (left: WindowAppearance, right: WindowAppearance) =>
+  left.alwaysOnTop === right.alwaysOnTop && left.opacity === right.opacity;
+
+const showAppearance = (appearance: WindowAppearance) => {
+  desiredAppearance = appearance;
+  usePinnedAppearance.setState(appearance);
+};
+
+const drainAppearanceQueue = async () => {
+  if (requestInFlight || !pendingAppearance) return;
+
+  const sent = pendingAppearance;
+  pendingAppearance = undefined;
+  requestInFlight = true;
+
+  try {
+    const actual = await window.bridge.window.setPinnedAppearance(sent.alwaysOnTop, sent.opacity);
+    if (!pendingAppearance && sameAppearance(desiredAppearance, sent)) showAppearance(actual);
+  } catch {
+    try {
+      const actual = await window.bridge.window.getPinnedAppearance();
+      if (!pendingAppearance && sameAppearance(desiredAppearance, sent)) showAppearance(actual);
+    } catch {
+      // Keep the latest local choice when the window state cannot be read.
+    }
+  } finally {
+    requestInFlight = false;
+    if (pendingAppearance) void drainAppearanceQueue();
+  }
+};
+
+const requestAppearance = (appearance: WindowAppearance) => {
+  interactionVersion += 1;
+  showAppearance(appearance);
+  pendingAppearance = appearance;
+  void drainAppearanceQueue();
+};
+
+export const usePinnedAppearance = create<PinnedAppearanceState>()((set, get) => ({
+  ...initialAppearance,
+  initialize: () => {
+    if (get().initialized) return Promise.resolve();
+    if (initializePromise) return initializePromise;
+
+    const { alwaysOnTop, opacity } = get();
+    desiredAppearance = { alwaysOnTop, opacity };
+    const mountVersion = interactionVersion;
+    initializePromise = window.bridge.window.getPinnedAppearance()
+      .then((appearance: WindowAppearance) => {
+        if (interactionVersion === mountVersion) showAppearance(appearance);
+      })
+      .catch(() => {
+        // Use safe defaults if the native window state cannot be read.
+      })
+      .finally(() => {
+        set({ initialized: true });
+        initializePromise = undefined;
+      });
+
+    return initializePromise;
+  },
+  initialized: false,
+  setOpacity: (opacity) => requestAppearance({
+    alwaysOnTop: desiredAppearance.alwaysOnTop,
+    opacity
+  }),
+  togglePin: () => requestAppearance({
+    alwaysOnTop: !desiredAppearance.alwaysOnTop,
+    opacity: desiredAppearance.opacity
+  })
+}));

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -82,8 +82,8 @@ const mockBridge = {
     add: vi.fn()
   },
   window: {
-    getAlwaysOnTop: vi.fn().mockResolvedValue(false),
-    setAlwaysOnTop: vi.fn().mockResolvedValue(false)
+    getPinnedAppearance: vi.fn().mockResolvedValue({ alwaysOnTop: false, opacity: 1 }),
+    setPinnedAppearance: vi.fn().mockImplementation((alwaysOnTop, opacity) => Promise.resolve({ alwaysOnTop, opacity }))
   },
   worktree: {
     add: vi.fn(),

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -1,0 +1,12 @@
+export const WINDOW_OPACITY_MIN = 0.4;
+export const WINDOW_OPACITY_MAX = 1;
+export const WINDOW_OPACITY_STEP = 0.01;
+export const WINDOW_OPACITY_DEFAULT = 1;
+
+export type WindowAppearance = {
+  alwaysOnTop: boolean;
+  /** Saved glass level. The native window itself always stays fully opaque. */
+  opacity: WindowOpacity;
+};
+
+export type WindowOpacity = number;


### PR DESCRIPTION
## Summary
- add a live 40% to 100% native window opacity slider under the pin button
- show the control only while the window is pinned
- restore 100% opacity on unpin and restore the saved value on repin
- reduce the minimum window height from 600px to 300px
- clarify that the Codex model list uses local session data

## Checks
- 797 tests passed
- focused opacity tests passed
- production build passed
- live macOS QA passed at 40% and 100%
- final code review approved