### PR TITLE
Fix navbar icons disappearing after filtering

### DIFF
--- a/src/renderer/components/AppNavbar/AppNavbar.test.tsx
+++ b/src/renderer/components/AppNavbar/AppNavbar.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+const longBranch = 'HERO-10251/this-is-a-very-long-focused-worktree-name-that-must-not-hide-the-navbar-icons';
+
+vi.mock('renderer/hooks/useAIUsage', () => ({
+  useAIUsage: (selector: (state: object) => unknown) => selector({
+    accounts: [{ dir: '/test', provider: 'claude' }],
+    detection: { claude: { installed: true }, codex: { installed: false } },
+    discoveryErrors: {},
+    init: vi.fn()
+  })
+}));
+vi.mock('renderer/hooks/useAppSettings', () => ({
+  useAppSettings: () => ({
+    claudeEnabled: true,
+    clipboardDownscale: false,
+    set: vi.fn(),
+    showClaudeUsage: true,
+    showLogo: true
+  }),
+  useIsSunset: () => false
+}));
+vi.mock('renderer/hooks/useCommandPalette', () => ({
+  useCommandPalette: (selector: (state: object) => unknown) => selector({ open: vi.fn() })
+}));
+vi.mock('renderer/hooks/useDarkMode', () => ({
+  useDarkMode: () => ({ themeSource: 'light', toggleDarkMode: vi.fn() })
+}));
+vi.mock('renderer/hooks/useFilter', () => ({ useFilter: () => ({ clear: vi.fn() }) }));
+vi.mock('renderer/hooks/useFocus', () => ({
+  useFocus: () => ({
+    clearFocus: vi.fn(),
+    focusedProjectId: 'project-1',
+    focusedWorktreePath: '/repo/worktrees/long'
+  })
+}));
+vi.mock('renderer/hooks/useProjects', () => ({
+  useProjects: () => ({ addProject: vi.fn(), projects: [{ id: 'project-1', name: 'repo' }] })
+}));
+vi.mock('renderer/hooks/useWorktrees', () => ({
+  useWorktrees: (selector: (state: object) => unknown) => selector({
+    byProject: {
+      'project-1': [{ branch: longBranch, isMain: false, path: '/repo/worktrees/long', searchText: longBranch }]
+    }
+  })
+}));
+vi.mock('renderer/assets/devkitty.svg?react', () => ({
+  default: ({ className }: { className?: string }) => (
+    <svg
+      aria-label="Devkitty logo"
+      className={className}
+    />
+  )
+}));
+vi.mock('../ClaudeUsage', () => ({ ClaudeMark: () => <span data-testid="claude-mark" /> }));
+vi.mock('../ShinyText', () => ({ ShinyText: ({ text }: { text: string }) => <span>{text}</span> }));
+vi.mock('./AlwaysOnTopControl', () => ({
+  AlwaysOnTopControl: () => <button aria-label="Toggle always on top" />
+}));
+
+import { AppNavbar } from './AppNavbar';
+
+const expectClasses = (element: HTMLElement, ...classNames: string[]) => {
+  classNames.forEach((className) => expect(element.classList.contains(className)).toBe(true));
+};
+
+describe('AppNavbar layout', () => {
+  it('keeps a long focused name and every icon control on one stable row', () => {
+    render(
+      <MemoryRouter>
+        <AppNavbar />
+      </MemoryRouter>
+    );
+
+    const navbar = screen.getByTestId('app-navbar');
+    const left = screen.getByTestId('app-navbar-left');
+    const right = screen.getByTestId('app-navbar-right');
+    const search = screen.getByTestId('app-navbar-search');
+    const controls = screen.getByTestId('app-navbar-icon-controls');
+
+    expectClasses(navbar, 'flex', 'flex-nowrap', 'overflow-hidden');
+    expectClasses(left, 'shrink-0');
+    expectClasses(right, 'ml-auto', 'min-w-0', 'flex-nowrap');
+    expectClasses(search, 'min-w-0', 'shrink');
+    expectClasses(controls, 'shrink-0');
+
+    expect(screen.getByText(longBranch)).toBeTruthy();
+    expect(right.querySelector('.bp6-icon-refresh')).toBeTruthy();
+    expect(screen.getByTestId('claude-mark')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Toggle clipboard downscale' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Toggle always on top' })).toBeTruthy();
+    expect(right.querySelector('.bp6-icon-contrast')).toBeTruthy();
+    expect(right.querySelector('a[href="/settings"]')).toBeTruthy();
+    expect(right.querySelector('.devkitty-logo')).toBeTruthy();
+  });
+});

--- a/src/renderer/components/AppNavbar/AppNavbar.tsx
+++ b/src/renderer/components/AppNavbar/AppNavbar.tsx
@@ -202,13 +202,17 @@ export const AppNavbar = () => {
   return (
     <Navbar
       className={cn(
-        'app-region-drag select-none !shadow-none overflow-hidden',
+        'app-region-drag flex flex-nowrap items-center select-none !shadow-none overflow-hidden',
         isSunset
           ? 'devkitty-header-grad'
           : '!bg-bp-light-gray-4 dark:!bg-bp-dark-gray-1 dark:border-b dark:border-bp-dark-gray-2'
       )}
+      data-testid="app-navbar"
     >
-      <Navbar.Group className="app-region-no-drag ml-[70px] overflow-hidden">
+      <Navbar.Group
+        className="app-region-no-drag ml-[70px] shrink-0 overflow-hidden"
+        data-testid="app-navbar-left"
+      >
         <Button
           icon="plus"
           minimal
@@ -233,11 +237,15 @@ export const AppNavbar = () => {
 
       <Navbar.Group
         align="right"
-        className="app-region-no-drag ml-[70px] [&>button+button]:ml-2 [&>button+a]:ml-2"
+        className="app-region-no-drag ml-auto min-w-0 shrink flex-nowrap [&>button+button]:ml-2 [&>button+a]:ml-2"
+        data-testid="app-navbar-right"
       >
         {/* Nothing to filter anywhere but the project list. */}
         {onHome && (
-          <div className="flex items-center self-center mr-2">
+          <div
+            className="flex min-w-0 shrink items-center self-center mr-2"
+            data-testid="app-navbar-search"
+          >
             <SearchInput
               inputRef={searchRef}
               label={focusedName}
@@ -250,6 +258,7 @@ export const AppNavbar = () => {
         )}
 
         <Button
+          className="shrink-0"
           icon={<Icon className={refreshing ? 'animate-spin' : undefined}
             icon="refresh"
                 />}
@@ -257,9 +266,13 @@ export const AppNavbar = () => {
           onClick={refresh}
         />
 
-        <Navbar.Divider />
+        <Navbar.Divider className="shrink-0" />
 
-        <ButtonGroup minimal>
+        <ButtonGroup
+          className="shrink-0"
+          data-testid="app-navbar-icon-controls"
+          minimal
+        >
           {aiAvailable && (claudeEnabled ?? true) && (
             <Tooltip
               compact
@@ -332,8 +345,8 @@ export const AppNavbar = () => {
 
         {showLogo && (
           <>
-            <Navbar.Divider />
-            <Devkitty className="h-7 devkitty-logo" />
+            <Navbar.Divider className="shrink-0" />
+            <Devkitty className="h-7 shrink-0 devkitty-logo" />
           </>
         )}
       </Navbar.Group>


### PR DESCRIPTION
## What

- keep the navbar on one fixed flex row
- let long focused worktree names shrink
- keep the top-right icon controls visible and full size
- add a regression test for a long focused worktree name

## Checks

- focused Vitest test passed
- ESLint passed for both changed files
- production Electron build passed
- git diff check passed