### PR TITLE
Add AI usage providers and stabilize PR checks

### DIFF
--- a/src/main/ipcs/index.ts
+++ b/src/main/ipcs/index.ts
@@ -1,4 +1,5 @@
 import './ipcAnalytics';
+import './ipcAIUsageCredentials';
 import './ipcDarkMode';
 import './ipcSettings';
 import './ipcProjects';
@@ -10,4 +11,5 @@ import './ipcSticker';
 import './ipcWorktree';
 import './ipcClaude';
 import './ipcCodex';
+import './ipcCursor';
 import './ipcWindow';

--- a/src/main/ipcs/ipcAIUsageCredentials.test.ts
+++ b/src/main/ipcs/ipcAIUsageCredentials.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Handler = (...args: unknown[]) => unknown;
+const handlers: Record<string, Handler> = {};
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn((channel: string, handler: Handler) => { handlers[channel] = handler; }) } }));
+vi.mock('../libs/aiUsage/secrets', () => ({
+  aiUsageSecrets: { clear: vi.fn(), set: vi.fn(), status: vi.fn(() => ({ anthropic: true, openai: false })) }
+}));
+
+import { aiUsageSecrets } from '../libs/aiUsage/secrets';
+
+await import('./ipcAIUsageCredentials');
+
+describe('AI usage credential IPC', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns only saved status', () => {
+    expect(handlers['aiUsageCredentials:status']({})).toEqual({ anthropic: true, openai: false });
+  });
+
+  it('trims and saves an allowed provider key', () => {
+    handlers['aiUsageCredentials:set']({}, 'openai', ' sk-admin-secret ');
+    expect(aiUsageSecrets.set).toHaveBeenCalledWith('openai', 'sk-admin-secret');
+  });
+
+  it('rejects unknown providers and does not pass the key to storage', () => {
+    expect(() => handlers['aiUsageCredentials:set']({}, 'other', 'secret')).toThrow('Invalid AI usage provider');
+    expect(aiUsageSecrets.set).not.toHaveBeenCalled();
+  });
+
+  it('clears an allowed provider', () => {
+    handlers['aiUsageCredentials:clear']({}, 'anthropic');
+    expect(aiUsageSecrets.clear).toHaveBeenCalledWith('anthropic');
+  });
+});

--- a/src/main/ipcs/ipcAIUsageCredentials.ts
+++ b/src/main/ipcs/ipcAIUsageCredentials.ts
@@ -1,0 +1,16 @@
+import { ipcMain } from 'electron';
+
+import { type AIUsageCredentialProvider, aiUsageSecrets } from '../libs/aiUsage/secrets';
+
+const isProvider = (value: unknown): value is AIUsageCredentialProvider => value === 'anthropic' || value === 'openai';
+const provider = (value: unknown): AIUsageCredentialProvider => {
+  if (!isProvider(value)) throw new Error('Invalid AI usage provider');
+  return value;
+};
+
+ipcMain.handle('aiUsageCredentials:status', () => aiUsageSecrets.status());
+ipcMain.handle('aiUsageCredentials:set', (_event, name: unknown, value: unknown) => {
+  if (typeof value !== 'string') throw new Error('Invalid admin key');
+  aiUsageSecrets.set(provider(name), value.trim());
+});
+ipcMain.handle('aiUsageCredentials:clear', (_event, name: unknown) => aiUsageSecrets.clear(provider(name)));

--- a/src/main/ipcs/ipcClaude.test.ts
+++ b/src/main/ipcs/ipcClaude.test.ts
@@ -1,56 +1,46 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const handlers: Record<string, (...args: any[]) => any> = {};
+type Handler = (...args: unknown[]) => unknown;
+const handlers: Record<string, Handler> = {};
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn((channel: string, handler: Handler) => { handlers[channel] = handler; }) } }));
+vi.mock('../libs/aiUsage/secrets', () => ({ aiUsageSecrets: { get: vi.fn() } }));
+vi.mock('../libs/claude/accounts', () => ({ detectClaudeCli: vi.fn(), discoverAccounts: vi.fn() }));
+vi.mock('../libs/claude/adminUsage', () => ({ getClaudeAdminUsage: vi.fn() }));
+vi.mock('../libs/claude/getUsage', () => ({ buildUsage: vi.fn() }));
+vi.mock('../settings', () => ({ settings: { get: vi.fn(() => ({ anthropicUsageWorkspaceId: 'ws-1' })) } }));
 
-vi.mock('electron', () => ({
-  ipcMain: {
-    handle: vi.fn((channel: string, handler: any) => {
-      handlers[channel] = handler;
-    })
-  }
-}));
-
-vi.mock('../libs/claude/accounts', () => ({
-  detectClaudeCli: vi.fn(),
-  discoverAccounts: vi.fn()
-}));
-
-vi.mock('../libs/claude/getUsage', () => ({
-  buildUsage: vi.fn()
-}));
-
-import { detectClaudeCli, discoverAccounts } from '../libs/claude/accounts';
+import { aiUsageSecrets } from '../libs/aiUsage/secrets';
+import { discoverAccounts } from '../libs/claude/accounts';
+import { getClaudeAdminUsage } from '../libs/claude/adminUsage';
 import { buildUsage } from '../libs/claude/getUsage';
 
 await import('./ipcClaude');
 
-const mockDetect = vi.mocked(detectClaudeCli);
-const mockAccounts = vi.mocked(discoverAccounts);
-const mockBuildUsage = vi.mocked(buildUsage);
-
-describe('ipcClaude', () => {
+const account = { dir: '/claude', label: 'Claude' };
+const local = { account, computedAt: 1, metrics: [{ id: 'five-hour' }] };
+describe('Claude usage IPC', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(discoverAccounts).mockReturnValue([account]);
+    vi.mocked(buildUsage).mockResolvedValue(local as never);
+    vi.mocked(aiUsageSecrets.get).mockReturnValue('sk-ant-admin-secret');
   });
 
-  it('claude:detect delegates to detectClaudeCli', () => {
-    mockDetect.mockReturnValue(Promise.resolve({ installed: true, version: '2.1.0' }));
-    handlers['claude:detect']({});
-    expect(mockDetect).toHaveBeenCalledOnce();
+  it('adds the admin report to local usage', async () => {
+    vi.mocked(getClaudeAdminUsage).mockResolvedValue({ metric: { id: 'month' }, spend: { amountUsdMicros: 1 } } as never);
+    const result = await handlers['claude:usage']({}, { ...account, email: 'fake@example.test' }) as { metrics: unknown[]; spend: unknown };
+    expect(buildUsage).toHaveBeenCalledWith(account, expect.any(Number));
+    expect(result.metrics).toEqual([{ id: 'five-hour' }, { id: 'month' }]);
+    expect(result.spend).toEqual({ amountUsdMicros: 1 });
   });
 
-  it('claude:accounts delegates to discoverAccounts', () => {
-    mockAccounts.mockReturnValue([{ dir: '/home/.claude', label: 'claude' }]);
-    const res = handlers['claude:accounts']({});
-    expect(mockAccounts).toHaveBeenCalledOnce();
-    expect(res).toEqual([{ dir: '/home/.claude', label: 'claude' }]);
+  it('keeps local usage when the admin report fails', async () => {
+    vi.mocked(getClaudeAdminUsage).mockRejectedValue(new Error('admin failed'));
+    await expect(handlers['claude:usage']({}, { dir: '/claude' })).resolves.toEqual(local);
   });
 
-  it('claude:usage builds usage for the given account with a current timestamp', () => {
-    const account = { dir: '/home/.claude', label: 'claude' };
-    handlers['claude:usage']({}, account);
-    expect(mockBuildUsage).toHaveBeenCalledOnce();
-    expect(mockBuildUsage.mock.calls[0][0]).toBe(account);
-    expect(typeof mockBuildUsage.mock.calls[0][1]).toBe('number');
+  it.each([null, {}, { ...account, dir: '/forged' }])('rejects an untrusted account %j', async (value) => {
+    await expect(handlers['claude:usage']({}, value)).rejects.toThrow();
+    expect(buildUsage).not.toHaveBeenCalled();
   });
 });

--- a/src/main/ipcs/ipcClaude.ts
+++ b/src/main/ipcs/ipcClaude.ts
@@ -1,11 +1,28 @@
 import { ipcMain } from 'electron';
 import { type ClaudeAccount } from 'types/claudeUsage';
 
+import { aiUsageSecrets } from '../libs/aiUsage/secrets';
 import { detectClaudeCli, discoverAccounts } from '../libs/claude/accounts';
+import { getClaudeAdminUsage } from '../libs/claude/adminUsage';
 import { buildUsage } from '../libs/claude/getUsage';
+import { settings } from '../settings';
 
 ipcMain.handle('claude:detect', () => detectClaudeCli());
 
 ipcMain.handle('claude:accounts', () => discoverAccounts());
 
-ipcMain.handle('claude:usage', (_event, account: ClaudeAccount) => buildUsage(account, Date.now()));
+ipcMain.handle('claude:usage', async (_event, account: ClaudeAccount) => {
+  if (!account || typeof account.dir !== 'string') throw new Error('Invalid Claude account');
+  const discovered = discoverAccounts().find(({ dir }) => dir === account.dir);
+  if (!discovered) throw new Error('Claude account is no longer available');
+  const now = Date.now();
+  const local = await buildUsage(discovered, now);
+  const key = aiUsageSecrets.get('anthropic');
+  if (!key) return local;
+  try {
+    const admin = await getClaudeAdminUsage(key, settings.get('appSettings').anthropicUsageWorkspaceId, now);
+    return { ...local, metrics: [...local.metrics, admin.metric], spend: admin.spend };
+  } catch {
+    return local;
+  }
+});

--- a/src/main/ipcs/ipcCodex.test.ts
+++ b/src/main/ipcs/ipcCodex.test.ts
@@ -3,31 +3,38 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 type Handler = (...args: unknown[]) => unknown;
 const handlers: Record<string, Handler> = {};
 vi.mock('electron', () => ({ ipcMain: { handle: vi.fn((channel: string, handler: Handler) => { handlers[channel] = handler; }) } }));
+vi.mock('../libs/aiUsage/secrets', () => ({ aiUsageSecrets: { get: vi.fn() } }));
 vi.mock('../libs/codex/accounts', () => ({ detectCodexCli: vi.fn(), discoverAccounts: vi.fn() }));
+vi.mock('../libs/codex/adminUsage', () => ({ getCodexAdminUsage: vi.fn() }));
 vi.mock('../libs/codex/getUsage', () => ({ buildUsage: vi.fn() }));
+vi.mock('../settings', () => ({ settings: { get: vi.fn(() => ({ openAIUsageProjectId: 'proj-1' })) } }));
 
-import { detectCodexCli, discoverAccounts } from '../libs/codex/accounts';
+import { aiUsageSecrets } from '../libs/aiUsage/secrets';
+import { discoverAccounts } from '../libs/codex/accounts';
+import { getCodexAdminUsage } from '../libs/codex/adminUsage';
 import { buildUsage } from '../libs/codex/getUsage';
 
 await import('./ipcCodex');
 
-const account = { dir: '/home/.codex', label: 'codex', provider: 'codex' as const };
-beforeEach(() => { vi.clearAllMocks(); vi.mocked(discoverAccounts).mockReturnValue([account]); });
-
-describe('Codex IPC', () => {
-  it('delegates discovery and CLI detection', () => {
-    handlers['codex:detect']({});
-    expect(detectCodexCli).toHaveBeenCalledOnce();
-    expect(handlers['codex:accounts']({})).toEqual([account]);
+const account = { dir: '/codex', label: 'Codex', provider: 'codex' as const };
+const local = { account, computedAt: 1, metrics: [{ id: 'five-hour' }] };
+describe('Codex usage IPC', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(discoverAccounts).mockReturnValue([account]);
+    vi.mocked(buildUsage).mockResolvedValue(local as never);
+    vi.mocked(aiUsageSecrets.get).mockReturnValue('sk-admin-secret');
   });
 
-  it('reads only rediscovered profile and discards caller-supplied display metadata', () => {
-    handlers['codex:usage']({}, { ...account, email: 'untrusted@example.test' });
-    expect(buildUsage).toHaveBeenCalledWith(account, expect.any(Number));
+  it('adds the admin report to local usage', async () => {
+    vi.mocked(getCodexAdminUsage).mockResolvedValue({ metric: { id: 'month' }, spend: { amountUsdMicros: 2 } } as never);
+    const result = await handlers['codex:usage']({}, account) as { metrics: unknown[]; spend: unknown };
+    expect(result.metrics).toEqual([{ id: 'five-hour' }, { id: 'month' }]);
+    expect(result.spend).toEqual({ amountUsdMicros: 2 });
   });
 
-  it.each([null, {}, { ...account, provider: 'claude' }, { ...account, dir: '/arbitrary/private' }])('rejects invalid profile %j', (value) => {
-    expect(() => handlers['codex:usage']({}, value)).toThrow();
-    expect(buildUsage).not.toHaveBeenCalled();
+  it('keeps local usage when the admin report fails', async () => {
+    vi.mocked(getCodexAdminUsage).mockRejectedValue(new Error('admin failed'));
+    await expect(handlers['codex:usage']({}, account)).resolves.toEqual(local);
   });
 });

--- a/src/main/ipcs/ipcCodex.ts
+++ b/src/main/ipcs/ipcCodex.ts
@@ -1,14 +1,26 @@
 import { ipcMain } from 'electron';
 import { type AIAccount } from 'types/aiUsage';
 
+import { aiUsageSecrets } from '../libs/aiUsage/secrets';
 import { detectCodexCli, discoverAccounts } from '../libs/codex/accounts';
+import { getCodexAdminUsage } from '../libs/codex/adminUsage';
 import { buildUsage } from '../libs/codex/getUsage';
+import { settings } from '../settings';
 
 ipcMain.handle('codex:detect', () => detectCodexCli());
 ipcMain.handle('codex:accounts', () => discoverAccounts());
-ipcMain.handle('codex:usage', (_event, account: AIAccount) => {
+ipcMain.handle('codex:usage', async (_event, account: AIAccount) => {
   if (account?.provider !== 'codex' || typeof account.dir !== 'string') throw new Error('Invalid Codex account');
   const discovered = discoverAccounts().find(({ dir }) => dir === account.dir);
   if (!discovered) throw new Error('Codex account is no longer available');
-  return buildUsage(discovered, Date.now());
+  const now = Date.now();
+  const local = await buildUsage(discovered, now);
+  const key = aiUsageSecrets.get('openai');
+  if (!key) return local;
+  try {
+    const admin = await getCodexAdminUsage(key, settings.get('appSettings').openAIUsageProjectId, now);
+    return { ...local, metrics: [...local.metrics, admin.metric], spend: admin.spend };
+  } catch {
+    return local;
+  }
 });

--- a/src/main/ipcs/ipcCursor.test.ts
+++ b/src/main/ipcs/ipcCursor.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Handler = (...args: unknown[]) => unknown;
+const handlers: Record<string, Handler> = {};
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn((channel: string, handler: Handler) => { handlers[channel] = handler; }) } }));
+vi.mock('../libs/cursor/accounts', () => ({ detectCursor: vi.fn(), discoverAccounts: vi.fn() }));
+vi.mock('../libs/cursor/getUsage', () => ({ buildUsage: vi.fn() }));
+
+import { detectCursor, discoverAccounts } from '../libs/cursor/accounts';
+import { buildUsage } from '../libs/cursor/getUsage';
+
+await import('./ipcCursor');
+
+const account = { dir: '/trusted/cursor', label: 'cursor', provider: 'cursor' as const };
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(discoverAccounts).mockReturnValue([account]);
+});
+
+describe('Cursor IPC', () => {
+  it('delegates detection and discovery', () => {
+    handlers['cursor:detect']({});
+    expect(detectCursor).toHaveBeenCalledOnce();
+    expect(handlers['cursor:accounts']({})).toEqual([account]);
+  });
+
+  it('uses the rediscovered account and drops caller display data', () => {
+    handlers['cursor:usage']({}, { ...account, email: 'forged@example.test' });
+    expect(buildUsage).toHaveBeenCalledWith(account, expect.any(Number));
+  });
+
+  it.each([null, {}, { ...account, provider: 'codex' }, { ...account, dir: '/forged' }])('rejects an untrusted account %j', (value) => {
+    expect(() => handlers['cursor:usage']({}, value)).toThrow();
+    expect(buildUsage).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/ipcs/ipcCursor.ts
+++ b/src/main/ipcs/ipcCursor.ts
@@ -1,0 +1,14 @@
+import { ipcMain } from 'electron';
+import { type AIAccount } from 'types/aiUsage';
+
+import { detectCursor, discoverAccounts } from '../libs/cursor/accounts';
+import { buildUsage } from '../libs/cursor/getUsage';
+
+ipcMain.handle('cursor:detect', () => detectCursor());
+ipcMain.handle('cursor:accounts', () => discoverAccounts());
+ipcMain.handle('cursor:usage', (_event, account: AIAccount) => {
+  if (account?.provider !== 'cursor' || typeof account.dir !== 'string') throw new Error('Invalid Cursor account');
+  const discovered = discoverAccounts().find(({ dir }) => dir === account.dir);
+  if (!discovered) throw new Error('Cursor account is no longer available');
+  return buildUsage(discovered, Date.now());
+});

--- a/src/main/ipcs/ipcGitHub.test.ts
+++ b/src/main/ipcs/ipcGitHub.test.ts
@@ -4,6 +4,7 @@ const handlers: Record<string, (...args: any[]) => any> = {};
 
 const mockOctokitInstance = {
   graphql: vi.fn(),
+  paginate: vi.fn(),
   rest: {
     actions: {
       cancelWorkflowRun: vi.fn(),
@@ -51,13 +52,15 @@ vi.mock('electron', () => ({
 vi.mock('electron-log', () => ({
   default: {
     error: vi.fn(),
-    info: vi.fn()
+    info: vi.fn(),
+    warn: vi.fn()
   }
 }));
 
 vi.mock('octokit', () => ({
   Octokit: class MockOctokit {
     graphql = mockOctokitInstance.graphql;
+    paginate = mockOctokitInstance.paginate;
     rest = mockOctokitInstance.rest;
   }
 }));
@@ -520,7 +523,7 @@ describe('ipcGitHub', () => {
       head: { sha: 'sha123' },
       mergeable: true,
       mergeable_state: 'clean',
-      requested_reviewers: [],
+      requested_reviewers: [] as { avatar_url: string; login: string }[],
       user: { login: 'author' }
     };
 
@@ -529,8 +532,16 @@ describe('ipcGitHub', () => {
         autoMergeAllowed: true,
         mergeCommitAllowed: true,
         pullRequest: {
-          autoMergeRequest: null,
-          reviewThreads: { nodes: [] },
+          autoMergeRequest: null as null | { enabledAt: string },
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+          reviewThreads: {
+            nodes: [] as {
+              comments: { nodes: { author: null | { avatarUrl: string; login: string } }[]; totalCount: number };
+              isResolved: boolean;
+              path: null | string;
+            }[]
+          },
           viewerCanEnableAutoMerge: true
         },
         rebaseMergeAllowed: true,
@@ -542,6 +553,8 @@ describe('ipcGitHub', () => {
       mockOctokitInstance.rest.checks.listForRef.mockResolvedValue({
         data: { check_runs: [{ conclusion: 'success', id: 1, name: 'build', status: 'completed' }] }
       });
+      mockOctokitInstance.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({ data: { workflow_runs: [] } });
+      mockOctokitInstance.paginate.mockResolvedValue([]);
       mockOctokitInstance.rest.pulls.listReviews.mockResolvedValue({ data: [] });
       mockOctokitInstance.graphql.mockResolvedValue(cleanGraphql);
       mockOctokitInstance.rest.repos.compareCommits.mockResolvedValue({ data: { behind_by: 0 } });
@@ -572,6 +585,53 @@ describe('ipcGitHub', () => {
       expect(result.behind).toBe(false);
       expect(result.mergeable).toBe(true);
       expect(result.mergeableState).toBe('clean');
+    });
+
+    it('should return full workflow runs for the exact PR head SHA', async () => {
+      const workflowRuns = [
+        { conclusion: 'success', head_sha: 'sha123', id: 99, name: 'Build', status: 'completed' }
+      ];
+      mockOctokitInstance.rest.pulls.get.mockResolvedValue({ data: basePr });
+      mockOctokitInstance.paginate.mockResolvedValue(workflowRuns);
+
+      const result = await handlers['git:api:getPRChecks']({}, 'proj-1', 42);
+
+      expect(mockOctokitInstance.paginate).toHaveBeenCalledWith(
+        mockOctokitInstance.rest.actions.listWorkflowRunsForRepo,
+        {
+          head_sha: 'sha123',
+          owner: 'egor-xyz',
+          per_page: 100,
+          repo: 'devkitty'
+        }
+      );
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.workflowRuns).toEqual(workflowRuns);
+    });
+
+    it('should fetch every page of exact-head workflow runs', async () => {
+      const workflowRuns = Array.from({ length: 101 }, (_, id) => ({ head_sha: 'sha123', id }));
+      mockOctokitInstance.rest.pulls.get.mockResolvedValue({ data: basePr });
+      mockOctokitInstance.paginate.mockResolvedValue(workflowRuns);
+
+      const result = await handlers['git:api:getPRChecks']({}, 'proj-1', 42);
+
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.workflowRuns).toHaveLength(101);
+    });
+
+    it('should keep PR status when exact-head workflow runs fail to load', async () => {
+      mockOctokitInstance.rest.pulls.get.mockResolvedValue({ data: basePr });
+      mockOctokitInstance.paginate.mockRejectedValue(new Error('Actions history unavailable'));
+
+      const result = await handlers['git:api:getPRChecks']({}, 'proj-1', 42);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.checks).toEqual([{ conclusion: 'success', id: 1, name: 'build', status: 'completed' }]);
+        expect(result.mergeableState).toBe('clean');
+        expect(result.workflowRuns).toEqual([]);
+      }
     });
 
     it('should report changes_requested as the overall state when any reviewer requests changes', async () => {
@@ -631,6 +691,21 @@ describe('ipcGitHub', () => {
       expect(result.unresolvedThreads).toEqual([]);
       expect(result.autoMergeAllowed).toBe(false);
       expect(result.allowedMergeMethods).toEqual([]);
+      expect(result.mergeable).toBe(true);
+      expect(result.mergeableState).toBe('clean');
+    });
+
+    it('should use the later GraphQL merge state instead of stale REST merge state', async () => {
+      mockOctokitInstance.rest.pulls.get.mockResolvedValue({
+        data: { ...basePr, mergeable: false, mergeable_state: 'blocked' }
+      });
+      mockOctokitInstance.graphql.mockResolvedValue(cleanGraphql);
+
+      const result = await handlers['git:api:getPRChecks']({}, 'proj-1', 42);
+
+      expect(result.success).toBe(true);
+      expect(result.mergeable).toBe(true);
+      expect(result.mergeableState).toBe('clean');
     });
 
     it('should surface unresolved review threads from GraphQL', async () => {

--- a/src/main/ipcs/ipcGitHub.ts
+++ b/src/main/ipcs/ipcGitHub.ts
@@ -2,7 +2,7 @@ import { execFile } from 'child_process';
 import { ipcMain, safeStorage } from 'electron';
 import log from 'electron-log';
 import { Octokit } from 'octokit';
-import { type PullType, type Run } from 'types/gitHub';
+import { type MergeableState, type MergeMethod, type PRStatusResult, type PullType, type Run } from 'types/gitHub';
 import { promisify } from 'util';
 
 import { getProjectPath, getRepoInfo } from '../libs/git';
@@ -84,6 +84,22 @@ ipcMain.handle('git:api:reset', async (_, id: string, origin: string, target: st
 // out anyway; polls stay on one page and merge into what the renderer already
 // holds.
 const maxPages = 5;
+
+const mergeableStates = [
+  'behind',
+  'blocked',
+  'clean',
+  'dirty',
+  'draft',
+  'has_hooks',
+  'unknown',
+  'unstable'
+] as const satisfies readonly MergeableState[];
+
+const toMergeableState = (state: null | string | undefined): MergeableState => {
+  const normalized = state?.toLowerCase();
+  return mergeableStates.find((value) => value === normalized) ?? 'unknown';
+};
 
 ipcMain.handle('git:api:getRuns', async (_, id: string, deep = false) => {
   try {
@@ -275,33 +291,43 @@ ipcMain.handle('git:api:rerunFailedJobs', async (_, id: string, runId: number) =
   }
 });
 
-ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number) => {
+ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number): Promise<PRStatusResult> => {
   try {
     const { owner, repo } = await getRepoInfo(id);
     if (!owner || !repo) throw new Error('Project not found');
 
-    let { data: pr } = await octokit().rest.pulls.get({
+    const { data: pr } = await octokit().rest.pulls.get({
       owner,
       pull_number: prNumber,
       repo
     });
 
-    // GitHub computes mergeable/mergeable_state asynchronously; the first read
-    // after any change returns mergeable: null (state 'unknown'). Poll briefly
-    // so the Merge affordance reflects the real state instead of staying hidden
-    // behind a stale "unknown".
-    for (let attempt = 0; attempt < 3 && pr.mergeable === null; attempt += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 700));
-      ({ data: pr } = await octokit().rest.pulls.get({ owner, pull_number: prNumber, repo }));
-    }
-
-    const {sha} = pr.head;
+    const { sha } = pr.head;
 
     const { data } = await octokit().rest.checks.listForRef({
       owner,
       ref: sha,
       repo
     });
+
+    // The normal Actions poll only keeps recent runs. PR checks need a separate
+    // request because a PR can still point at an older commit. GitHub filters
+    // this endpoint by the exact commit SHA, so rows and check totals describe
+    // the same revision in normal and filtered views.
+    const github = octokit();
+    let workflowRuns: Run[] = [];
+    try {
+      workflowRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+        head_sha: sha,
+        owner,
+        per_page: 100,
+        repo
+      });
+    } catch (error) {
+      // Workflow rows are extra detail. Keep checks, review, and merge actions
+      // usable when the Actions history endpoint has a temporary failure.
+      log.warn('Failed to fetch workflow runs for PR head', error);
+    }
 
     // GitHub returns every check run for the head SHA, including stale ones a
     // re-run (or a superseding push) replaced — an old "cancelled"/"failure" run
@@ -407,11 +433,13 @@ ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number) =>
     // One GraphQL round-trip for the things REST can't give us: unresolved
     // review conversations (GitHub blocks merge on these), and whether auto-merge
     // is available / already armed for this PR.
+    let mergeable = pr.mergeable ?? null;
+    let mergeableState = toMergeableState(pr.mergeable_state);
     let unresolvedComments = 0;
     let unresolvedThreads: { avatarUrl: string; count: number; login: string; path: null | string }[] = [];
     let autoMergeAllowed = false;
     let autoMergeEnabled = false;
-    let allowedMergeMethods: ('merge' | 'rebase' | 'squash')[] = [];
+    let allowedMergeMethods: MergeMethod[] = [];
     try {
       const gql = await octokit().graphql<{
         repository: {
@@ -419,6 +447,8 @@ ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number) =>
           mergeCommitAllowed: boolean;
           pullRequest: {
             autoMergeRequest: null | { enabledAt: string };
+            mergeable: 'CONFLICTING' | 'MERGEABLE' | 'UNKNOWN';
+            mergeStateStatus: string;
             reviewThreads: {
               nodes: {
                 comments: { nodes: { author: null | { avatarUrl: string; login: string } }[]; totalCount: number };
@@ -439,6 +469,8 @@ ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number) =>
             mergeCommitAllowed
             rebaseMergeAllowed
             pullRequest(number: $num) {
+              mergeable
+              mergeStateStatus
               reviewThreads(first: 100) {
                 nodes {
                   isResolved
@@ -457,6 +489,8 @@ ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number) =>
         { num: prNumber, owner, repo }
       );
       const gqlPr = gql.repository.pullRequest;
+      mergeable = gqlPr.mergeable === 'MERGEABLE' ? true : gqlPr.mergeable === 'CONFLICTING' ? false : null;
+      mergeableState = toMergeableState(gqlPr.mergeStateStatus);
       const unresolved = gqlPr.reviewThreads.nodes.filter((t) => !t.isResolved);
       unresolvedComments = unresolved.length;
       unresolvedThreads = unresolved.map((t) => ({
@@ -503,12 +537,13 @@ ipcMain.handle('git:api:getPRChecks', async (_, id: string, prNumber: number) =>
       autoMergeEnabled,
       behind,
       checks,
-      mergeable: pr.mergeable ?? null,
-      mergeableState: pr.mergeable_state ?? 'unknown',
+      mergeable,
+      mergeableState,
       review,
       success: true,
       unresolvedComments,
-      unresolvedThreads
+      unresolvedThreads,
+      workflowRuns
     };
   } catch (e) {
     log.error(e);

--- a/src/main/libs/aiUsage/admin.ts
+++ b/src/main/libs/aiUsage/admin.ts
@@ -1,0 +1,84 @@
+import { type AIUsageMetric, type AIUsageSpend } from 'types/aiUsage';
+
+import { fetchJson } from './fetchJson';
+
+export const ADMIN_CACHE_MS = 5 * 60 * 1000;
+export const MAX_ADMIN_PAGES = 20;
+
+export type AIAdminUsage = {
+  metric: AIUsageMetric;
+  reportedAt: number;
+  spend: AIUsageSpend;
+};
+
+type AdminPagesOptions = {
+  endpoint: string;
+  fetcher: Fetcher;
+  headers: Record<string, string>;
+  params: URLSearchParams;
+};
+
+type Fetcher = typeof fetch;
+
+export const currentUtcMonth = (now: number) => {
+  const date = new Date(now);
+  return {
+    endMs: now,
+    startMs: Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1)
+  };
+};
+
+export const decimalToMicros = (value: string, unitMicros: bigint): number => {
+  const match = /^(\d+)(?:\.(\d+))?$/.exec(value);
+  if (!match) throw new Error('Invalid money amount');
+  const fraction = match[2] ?? '';
+  const scale = 10n ** BigInt(fraction.length);
+  const units = BigInt(match[1]) * scale + BigInt(fraction || '0');
+  const numerator = units * unitMicros;
+  const rounded = (numerator + scale / 2n) / scale;
+  if (rounded > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error('Money amount is too large');
+  return Number(rounded);
+};
+
+export const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readPage = (value: unknown): { data: Record<string, unknown>[]; hasMore: boolean; nextPage?: string } => {
+  if (!isObject(value) || !Array.isArray(value.data) || !value.data.every(isObject) || typeof value.has_more !== 'boolean') {
+    throw new Error('Invalid admin response');
+  }
+  if (value.has_more && typeof value.next_page !== 'string') throw new Error('Invalid admin response');
+  return {
+    data: value.data,
+    hasMore: value.has_more,
+    ...(typeof value.next_page === 'string' ? { nextPage: value.next_page } : {})
+  };
+};
+
+export const fetchAdminPages = async ({ endpoint, fetcher, headers, params }: AdminPagesOptions): Promise<Record<string, unknown>[]> => {
+  const rows: Record<string, unknown>[] = [];
+  const seen = new Set<string>();
+  let page: string | undefined;
+
+  for (let pageIndex = 0; pageIndex < MAX_ADMIN_PAGES; pageIndex += 1) {
+    const pageParams = new URLSearchParams(params);
+    if (page) pageParams.set('page', page);
+    const response = readPage(await fetchJson(`${endpoint}?${pageParams}`, { fetcher, headers }));
+    rows.push(...response.data);
+    if (!response.hasMore) return rows;
+    if (!response.nextPage || seen.has(response.nextPage)) throw new Error('Invalid admin pagination');
+    page = response.nextPage;
+    seen.add(page);
+  }
+
+  throw new Error('Admin pagination limit reached');
+};
+
+export const readBucketResults = (buckets: Record<string, unknown>[]): Record<string, unknown>[] => buckets.flatMap((bucket) => {
+  if (!Array.isArray(bucket.results) || !bucket.results.every(isObject)) throw new Error('Invalid admin response');
+  return bucket.results;
+});
+
+export const safeNonNegativeInteger = (value: unknown): number => {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) throw new Error('Invalid usage response');
+  return value;
+};

--- a/src/main/libs/aiUsage/fetchJson.test.ts
+++ b/src/main/libs/aiUsage/fetchJson.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchJson } from './fetchJson';
+
+describe('fetchJson', () => {
+  it('returns parsed JSON', async () => {
+    await expect(fetchJson('https://test', { fetcher: vi.fn(async () => new Response('{"ok":true}')) })).resolves.toEqual({ ok: true });
+  });
+
+  it('caps response bytes', async () => {
+    const fetcher = vi.fn(async () => new Response('x'.repeat(20)));
+    await expect(fetchJson('https://test', { fetcher, maxBytes: 10 })).rejects.toThrow('too large');
+  });
+
+  it('times out and does not expose a request error', async () => {
+    const secret = 'sk-admin-secret';
+    const fetcher = vi.fn((_url: string, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new Error(secret)));
+    }));
+    const error = await fetchJson('https://test', { fetcher, timeoutMs: 1 }).catch((value: unknown) => value);
+    expect(String(error)).toContain('timed out');
+    expect(String(error)).not.toContain(secret);
+  });
+
+  it('does not expose an HTTP response body', async () => {
+    const secret = 'private response';
+    const error = await fetchJson('https://test', { fetcher: vi.fn(async () => new Response(secret, { status: 400 })) }).catch((value: unknown) => value);
+    expect(String(error)).toBe('Error: Request failed (400)');
+    expect(String(error)).not.toContain(secret);
+  });
+});

--- a/src/main/libs/aiUsage/fetchJson.ts
+++ b/src/main/libs/aiUsage/fetchJson.ts
@@ -1,0 +1,60 @@
+const DEFAULT_MAX_BYTES = 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export type FetchJsonOptions = {
+  fetcher?: Fetcher;
+  headers?: Record<string, string>;
+  maxBytes?: number;
+  method?: 'GET';
+  timeoutMs?: number;
+};
+
+type Fetcher = typeof fetch;
+
+const readLimitedBody = async (response: Response, maxBytes: number): Promise<string> => {
+  const declaredSize = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declaredSize) && declaredSize > maxBytes) throw new Error('Response is too large');
+
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let text = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > maxBytes) {
+      await reader.cancel();
+      throw new Error('Response is too large');
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
+};
+
+export const fetchJson = async (url: string, options: FetchJsonOptions = {}): Promise<unknown> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const response = await (options.fetcher ?? fetch)(url, {
+      headers: options.headers,
+      method: options.method ?? 'GET',
+      signal: controller.signal
+    });
+    if (!response.ok) throw new Error(`Request failed (${response.status})`);
+    const body = await readLimitedBody(response, options.maxBytes ?? DEFAULT_MAX_BYTES);
+    try {
+      return JSON.parse(body) as unknown;
+    } catch {
+      throw new Error('Response is not valid JSON');
+    }
+  } catch (error) {
+    if (error instanceof Error && ['Response is not valid JSON', 'Response is too large'].includes(error.message)) throw error;
+    if (controller.signal.aborted) throw new Error('Request timed out');
+    if (error instanceof Error && /^Request failed \(\d+\)$/.test(error.message)) throw error;
+    throw new Error('Request failed');
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/src/main/libs/aiUsage/localMetric.ts
+++ b/src/main/libs/aiUsage/localMetric.ts
@@ -1,0 +1,31 @@
+import { type AIUsageMetric } from 'types/aiUsage';
+
+import { modelBreakdown, type UsageEntry } from '../claude/usage';
+
+type LocalMetricOptions = {
+  entries: UsageEntry[];
+  id: 'five-hour' | 'seven-day';
+  now: number;
+  reported?: ReportedWindow;
+  title: string;
+  windowMs: number;
+};
+
+type ReportedWindow = { pct: number; resetsAt: number };
+
+export const buildLocalMetric = ({ entries, id, now, reported, title, windowMs }: LocalMetricOptions): AIUsageMetric => {
+  const startsAt = reported ? reported.resetsAt - windowMs : now - windowMs;
+  const models = modelBreakdown(entries, startsAt, now);
+
+  return {
+    id,
+    label: reported ? `${title} usage` : `${title} · Quota unavailable`,
+    models,
+    ...(reported ? { percent: reported.pct, resetsAt: reported.resetsAt } : {}),
+    scope: 'account',
+    source: reported ? 'provider' : 'local',
+    title,
+    tokens: models.reduce((total, model) => total + model.tokens, 0),
+    tokensPeriod: reported ? 'provider-period' : 'trailing-window'
+  };
+};

--- a/src/main/libs/aiUsage/secrets.test.ts
+++ b/src/main/libs/aiUsage/secrets.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({ safeStorage: {} }));
+vi.mock('electron-store', () => ({ default: class { delete = vi.fn(); get = vi.fn(); set = vi.fn(); } }));
+
+import { createAIUsageSecrets } from './secrets';
+
+describe('AI usage secrets', () => {
+  const values = new Map<string, string>();
+  const store = {
+    delete: vi.fn((key: string) => values.delete(key)),
+    get: vi.fn((key: string) => values.get(key)),
+    set: vi.fn((key: string, value: string) => values.set(key, value))
+  };
+  const crypto = {
+    decryptString: vi.fn((value: Buffer) => value.toString().replace('locked:', '')),
+    encryptString: vi.fn((value: string) => Buffer.from(`locked:${value}`)),
+    isEncryptionAvailable: vi.fn(() => true)
+  };
+  const secrets = createAIUsageSecrets(store, crypto);
+
+  beforeEach(() => {
+    values.clear();
+    vi.clearAllMocks();
+  });
+
+  it('stores only encrypted text and returns only boolean status', () => {
+    secrets.set('anthropic', 'sk-ant-admin-secret');
+    expect([...values.values()][0]).not.toContain('sk-ant-admin-secret');
+    expect(secrets.status()).toEqual({ anthropic: true, openai: false });
+  });
+
+  it.each([
+    ['anthropic', 'sk-ant-api03-normal'],
+    ['openai', 'sk-proj-normal']
+  ] as const)('rejects a normal %s API key', (provider, key) => {
+    expect(() => secrets.set(provider, key)).toThrow('admin key');
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it('does not write when secure storage is unavailable', () => {
+    crypto.isEncryptionAvailable.mockReturnValueOnce(false);
+    expect(() => secrets.set('openai', 'sk-admin-secret')).toThrow('Secure storage');
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it('clears a key and hides damaged encrypted data', () => {
+    values.set('openai', 'bad');
+    crypto.decryptString.mockImplementationOnce(() => { throw new Error('bad'); });
+    expect(secrets.status().openai).toBe(false);
+    secrets.clear('openai');
+    expect(values.has('openai')).toBe(false);
+  });
+});

--- a/src/main/libs/aiUsage/secrets.ts
+++ b/src/main/libs/aiUsage/secrets.ts
@@ -1,0 +1,47 @@
+import { safeStorage } from 'electron';
+import Store from 'electron-store';
+
+export type AIUsageCredentialProvider = 'anthropic' | 'openai';
+type EncryptedSecretStore = {
+  delete: (key: AIUsageCredentialProvider) => void;
+  get: (key: AIUsageCredentialProvider) => string | undefined;
+  set: (key: AIUsageCredentialProvider, value: string) => void;
+};
+type SecretCrypto = {
+  decryptString: (value: Buffer) => string;
+  encryptString: (value: string) => Buffer;
+  isEncryptionAvailable: () => boolean;
+};
+
+const prefixes: Record<AIUsageCredentialProvider, string> = {
+  anthropic: 'sk-ant-admin',
+  openai: 'sk-admin'
+};
+
+export const createAIUsageSecrets = (store: EncryptedSecretStore, crypto: SecretCrypto) => {
+  const clear = (provider: AIUsageCredentialProvider): void => {
+    store.delete(provider);
+  };
+  const get = (provider: AIUsageCredentialProvider): string | undefined => {
+    const encrypted = store.get(provider);
+    if (!encrypted) return undefined;
+    try {
+      return crypto.decryptString(Buffer.from(encrypted, 'base64'));
+    } catch {
+      return undefined;
+    }
+  };
+  const set = (provider: AIUsageCredentialProvider, value: string): void => {
+    if (!value.startsWith(prefixes[provider])) throw new Error(`A ${provider} admin key is required`);
+    if (!crypto.isEncryptionAvailable()) throw new Error('Secure storage is not available');
+    store.set(provider, crypto.encryptString(value).toString('base64'));
+  };
+  const status = (): Record<AIUsageCredentialProvider, boolean> => ({
+    anthropic: Boolean(get('anthropic')),
+    openai: Boolean(get('openai'))
+  });
+  return { clear, get, set, status };
+};
+
+const encryptedStore = new Store<Record<AIUsageCredentialProvider, string>>({ name: 'devkitty.ai-usage-secrets' });
+export const aiUsageSecrets = createAIUsageSecrets(encryptedStore, safeStorage);

--- a/src/main/libs/claude/adminUsage.test.ts
+++ b/src/main/libs/claude/adminUsage.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createClaudeAdminUsageClient } from './adminUsage';
+
+const NOW = Date.UTC(2026, 8, 12, 9, 30);
+const json = (value: unknown) => new Response(JSON.stringify(value));
+
+describe('Claude admin usage', () => {
+  it('uses UTC month bounds, pages, filters workspace, and counts each token class once', async () => {
+    const fetcher = vi.fn(async (input: Request | string | URL) => {
+      const url = new URL(String(input));
+      const isCost = url.pathname.endsWith('cost_report');
+      const page = url.searchParams.get('page');
+      if (isCost) return json({ data: [{ ending_at: '2026-09-02T00:00:00Z', results: [{ amount: '12.3456', currency: 'USD', workspace_id: 'ws-1' }, { amount: '99', currency: 'USD', workspace_id: 'other' }], starting_at: '2026-09-01T00:00:00Z' }], has_more: false });
+      if (!page) return json({ data: [{ ending_at: '2026-09-02T00:00:00Z', results: [{ cache_creation: { ephemeral_1h_input_tokens: 1, ephemeral_5m_input_tokens: 1 }, cache_read_input_tokens: 3, output_tokens: 4, uncached_input_tokens: 1, workspace_id: 'ws-1' }], starting_at: '2026-09-01T00:00:00Z' }], has_more: true, next_page: 'next' });
+      return json({ data: [{ ending_at: '2026-09-03T00:00:00Z', results: [{ input_tokens: 10, output_tokens: 5, workspace_id: 'ws-1' }], starting_at: '2026-09-02T00:00:00Z' }], has_more: false });
+    });
+    const client = createClaudeAdminUsageClient(fetcher);
+    const result = await client('sk-ant-admin-secret', 'ws-1', NOW);
+    expect(result.metric.tokens).toBe(25);
+    expect(result.metric.scope).toBe('workspace');
+    expect(result.spend.amountUsdMicros).toBe(123456);
+    expect(result.spend.qualifier).toContain('Priority Tier');
+    const urls = fetcher.mock.calls.map(([url]) => new URL(String(url)));
+    expect(urls[0].searchParams.get('starting_at')).toBe('2026-09-01T00:00:00.000Z');
+    expect(urls[0].searchParams.get('ending_at')).toBe('2026-09-12T09:30:00.000Z');
+    expect(urls[0].searchParams.getAll('group_by[]')).toEqual(['workspace_id']);
+    expect(urls.some((url) => url.searchParams.get('page') === 'next')).toBe(true);
+  });
+
+  it('uses a five minute cache without another network call', async () => {
+    const fetcher = vi.fn(async (input: Request | string | URL) => json({
+      data: [{ results: String(input).includes('cost_report') ? [{ amount: '0', currency: 'USD' }] : [] }],
+      has_more: false
+    }));
+    const client = createClaudeAdminUsageClient(fetcher);
+    await client('sk-ant-admin-secret', undefined, NOW);
+    await client('sk-ant-admin-secret', undefined, NOW + 60_000);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('never puts the key or response body in an error', async () => {
+    const key = 'sk-ant-admin-very-secret';
+    const fetcher = vi.fn(async () => new Response(`bad ${key}`, { status: 500 }));
+    const error = await createClaudeAdminUsageClient(fetcher)(key, undefined, NOW).catch((value: unknown) => value);
+    expect(String(error)).not.toContain(key);
+    expect(String(error)).not.toContain('bad');
+  });
+});

--- a/src/main/libs/claude/adminUsage.ts
+++ b/src/main/libs/claude/adminUsage.ts
@@ -1,0 +1,79 @@
+import { ADMIN_CACHE_MS, type AIAdminUsage, currentUtcMonth, decimalToMicros, fetchAdminPages, isObject, readBucketResults, safeNonNegativeInteger } from '../aiUsage/admin';
+
+export type ClaudeAdminUsage = AIAdminUsage;
+type Fetcher = typeof fetch;
+
+const endpoint = 'https://api.anthropic.com/v1/organizations';
+const headers = (key: string) => ({ 'anthropic-version': '2023-06-01', 'x-api-key': key });
+
+const workspaceMatches = (row: Record<string, unknown>, workspaceId?: string) => !workspaceId || row.workspace_id === workspaceId;
+
+const pages = (path: string, params: URLSearchParams, key: string, fetcher: Fetcher) => fetchAdminPages({
+  endpoint: `${endpoint}/${path}`,
+  fetcher,
+  headers: headers(key),
+  params
+});
+
+const usageTokens = (row: Record<string, unknown>): number => {
+  // Anthropic reports uncached input separately from both cache classes.
+  const input = row.uncached_input_tokens ?? row.input_tokens ?? 0;
+  const cacheCreation = row.cache_creation ?? {};
+  if (!isObject(cacheCreation)) throw new Error('Invalid admin response');
+  return safeNonNegativeInteger(input)
+    + safeNonNegativeInteger(cacheCreation.ephemeral_1h_input_tokens ?? 0)
+    + safeNonNegativeInteger(cacheCreation.ephemeral_5m_input_tokens ?? 0)
+    + safeNonNegativeInteger(row.cache_read_input_tokens ?? 0)
+    + safeNonNegativeInteger(row.output_tokens ?? 0);
+};
+
+const costMicros = (row: Record<string, unknown>): number => {
+  if (row.currency !== 'USD' || typeof row.amount !== 'string') throw new Error('Invalid admin response');
+  return decimalToMicros(row.amount, 10_000n);
+};
+
+export const createClaudeAdminUsageClient = (fetcher: Fetcher = fetch) => {
+  let cache: undefined | { key: string; scope?: string; until: number; value: ClaudeAdminUsage };
+  return async (key: string, workspaceId: string | undefined, now: number): Promise<ClaudeAdminUsage> => {
+    if (cache && cache.key === key && cache.scope === workspaceId && cache.until > now) return cache.value;
+    const { endMs, startMs } = currentUtcMonth(now);
+    const common = new URLSearchParams({
+      bucket_width: '1d',
+      ending_at: new Date(endMs).toISOString(),
+      starting_at: new Date(startMs).toISOString()
+    });
+    common.append('group_by[]', 'workspace_id');
+    const [usageBuckets, costBuckets] = await Promise.all([
+      pages('usage_report/messages', common, key, fetcher),
+      pages('cost_report', common, key, fetcher)
+    ]);
+    const usageRows = readBucketResults(usageBuckets);
+    const costRows = readBucketResults(costBuckets);
+    const scope = workspaceId ? 'workspace' : 'organization';
+    const title = workspaceId ? 'Workspace API' : 'Org API';
+    const value: ClaudeAdminUsage = {
+      metric: {
+        id: 'month',
+        label: `${title} tokens`,
+        scope,
+        source: 'admin',
+        title: 'Month',
+        tokens: usageRows.filter((row) => workspaceMatches(row, workspaceId)).reduce((sum, row) => sum + usageTokens(row), 0)
+      },
+      reportedAt: now,
+      spend: {
+        amountUsdMicros: costRows.filter((row) => workspaceMatches(row, workspaceId)).reduce((sum, row) => sum + costMicros(row), 0),
+        label: workspaceId ? 'Workspace API spend' : 'Org API spend',
+        period: 'calendar-month',
+        qualifier: 'Does not include Priority Tier cost.',
+        scope,
+        source: 'admin',
+        startsAt: startMs
+      }
+    };
+    cache = { key, scope: workspaceId, until: now + ADMIN_CACHE_MS, value };
+    return value;
+  };
+};
+
+export const getClaudeAdminUsage = createClaudeAdminUsageClient();

--- a/src/main/libs/claude/getUsage.test.ts
+++ b/src/main/libs/claude/getUsage.test.ts
@@ -1,184 +1,89 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('./lastUsage', () => ({
-  readReportedUsage: vi.fn()
-}));
-
-vi.mock('./transcripts', () => ({
-  readEntries: vi.fn()
-}));
+vi.mock('./lastUsage', () => ({ readReportedUsage: vi.fn() }));
+vi.mock('./transcripts', () => ({ readEntries: vi.fn() }));
 
 import type { ClaudeAccount } from 'types/claudeUsage';
 
 import { buildUsage } from './getUsage';
 import { readReportedUsage } from './lastUsage';
 import { readEntries } from './transcripts';
-import {
-  computeFiveHour,
-  computeWeek,
-  FIVE_HOURS_MS,
-  modelBreakdown,
-  SEVEN_DAYS_MS,
-  tokensInWindow,
-  type UsageEntry
-} from './usage';
 
-const mockReadReportedUsage = vi.mocked(readReportedUsage);
-const mockReadEntries = vi.mocked(readEntries);
-
-const DAY = 24 * 60 * 60 * 1000;
-const NOW = Date.UTC(2026, 0, 15, 12, 0, 0);
-
+const NOW = Date.UTC(2026, 0, 15, 12);
+const DAY = 86_400_000;
 const account: ClaudeAccount = { dir: '/Users/test/.claude', label: 'claude' };
-
-// Two entries well inside the 5h window (different models), plus one entry
-// 6 days back — inside the 7d window but outside the 5h window — so both
-// tokensInWindow and modelBreakdown produce non-trivial, differing output
-// for fiveHour vs week.
-const entries: UsageEntry[] = [
-  { model: 'claude-opus-4-8', requestId: 'r1', tokens: 100, ts: NOW - 1000 },
-  { model: 'claude-sonnet-4-6', requestId: 'r2', tokens: 50, ts: NOW - 2000 },
-  { model: 'claude-opus-4-8', requestId: 'r3', tokens: 200, ts: NOW - 6 * DAY }
+const entries = [
+  { model: 'claude-opus', requestId: 'a', tokens: 100, ts: NOW - 1000 },
+  { model: 'claude-sonnet', requestId: 'b', tokens: 50, ts: NOW - 6 * DAY }
 ];
 
-describe('buildUsage', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+describe('Claude common usage model', () => {
+  beforeEach(() => vi.clearAllMocks());
 
-  it('prefers server-reported pct/resetsAt for both windows when present, keeping local tokens/models', async () => {
-    mockReadEntries.mockResolvedValue(entries);
-    const reported = {
+  it('keeps provider quota and local token detail separate', async () => {
+    vi.mocked(readEntries).mockResolvedValue(entries);
+    vi.mocked(readReportedUsage).mockReturnValue({
       capturedAt: NOW - 500,
-      fiveHour: { pct: 0.42, resetsAt: NOW + 1_000_000 },
-      sevenDay: { pct: 0.1, resetsAt: NOW + 2_000_000 }
-    };
-    mockReadReportedUsage.mockReturnValue(reported);
-
-    const result = await buildUsage(account, NOW);
-
-    expect(result.account).toBe(account);
-    expect(result.computedAt).toBe(NOW);
-    expect(result.reportedAt).toBe(reported.capturedAt);
-
-    expect(result.fiveHour.reported).toBe(true);
-    expect(result.fiveHour.pct).toBe(0.42);
-    expect(result.fiveHour.resetsAt).toBe(reported.fiveHour.resetsAt);
-    expect(result.fiveHour.active).toBe(true);
-    expect(result.fiveHour.tokens).toBe(150);
-    expect(result.fiveHour.models).toEqual([
-      { model: 'claude-opus-4-8', tokens: 100 },
-      { model: 'claude-sonnet-4-6', tokens: 50 }
-    ]);
-    const fiveHourEstimate = computeFiveHour(entries, NOW);
-    expect(result.fiveHour.cap).toBe(fiveHourEstimate.cap);
-    expect(result.fiveHour.startsAt).toBe(fiveHourEstimate.startsAt);
-
-    expect(result.week.reported).toBe(true);
-    expect(result.week.pct).toBe(0.1);
-    expect(result.week.resetsAt).toBe(reported.sevenDay.resetsAt);
-    expect(result.week.active).toBe(true);
-    expect(result.week.tokens).toBe(350);
-    expect(result.week.models).toEqual([
-      { model: 'claude-opus-4-8', tokens: 300 },
-      { model: 'claude-sonnet-4-6', tokens: 50 }
-    ]);
-    const weekEstimate = computeWeek(entries, NOW);
-    expect(result.week.cap).toBe(weekEstimate.cap);
-    expect(result.week.startsAt).toBe(weekEstimate.startsAt);
-  });
-
-  it('falls back to the local estimate for both windows when nothing is reported', async () => {
-    mockReadEntries.mockResolvedValue(entries);
-    mockReadReportedUsage.mockReturnValue(null);
-
-    const result = await buildUsage(account, NOW);
-
-    expect(result.reportedAt).toBeUndefined();
-
-    const fiveHourEstimate = computeFiveHour(entries, NOW);
-    expect(result.fiveHour.reported).toBe(false);
-    expect(result.fiveHour.pct).toBe(fiveHourEstimate.pct);
-    expect(result.fiveHour.active).toBe(fiveHourEstimate.active);
-    expect(result.fiveHour.resetsAt).toBe(fiveHourEstimate.resetsAt);
-    expect(result.fiveHour.cap).toBe(fiveHourEstimate.cap);
-    expect(result.fiveHour.startsAt).toBe(fiveHourEstimate.startsAt);
-    expect(result.fiveHour.tokens).toBe(tokensInWindow(entries, NOW, FIVE_HOURS_MS));
-    expect(result.fiveHour.models).toEqual(modelBreakdown(entries, NOW - FIVE_HOURS_MS, NOW));
-
-    const weekEstimate = computeWeek(entries, NOW);
-    expect(result.week.reported).toBe(false);
-    expect(result.week.pct).toBe(weekEstimate.pct);
-    expect(result.week.active).toBe(weekEstimate.active);
-    expect(result.week.resetsAt).toBe(weekEstimate.resetsAt);
-    expect(result.week.cap).toBe(weekEstimate.cap);
-    expect(result.week.startsAt).toBe(weekEstimate.startsAt);
-    expect(result.week.tokens).toBe(tokensInWindow(entries, NOW, SEVEN_DAYS_MS));
-    expect(result.week.models).toEqual(modelBreakdown(entries, NOW - SEVEN_DAYS_MS, NOW));
-  });
-
-  it('applies the reported figure only to the window that has one, falling back for the other', async () => {
-    mockReadEntries.mockResolvedValue(entries);
-    const reported = {
-      capturedAt: NOW - 500,
-      fiveHour: { pct: 0.7, resetsAt: NOW + 9999 },
-      sevenDay: undefined
-    };
-    mockReadReportedUsage.mockReturnValue(reported);
-
-    const result = await buildUsage(account, NOW);
-
-    expect(result.fiveHour.reported).toBe(true);
-    expect(result.fiveHour.pct).toBe(0.7);
-    expect(result.fiveHour.resetsAt).toBe(reported.fiveHour.resetsAt);
-    expect(result.fiveHour.active).toBe(true);
-
-    const weekEstimate = computeWeek(entries, NOW);
-    expect(result.week.reported).toBe(false);
-    expect(result.week.pct).toBe(weekEstimate.pct);
-    expect(result.week.active).toBe(weekEstimate.active);
-    expect(result.week.resetsAt).toBe(weekEstimate.resetsAt);
-  });
-
-  it('handles no entries at all, regardless of whether usage is reported', async () => {
-    mockReadEntries.mockResolvedValue([]);
-
-    mockReadReportedUsage.mockReturnValue(null);
-    const unreported = await buildUsage(account, NOW);
-    expect(unreported.fiveHour.tokens).toBe(0);
-    expect(unreported.fiveHour.models).toEqual([]);
-    expect(unreported.week.tokens).toBe(0);
-    expect(unreported.week.models).toEqual([]);
-
-    mockReadReportedUsage.mockReturnValue({
-      capturedAt: NOW,
-      fiveHour: { pct: 0.5, resetsAt: NOW + 1 },
-      sevenDay: { pct: 0.5, resetsAt: NOW + 1 }
+      fiveHour: { pct: 0.42, resetsAt: NOW + 1000 },
+      sevenDay: { pct: 0.1, resetsAt: NOW + 2000 }
     });
-    const reportedResult = await buildUsage(account, NOW);
-    expect(reportedResult.fiveHour.tokens).toBe(0);
-    expect(reportedResult.fiveHour.models).toEqual([]);
-    expect(reportedResult.week.tokens).toBe(0);
-    expect(reportedResult.week.models).toEqual([]);
-  });
-
-  it('passes account and now through unchanged', async () => {
-    mockReadEntries.mockResolvedValue([]);
-    mockReadReportedUsage.mockReturnValue(null);
-
     const result = await buildUsage(account, NOW);
-
-    expect(result.account).toBe(account);
-    expect(result.computedAt).toBe(NOW);
+    expect(result.account).toEqual({ ...account, provider: 'claude' });
+    expect(result.reportedAt).toBe(NOW - 500);
+    expect(result.metrics).toEqual([
+      expect.objectContaining({ id: 'five-hour', percent: 0.42, resetsAt: NOW + 1000, source: 'provider', tokens: 100, tokensPeriod: 'provider-period' }),
+      expect.objectContaining({ id: 'seven-day', percent: 0.1, resetsAt: NOW + 2000, source: 'provider', tokens: 150, tokensPeriod: 'provider-period' })
+    ]);
   });
 
-  it('reads reported usage and transcript entries for the given account dir and timestamp', async () => {
-    mockReadEntries.mockResolvedValue([]);
-    mockReadReportedUsage.mockReturnValue(null);
+  it('shows local tokens without inventing a quota percent', async () => {
+    vi.mocked(readEntries).mockResolvedValue(entries);
+    vi.mocked(readReportedUsage).mockReturnValue(null);
+    const result = await buildUsage(account, NOW);
+    expect(result.reportedAt).toBeUndefined();
+    expect(result.metrics[0]).toMatchObject({ label: '5H · Quota unavailable', source: 'local', tokens: 100, tokensPeriod: 'trailing-window' });
+    expect(result.metrics[0]).not.toHaveProperty('percent');
+    expect(result.metrics[1]).toMatchObject({ label: '7D · Quota unavailable', source: 'local', tokens: 150 });
+  });
 
+  it('reads the selected account and time', async () => {
+    vi.mocked(readEntries).mockResolvedValue([]);
+    vi.mocked(readReportedUsage).mockReturnValue(null);
     await buildUsage(account, NOW);
+    expect(readReportedUsage).toHaveBeenCalledWith(account.dir);
+    expect(readEntries).toHaveBeenCalledWith(account.dir, NOW);
+  });
 
-    expect(mockReadReportedUsage).toHaveBeenCalledWith(account.dir);
-    expect(mockReadEntries).toHaveBeenCalledWith(account.dir, NOW);
+  it('excludes local tokens from before the current provider period', async () => {
+    vi.mocked(readEntries).mockResolvedValue([
+      { model: 'claude-opus', requestId: 'old', tokens: 900, ts: NOW - 4.5 * 60 * 60 * 1000 },
+      { model: 'claude-sonnet', requestId: 'current', tokens: 100, ts: NOW - 1000 }
+    ]);
+    vi.mocked(readReportedUsage).mockReturnValue({
+      capturedAt: NOW - 500,
+      fiveHour: { pct: 0.2, resetsAt: NOW + 60 * 60 * 1000 }
+    });
+    const result = await buildUsage(account, NOW);
+    expect(result.metrics[0]).toMatchObject({
+      models: [{ model: 'claude-sonnet', tokens: 100 }],
+      tokens: 100,
+      tokensPeriod: 'provider-period'
+    });
+    expect(result.metrics[1]).toMatchObject({ tokens: 1000, tokensPeriod: 'trailing-window' });
+  });
+
+  it.each([0, NOW - 1])('does not use an old quota reset at %s', async (resetsAt) => {
+    vi.mocked(readEntries).mockResolvedValue(entries);
+    vi.mocked(readReportedUsage).mockReturnValue({
+      capturedAt: NOW - 500,
+      fiveHour: { pct: 0.9, resetsAt },
+      sevenDay: { pct: 0.8, resetsAt }
+    });
+    const result = await buildUsage(account, NOW);
+    expect(result.reportedAt).toBeUndefined();
+    expect(result.metrics[0]).toMatchObject({ label: '5H · Quota unavailable', source: 'local', tokens: 100 });
+    expect(result.metrics[0]).not.toHaveProperty('percent');
+    expect(result.metrics[1]).toMatchObject({ label: '7D · Quota unavailable', source: 'local', tokens: 150 });
+    expect(result.metrics[1]).not.toHaveProperty('percent');
   });
 });

--- a/src/main/libs/claude/getUsage.ts
+++ b/src/main/libs/claude/getUsage.ts
@@ -1,38 +1,24 @@
-import { type ClaudeAccount, type ClaudeUsage, type ClaudeUsageWindow } from 'types/claudeUsage';
+import { type AIUsage } from 'types/aiUsage';
+import { type ClaudeAccount } from 'types/claudeUsage';
 
-import { readReportedUsage, type ReportedWindow } from './lastUsage';
+import { buildLocalMetric } from '../aiUsage/localMetric';
+import { readReportedUsage } from './lastUsage';
 import { readEntries } from './transcripts';
-import { computeFiveHour, computeWeek, FIVE_HOURS_MS, modelBreakdown, SEVEN_DAYS_MS, tokensInWindow, type UsageEntry } from './usage';
+import { FIVE_HOURS_MS, SEVEN_DAYS_MS } from './usage';
 
-// Prefer the real server-reported %/reset; keep the local estimate's cap/start
-// as fallback. Tokens and models are always the local trailing-window figures —
-// they describe what you actually ran, alongside whichever % we trust.
-const mergeWindow = (
-  reported: ReportedWindow | undefined,
-  estimate: ClaudeUsageWindow,
-  entries: UsageEntry[],
-  now: number,
-  windowMs: number
-): ClaudeUsageWindow => ({
-  active: reported ? true : estimate.active,
-  cap: estimate.cap,
-  models: modelBreakdown(entries, now - windowMs, now),
-  pct: reported ? reported.pct : estimate.pct,
-  reported: Boolean(reported),
-  resetsAt: reported ? reported.resetsAt : estimate.resetsAt,
-  startsAt: estimate.startsAt,
-  tokens: tokensInWindow(entries, now, windowMs)
-});
-
-export const buildUsage = async (account: ClaudeAccount, now: number): Promise<ClaudeUsage> => {
+export const buildUsage = async (account: ClaudeAccount, now: number): Promise<AIUsage> => {
   const reported = readReportedUsage(account.dir);
   const entries = await readEntries(account.dir, now);
+  const fiveHour = reported?.fiveHour && reported.fiveHour.resetsAt > now ? reported.fiveHour : undefined;
+  const sevenDay = reported?.sevenDay && reported.sevenDay.resetsAt > now ? reported.sevenDay : undefined;
 
   return {
-    account,
+    account: { ...account, provider: 'claude' },
     computedAt: now,
-    fiveHour: mergeWindow(reported?.fiveHour, computeFiveHour(entries, now), entries, now, FIVE_HOURS_MS),
-    reportedAt: reported?.capturedAt,
-    week: mergeWindow(reported?.sevenDay, computeWeek(entries, now), entries, now, SEVEN_DAYS_MS)
+    metrics: [
+      buildLocalMetric({ entries, id: 'five-hour', now, reported: fiveHour, title: '5H', windowMs: FIVE_HOURS_MS }),
+      buildLocalMetric({ entries, id: 'seven-day', now, reported: sevenDay, title: '7D', windowMs: SEVEN_DAYS_MS })
+    ],
+    reportedAt: fiveHour || sevenDay ? reported?.capturedAt : undefined,
   };
 };

--- a/src/main/libs/codex/adminUsage.test.ts
+++ b/src/main/libs/codex/adminUsage.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createCodexAdminUsageClient } from './adminUsage';
+
+const NOW = Date.UTC(2026, 8, 12, 9, 30);
+const json = (value: unknown) => new Response(JSON.stringify(value));
+
+describe('Codex admin usage', () => {
+  it('uses UTC month bounds, pages, project scope, tokens, and dollar values', async () => {
+    const fetcher = vi.fn(async (input: Request | string | URL) => {
+      const url = new URL(String(input));
+      const isCost = url.pathname.endsWith('/costs');
+      const page = url.searchParams.get('page');
+      if (isCost) return json({ data: [{ results: [{ amount: { currency: 'usd', value: '1.234567' }, project_id: 'proj-1' }] }], has_more: false });
+      if (!page) return json({ data: [{ results: [{ input_tokens: 4, output_tokens: 6, project_id: 'proj-1' }] }], has_more: true, next_page: 'next' });
+      return json({ data: [{ results: [{ input_tokens: 5, output_tokens: 5, project_id: 'proj-1' }] }], has_more: false });
+    });
+    const result = await createCodexAdminUsageClient(fetcher)('sk-admin-secret', 'proj-1', NOW);
+    expect(result.metric.tokens).toBe(20);
+    expect(result.metric.scope).toBe('project');
+    expect(result.spend.amountUsdMicros).toBe(1234567);
+    const urls = fetcher.mock.calls.map(([url]) => new URL(String(url)));
+    expect(urls[0].searchParams.get('start_time')).toBe(String(Date.UTC(2026, 8, 1) / 1000));
+    expect(urls[0].searchParams.get('end_time')).toBe(String(NOW / 1000));
+    expect(urls[0].searchParams.getAll('project_ids[]')).toEqual(['proj-1']);
+  });
+
+  it('uses the cache for the footer poll', async () => {
+    const fetcher = vi.fn(async () => json({ data: [], has_more: false }));
+    const client = createCodexAdminUsageClient(fetcher);
+    await client('sk-admin-secret', undefined, NOW);
+    await client('sk-admin-secret', undefined, NOW + 60_000);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/main/libs/codex/adminUsage.ts
+++ b/src/main/libs/codex/adminUsage.ts
@@ -1,0 +1,63 @@
+import { ADMIN_CACHE_MS, type AIAdminUsage, currentUtcMonth, decimalToMicros, fetchAdminPages, isObject, readBucketResults, safeNonNegativeInteger } from '../aiUsage/admin';
+
+export type CodexAdminUsage = AIAdminUsage;
+type Fetcher = typeof fetch;
+const endpoint = 'https://api.openai.com/v1/organization';
+
+const pages = (path: string, params: URLSearchParams, key: string, fetcher: Fetcher) => fetchAdminPages({
+  endpoint: `${endpoint}/${path}`,
+  fetcher,
+  headers: { Authorization: `Bearer ${key}` },
+  params
+});
+
+const projectMatches = (row: Record<string, unknown>, projectId?: string) => !projectId || row.project_id === projectId;
+
+export const createCodexAdminUsageClient = (fetcher: Fetcher = fetch) => {
+  let cache: undefined | { key: string; scope?: string; until: number; value: CodexAdminUsage };
+  return async (key: string, projectId: string | undefined, now: number): Promise<CodexAdminUsage> => {
+    if (cache && cache.key === key && cache.scope === projectId && cache.until > now) return cache.value;
+    const { endMs, startMs } = currentUtcMonth(now);
+    const params = new URLSearchParams({
+      bucket_width: '1d',
+      end_time: String(Math.floor(endMs / 1000)),
+      start_time: String(Math.floor(startMs / 1000))
+    });
+    params.append('group_by[]', 'project_id');
+    if (projectId) params.append('project_ids[]', projectId);
+    const [usageBuckets, costBuckets] = await Promise.all([
+      pages('usage/completions', params, key, fetcher),
+      pages('costs', params, key, fetcher)
+    ]);
+    const usageRows = readBucketResults(usageBuckets).filter((row) => projectMatches(row, projectId));
+    const costRows = readBucketResults(costBuckets).filter((row) => projectMatches(row, projectId));
+    const scope = projectId ? 'project' : 'organization';
+    const title = projectId ? 'Project API' : 'Org API';
+    const value: CodexAdminUsage = {
+      metric: {
+        id: 'month',
+        label: `${title} tokens`,
+        scope,
+        source: 'admin',
+        title: 'Month',
+        tokens: usageRows.reduce((sum, row) => sum + safeNonNegativeInteger(row.input_tokens ?? 0) + safeNonNegativeInteger(row.output_tokens ?? 0), 0)
+      },
+      reportedAt: now,
+      spend: {
+        amountUsdMicros: costRows.reduce((sum, row) => {
+          if (!isObject(row.amount) || row.amount.currency !== 'usd' || (typeof row.amount.value !== 'number' && typeof row.amount.value !== 'string')) throw new Error('Invalid admin response');
+          return sum + decimalToMicros(String(row.amount.value), 1_000_000n);
+        }, 0),
+        label: projectId ? 'Project API spend' : 'Org API spend',
+        period: 'calendar-month',
+        scope,
+        source: 'admin',
+        startsAt: startMs
+      }
+    };
+    cache = { key, scope: projectId, until: now + ADMIN_CACHE_MS, value };
+    return value;
+  };
+};
+
+export const getCodexAdminUsage = createCodexAdminUsageClient();

--- a/src/main/libs/codex/getUsage.test.ts
+++ b/src/main/libs/codex/getUsage.test.ts
@@ -37,7 +37,9 @@ describe('Codex local usage', () => {
       'null', '{broken', token(-3000, 20, 20), token(-2000, undefined, 5), '{"partial"'
     ]);
     const usage = await buildUsage(account, now);
-    expect(usage.fiveHour).toMatchObject({ cap: 0, models: [{ model: 'gpt-5.4', tokens: 175 }], pct: 0, reported: false, resetsAt: 0, tokens: 175 });
+    expect(usage.metrics.map(({ id }) => id)).toEqual(['seven-day']);
+    expect(usage.metrics[0]).toMatchObject({ id: 'seven-day', models: [{ model: 'gpt-5.4', tokens: 175 }], source: 'local', tokens: 175 });
+    expect(usage.metrics[0]).not.toHaveProperty('percent');
     expect(usage.reportedAt).toBeUndefined();
   });
 
@@ -45,7 +47,7 @@ describe('Codex local usage', () => {
     write('one.jsonl', [token(-1000, undefined, undefined, { info: {
       total_token_usage: { cached_input_tokens: 60, input_tokens: 100, output_tokens: 40, reasoning_output_tokens: 30 }
     } })]);
-    expect((await buildUsage(account, now)).fiveHour.tokens).toBe(140);
+    expect((await buildUsage(account, now)).metrics[0].tokens).toBe(140);
   });
 
   it('deduplicates copied sessions and fork history, retaining new fork work', async () => {
@@ -53,12 +55,12 @@ describe('Codex local usage', () => {
     write('parent.jsonl', rows);
     write('copy.jsonl', rows);
     write('fork.jsonl', [{ payload: { forked_from_id: 'parent', id: 'child' }, type: 'session_meta' }, ...rows.slice(1), token(-1000, 175, 25)]);
-    expect((await buildUsage(account, now)).fiveHour.tokens).toBe(175);
+    expect((await buildUsage(account, now)).metrics[0].tokens).toBe(175);
   });
 
   it('does not attribute inherited totals to a fork without replay', async () => {
     write('fork.jsonl', [{ payload: { id: 'child', parent_thread_id: 'parent' }, type: 'session_meta' }, token(-1000, 100000, 25)]);
-    expect((await buildUsage(account, now)).fiveHour.tokens).toBe(25);
+    expect((await buildUsage(account, now)).metrics[0].tokens).toBe(25);
   });
 
   it('maps actual weekly primary to week, preserving capture time and ignoring other limit buckets', async () => {
@@ -68,9 +70,24 @@ describe('Codex local usage', () => {
       token(-1000, 100, 100, { rate_limits: { limit_id: 'other-product', primary: { resets_at: resetsAt, used_percent: 99, window_minutes: 300 } } })
     ]);
     const usage = await buildUsage(account, now);
-    expect(usage.week).toMatchObject({ durationMs: 604800000, pct: 0.42, reported: true, resetsAt: resetsAt * 1000 });
-    expect(usage.fiveHour.reported).toBe(false);
+    expect(usage.metrics[0]).toMatchObject({ id: 'seven-day', percent: 0.42, resetsAt: resetsAt * 1000, source: 'provider', tokensPeriod: 'provider-period' });
     expect(usage.reportedAt).toBe(now - 2000);
+  });
+
+  it('excludes local tokens from before the current provider period', async () => {
+    const resetsAt = Math.floor((now + 86_400_000) / 1000);
+    write('one.jsonl', [
+      { payload: { id: 'one' }, type: 'session_meta' },
+      { payload: { model: 'gpt-period' }, type: 'turn_context' },
+      token(-6.5 * 86_400_000, 900, 900),
+      token(-1000, 1000, 100, { rate_limits: { primary: { resets_at: resetsAt, used_percent: 25, window_minutes: 10080 } } })
+    ]);
+    const usage = await buildUsage(account, now);
+    expect(usage.metrics[0]).toMatchObject({
+      models: [{ model: 'gpt-period', tokens: 100 }],
+      tokens: 100,
+      tokensPeriod: 'provider-period'
+    });
   });
 
   it('ignores expired, malformed, future and unsupported rate windows', async () => {
@@ -82,14 +99,13 @@ describe('Codex local usage', () => {
     ]);
     const usage = await buildUsage(account, now);
     expect(usage.reportedAt).toBeUndefined();
-    expect(usage.fiveHour.tokens).toBe(100);
-    expect(usage.fiveHour.reported).toBe(false);
-    expect(usage.week.reported).toBe(false);
+    expect(usage.metrics[0].tokens).toBe(100);
+    expect(usage.metrics[0]).not.toHaveProperty('percent');
   });
 
   it('uses old events as cumulative baseline but counts only trailing windows', async () => {
     write('one.jsonl', [token(-29 * 86400000, 100000, 100000), token(-1000, 100010, 10)]);
-    expect((await buildUsage(account, now)).week.tokens).toBe(10);
+    expect((await buildUsage(account, now)).metrics[0].tokens).toBe(10);
   });
 
   it('streams large files without losing earlier tokens/model and caches unchanged files', async () => {
@@ -102,11 +118,11 @@ describe('Codex local usage', () => {
     ]);
     const stream = vi.spyOn(fs, 'createReadStream');
     const first = await buildUsage(account, now);
-    expect(first.fiveHour).toMatchObject({ models: [{ model: 'gpt-large', tokens: 150 }], tokens: 150 });
+    expect(first.metrics[0]).toMatchObject({ models: [{ model: 'gpt-large', tokens: 150 }], tokens: 150 });
     await buildUsage(account, now + 1);
     expect(stream).toHaveBeenCalledOnce();
     fs.appendFileSync(path.join(dir, 'sessions', 'large.jsonl'), `\n${JSON.stringify(token(-500, 175, 25))}`);
-    expect((await buildUsage(account, now + 2)).fiveHour.tokens).toBe(175);
+    expect((await buildUsage(account, now + 2)).metrics[0].tokens).toBe(175);
     expect(stream).toHaveBeenCalledTimes(2);
   });
 
@@ -119,11 +135,21 @@ describe('Codex local usage', () => {
     ];
     write('one.jsonl', rows);
     const usage = await buildUsage(account, now);
-    expect(usage.fiveHour).toMatchObject({ pct: 0.1, reported: true });
-    expect(usage.week.pct).toBe(0.21);
-    expect(usage.reportedAt).toBe(now - 3000);
+    expect(usage.metrics).toHaveLength(1);
+    expect(usage.metrics[0]).toMatchObject({ percent: 0.21, source: 'provider' });
+    expect(usage.reportedAt).toBe(now - 2000);
     write('one.jsonl', [...rows, token(-1000, 100, 100, { rate_limits: { plan_type: 'free', primary: weekly, secondary: null } })]);
-    expect((await buildUsage(account, now)).fiveHour.reported).toBe(false);
+    expect((await buildUsage(account, now)).metrics[0]).toMatchObject({ percent: 0.2, source: 'provider' });
     expect((await buildUsage(account, now + 7200001)).reportedAt).toBeUndefined();
+  });
+
+  it('does not use a hidden five-hour capture time for the seven-day meter', async () => {
+    write('one.jsonl', [
+      token(-1000, 100, 100, { rate_limits: { primary: { resets_at: now / 1000 + 3600, used_percent: 10, window_minutes: 300 } } })
+    ]);
+    const usage = await buildUsage(account, now);
+    expect(usage.metrics).toHaveLength(1);
+    expect(usage.metrics[0]).not.toHaveProperty('percent');
+    expect(usage.reportedAt).toBeUndefined();
   });
 });

--- a/src/main/libs/codex/getUsage.ts
+++ b/src/main/libs/codex/getUsage.ts
@@ -1,30 +1,17 @@
-import { type AIAccount, type AIUsage, type AIUsageWindow } from 'types/aiUsage';
+import { type AIAccount, type AIUsage } from 'types/aiUsage';
 
-import { FIVE_HOURS_MS, modelBreakdown, SEVEN_DAYS_MS, tokensInWindow, type UsageEntry } from '../claude/usage';
-import { readTranscripts, type ReportedWindow } from './transcripts';
-
-const buildWindow = (entries: UsageEntry[], now: number, durationMs: number, reported?: ReportedWindow): AIUsageWindow => {
-  const tokens = tokensInWindow(entries, now, durationMs);
-  return {
-    active: Boolean(reported) || tokens > 0,
-    cap: 0,
-    durationMs,
-    models: modelBreakdown(entries, now - durationMs, now),
-    pct: reported?.pct ?? 0,
-    reported: Boolean(reported),
-    resetsAt: reported?.resetsAt ?? 0,
-    startsAt: reported ? reported.resetsAt - durationMs : now - durationMs,
-    tokens
-  };
-};
+import { buildLocalMetric } from '../aiUsage/localMetric';
+import { SEVEN_DAYS_MS } from '../claude/usage';
+import { readTranscripts } from './transcripts';
 
 export const buildUsage = async (account: AIAccount, now: number): Promise<AIUsage> => {
   const { entries, reported } = await readTranscripts(account.dir, now);
   return {
     account,
     computedAt: now,
-    fiveHour: buildWindow(entries, now, FIVE_HOURS_MS, reported?.fiveHour),
-    reportedAt: reported?.capturedAt,
-    week: buildWindow(entries, now, SEVEN_DAYS_MS, reported?.week)
+    metrics: [
+      buildLocalMetric({ entries, id: 'seven-day', now, reported: reported?.week, title: '7D', windowMs: SEVEN_DAYS_MS })
+    ],
+    reportedAt: reported?.week?.capturedAt,
   };
 };

--- a/src/main/libs/cursor/accounts.test.ts
+++ b/src/main/libs/cursor/accounts.test.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as CursorStorageModule from './storage';
+
+vi.mock('./storage', async (load) => {
+  const actual = await load<typeof CursorStorageModule>();
+  return { ...actual, readCursorStorage: vi.fn() };
+});
+
+import { detectCursor, discoverAccounts } from './accounts';
+import { readCursorStorage } from './storage';
+
+let home: string;
+let apps: string;
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-home-'));
+  apps = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-apps-'));
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  fs.rmSync(home, { force: true, recursive: true });
+  fs.rmSync(apps, { force: true, recursive: true });
+});
+
+describe('Cursor accounts', () => {
+  it.each([
+    ['IDE', true, undefined, false, ['ide']],
+    ['CLI', false, '1.0', false, ['cli']],
+    ['Grok', false, undefined, true, ['grok-bot']],
+    ['all', true, '1.0', true, ['ide', 'cli', 'grok-bot']]
+  ])('detects %s surfaces', async (_name, ide, version, grok, surfaces) => {
+    vi.mocked(readCursorStorage).mockReturnValue(null);
+    if (ide) fs.mkdirSync(path.join(apps, 'Cursor.app'));
+    if (grok) fs.mkdirSync(path.join(apps, 'Grok Bot.app'));
+    expect(await detectCursor(home, apps, async () => version)).toEqual({ installed: true, surfaces, version });
+  });
+
+  it('returns one safe account for shared IDE and CLI use', () => {
+    vi.mocked(readCursorStorage).mockReturnValue({
+      accessToken: ['part', 'part', 'part'].join('.'), email: 'person@example.test', grokInstalled: true, plan: 'pro', team: 'Team'
+    });
+    const accounts = discoverAccounts(home);
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]).toMatchObject({ email: 'person@example.test', provider: 'cursor', surfaces: ['ide', 'grok-bot'] });
+    expect(accounts[0]).not.toHaveProperty('accessToken');
+  });
+
+  it('does not return an account without a local login', () => {
+    vi.mocked(readCursorStorage).mockReturnValue({ grokInstalled: true });
+    expect(discoverAccounts(home)).toEqual([]);
+  });
+});

--- a/src/main/libs/cursor/accounts.ts
+++ b/src/main/libs/cursor/accounts.ts
@@ -1,0 +1,47 @@
+import { execFile } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { type AIAccount, type AIDetection, type CursorSurface } from 'types/aiUsage';
+
+import { defaultCursorStorageDir, readCursorStorage } from './storage';
+
+const cliVersion = (): Promise<string | undefined> => new Promise((resolve) => {
+  execFile('cursor-agent', ['--version'], { timeout: 5000 }, (firstError, stdout) => {
+    if (!firstError) return resolve(stdout.trim() || undefined);
+    execFile('agent', ['--version'], { timeout: 5000 }, (error, fallbackStdout) => {
+      resolve(error ? undefined : fallbackStdout.trim() || undefined);
+    });
+  });
+});
+
+export const detectCursor = async (
+  home = os.homedir(),
+  applicationsDir = '/Applications',
+  readCliVersion = cliVersion
+): Promise<AIDetection> => {
+  const storage = readCursorStorage(defaultCursorStorageDir(home));
+  const version = await readCliVersion();
+  const surfaces: CursorSurface[] = [];
+  if (storage || fs.existsSync(path.join(applicationsDir, 'Cursor.app'))) surfaces.push('ide');
+  if (version) surfaces.push('cli');
+  if (storage?.grokInstalled || fs.existsSync(path.join(applicationsDir, 'Grok Bot.app'))) surfaces.push('grok-bot');
+  return { installed: surfaces.length > 0, surfaces, version };
+};
+
+export const discoverAccounts = (home = os.homedir()): AIAccount[] => {
+  const dir = defaultCursorStorageDir(home);
+  const data = readCursorStorage(dir);
+  if (!data?.accessToken) return [];
+  const surfaces: CursorSurface[] = ['ide'];
+  if (data.grokInstalled) surfaces.push('grok-bot');
+  return [{
+    dir,
+    email: data.email,
+    label: 'cursor',
+    org: data.team,
+    plan: data.plan,
+    provider: 'cursor',
+    surfaces
+  }];
+};

--- a/src/main/libs/cursor/getUsage.test.ts
+++ b/src/main/libs/cursor/getUsage.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./storage', () => ({ readCursorStorage: vi.fn() }));
+
+import { type AIAccount } from 'types/aiUsage';
+
+import { buildUsage } from './getUsage';
+import { readCursorStorage } from './storage';
+
+const NOW = Date.UTC(2026, 8, 12, 10);
+const account: AIAccount = { dir: '/cursor/storage', label: 'cursor', provider: 'cursor' };
+const encodedClaims = Buffer.from(JSON.stringify({ sub: 'auth0|user-id' })).toString('base64url');
+const sessionValue = ['e30', encodedClaims, 'signature'].join('.');
+const response = (body: unknown, init?: ResponseInit) => new Response(JSON.stringify(body), init);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(readCursorStorage).mockReturnValue({ accessToken: sessionValue, grokInstalled: false });
+});
+
+describe('Cursor usage', () => {
+  it('maps two monthly pools, separate Grok use, and shared spend once', async () => {
+    const fetcher = vi.fn(async () => response({
+      individualUsage: {
+        grokBot: { resetsAt: '2026-09-14T00:00:00Z', totalPercentUsed: 25 },
+        onDemand: { limit: 5000, used: 125 },
+        plan: {
+          cursorModels: { limit: 1000, used: 200 },
+          otherModels: { totalPercentUsed: 50 }
+        }
+      }
+    }));
+    const result = await buildUsage(account, NOW, fetcher);
+    expect(result.metrics.map(({ id, percent }) => ({ id, percent }))).toEqual([
+      { id: 'cursor-models', percent: 0.2 },
+      { id: 'other-models', percent: 0.5 },
+      { id: 'grok-weekly', percent: 0.25 }
+    ]);
+    expect(result.spend).toMatchObject({ amountUsdMicros: 1_250_000, limitUsdMicros: 50_000_000 });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it('uses one plan meter when split pools are absent and clamps large percent values', async () => {
+    const result = await buildUsage(account, NOW, vi.fn(async () => response({
+      individualUsage: { plan: { totalPercentUsed: 150 } }
+    })));
+    expect(result.metrics).toEqual([expect.objectContaining({ id: 'month', percent: 1, title: 'Plan' })]);
+  });
+
+  it('does not invent Grok usage from its installed flag', async () => {
+    vi.mocked(readCursorStorage).mockReturnValue({ accessToken: sessionValue, grokInstalled: true });
+    const result = await buildUsage(account, NOW, vi.fn(async () => response({
+      individualUsage: { plan: { totalPercentUsed: 5 } }
+    })));
+    expect(result.metrics.map(({ id }) => id)).toEqual(['month']);
+  });
+
+  it('returns on-demand spend when no exact limit is available', async () => {
+    const result = await buildUsage(account, NOW, vi.fn(async () => response({
+      individualUsage: { onDemand: { used: 125 }, plan: { totalPercentUsed: 5 } }
+    })));
+    expect(result.spend).toMatchObject({ amountUsdMicros: 1_250_000, label: 'On-demand' });
+    expect(result.spend).not.toHaveProperty('limitUsdMicros');
+  });
+
+  it.each([
+    ['HTTP error', async () => response({}, { status: 500 })],
+    ['invalid JSON', async () => new Response('{bad')],
+    ['bad schema', async () => response({ individualUsage: { plan: { totalPercentUsed: -1 } } })],
+    ['large body', async () => new Response('x'.repeat(256 * 1024 + 1))]
+  ])('fails safely for %s', async (_name, fetcher) => {
+    await expect(buildUsage(account, NOW, vi.fn(fetcher))).rejects.toThrow(/^Cursor usage/);
+  });
+
+  it('rejects a bad login token without calling the network', async () => {
+    vi.mocked(readCursorStorage).mockReturnValue({ accessToken: 'bad', grokInstalled: false });
+    const fetcher = vi.fn();
+    await expect(buildUsage(account, NOW, fetcher)).rejects.toThrow('Cursor login is not available');
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('stops a request after the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetcher = vi.fn((_url: Request | string | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('stopped')));
+      }));
+      const pending = buildUsage(account, NOW, fetcher);
+      const assertion = expect(pending).rejects.toThrow('Cursor usage request timed out');
+      await vi.advanceTimersByTimeAsync(5000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/main/libs/cursor/getUsage.ts
+++ b/src/main/libs/cursor/getUsage.ts
@@ -1,0 +1,156 @@
+import { type AIAccount, type AIUsage, type AIUsageMetric } from 'types/aiUsage';
+
+import { readCursorStorage } from './storage';
+
+const BODY_LIMIT = 256 * 1024;
+const TIMEOUT_MS = 5000;
+
+type Fetch = typeof fetch;
+type JsonObject = Record<string, unknown>;
+
+const object = (value: unknown): JsonObject | undefined => value && typeof value === 'object' && !Array.isArray(value)
+  ? value as JsonObject
+  : undefined;
+const number = (value: unknown): number | undefined => typeof value === 'number' && Number.isFinite(value) && value >= 0
+  ? value
+  : undefined;
+const percentPoints = (value: unknown): number | undefined => {
+  const raw = number(value);
+  if (raw === undefined) return undefined;
+  return Math.min(1, raw / 100);
+};
+const time = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value < 1e12 ? value * 1000 : value;
+  if (typeof value !== 'string') return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const poolPercent = (value: unknown): number | undefined => {
+  const pool = object(value);
+  if (!pool) return undefined;
+  const direct = percentPoints(pool.totalPercentUsed ?? pool.percentUsed);
+  if (direct !== undefined) return direct;
+  const used = number(pool.used);
+  const limit = number(pool.limit);
+  return used !== undefined && limit !== undefined && limit > 0 ? Math.min(1, used / limit) : undefined;
+};
+
+const metric = (id: AIUsageMetric['id'], title: string, pool: unknown): AIUsageMetric | undefined => {
+  const data = object(pool);
+  const value = poolPercent(data);
+  if (!data || value === undefined) return undefined;
+  return {
+    id,
+    label: `${title} usage`,
+    percent: value,
+    resetsAt: time(data.resetsAt ?? data.resetAt ?? data.billingCycleEnd),
+    scope: 'account',
+    source: 'provider',
+    title
+  };
+};
+
+const decodeUserId = (token: string): string | undefined => {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return undefined;
+    const claims: unknown = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    const sub = object(claims)?.sub;
+    if (typeof sub !== 'string' || !sub.trim()) return undefined;
+    const userId = sub.split('|').at(-1)?.trim();
+    return userId || undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const readLimitedText = async (response: Response): Promise<string> => {
+  if (!response.body) {
+    const text = await response.text();
+    if (Buffer.byteLength(text) > BODY_LIMIT) throw new Error('Cursor usage response is too large');
+    return text;
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > BODY_LIMIT) {
+      await reader.cancel();
+      throw new Error('Cursor usage response is too large');
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+};
+
+export const buildUsage = async (
+  account: AIAccount,
+  now: number,
+  fetcher: Fetch = fetch
+): Promise<AIUsage> => {
+  const token = readCursorStorage(account.dir)?.accessToken;
+  const userId = token && decodeUserId(token);
+  if (!token || !userId) throw new Error('Cursor login is not available');
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  let body: unknown;
+  try {
+    const response = await fetcher('https://cursor.com/api/usage-summary', {
+      headers: {
+        Accept: 'application/json',
+        Cookie: `WorkosCursorSessionToken=${encodeURIComponent(`${userId}::${token}`)}`
+      },
+      signal: controller.signal
+    });
+    if (!response.ok) throw new Error('Cursor usage request failed');
+    try {
+      body = JSON.parse(await readLimitedText(response));
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('too large')) throw error;
+      throw new Error('Cursor usage response is invalid');
+    }
+  } catch (error) {
+    if (controller.signal.aborted) throw new Error('Cursor usage request timed out');
+    if (error instanceof Error && error.message.startsWith('Cursor usage')) throw error;
+    throw new Error('Cursor usage request failed');
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const root = object(body);
+  const individual = object(root?.individualUsage);
+  const plan = object(individual?.plan);
+  if (!root || !individual || !plan) throw new Error('Cursor usage response is invalid');
+
+  const cursorPool = plan.cursorModels ?? individual.cursorModels;
+  const otherPool = plan.otherModels ?? individual.otherModels;
+  const split = [
+    metric('cursor-models', 'Cursor models', cursorPool),
+    metric('other-models', 'Other models', otherPool)
+  ].filter((row): row is AIUsageMetric => Boolean(row));
+  const planMetric = metric('month', 'Plan', plan);
+  const grokMetric = metric('grok-weekly', 'Grok Bot', individual.grokBot ?? root.grokBotUsage);
+  const metrics = split.length > 0 ? split : planMetric ? [planMetric] : [];
+  if (grokMetric) metrics.push(grokMetric);
+
+  const onDemand = object(individual.onDemand ?? object(root.teamUsage)?.onDemand);
+  const usedCents = number(onDemand?.used);
+  const limitCents = number(onDemand?.limit);
+  const spend = usedCents !== undefined ? {
+    amountUsdMicros: Math.round(usedCents * 10_000),
+    label: 'On-demand' as const,
+    ...(limitCents === undefined ? {} : { limitUsdMicros: Math.round(limitCents * 10_000) }),
+    period: 'billing-cycle' as const,
+    scope: 'account' as const,
+    source: 'provider' as const,
+    startsAt: time(onDemand?.startsAt ?? onDemand?.billingCycleStart)
+  } : undefined;
+
+  if (metrics.length === 0 && !spend) throw new Error('Cursor usage response is invalid');
+  return { account, computedAt: now, metrics, reportedAt: now, spend };
+};

--- a/src/main/libs/cursor/storage.test.ts
+++ b/src/main/libs/cursor/storage.test.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import { DatabaseSync } from 'node:sqlite';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readCursorStorage } from './storage';
+
+let dir: string;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-storage-')); });
+afterEach(() => { fs.rmSync(dir, { force: true, recursive: true }); });
+
+const database = (rows: [string, string][]) => {
+  const db = new DatabaseSync(path.join(dir, 'state.vscdb'));
+  db.exec('CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)');
+  const insert = db.prepare('INSERT INTO ItemTable (key, value) VALUES (?, ?)');
+  for (const row of rows) insert.run(...row);
+  db.close();
+};
+
+describe('Cursor storage', () => {
+  it('reads only the account allow-list', () => {
+    database([
+      ['cursorAuth/accessToken', 'session-value'],
+      ['cursorAuth/cachedEmail', 'person@example.test'],
+      ['cursorAuth/cachedTeam', '{"name":"Team"}'],
+      ['cursorAuth/stripeMembershipType', 'pro'],
+      ['cursor/grokBotInstalled', 'true'],
+      ['unrelated/private', 'must-not-return']
+    ]);
+    expect(readCursorStorage(dir)).toEqual({
+      accessToken: 'session-value', email: 'person@example.test', grokInstalled: true, plan: 'pro', team: 'Team'
+    });
+  });
+
+  it.each(['missing', 'bad'])('fails closed for a %s database', (kind) => {
+    if (kind === 'bad') fs.writeFileSync(path.join(dir, 'state.vscdb'), 'not sqlite');
+    expect(readCursorStorage(dir)).toBeNull();
+  });
+
+  it('rejects a large database before it opens it', () => {
+    const file = path.join(dir, 'state.vscdb');
+    fs.writeFileSync(file, '');
+    fs.truncateSync(file, 512 * 1024 * 1024 + 1);
+    expect(readCursorStorage(dir)).toBeNull();
+  });
+
+  it('returns no data when the database is locked', () => {
+    database([['cursorAuth/cachedEmail', 'person@example.test']]);
+    const lock = new DatabaseSync(path.join(dir, 'state.vscdb'));
+    lock.exec('BEGIN EXCLUSIVE; UPDATE ItemTable SET value = value');
+    expect(readCursorStorage(dir)).toBeNull();
+    lock.exec('ROLLBACK');
+    lock.close();
+  });
+});

--- a/src/main/libs/cursor/storage.ts
+++ b/src/main/libs/cursor/storage.ts
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import { DatabaseSync } from 'node:sqlite';
+import os from 'os';
+import path from 'path';
+
+const MAX_DATABASE_BYTES = 512 * 1024 * 1024;
+const KEYS = [
+  'cursor/grokBotInstalled',
+  'cursorAuth/accessToken',
+  'cursorAuth/cachedEmail',
+  'cursorAuth/cachedTeam',
+  'cursorAuth/stripeMembershipType'
+] as const;
+
+export type CursorStorage = {
+  accessToken?: string;
+  email?: string;
+  grokInstalled: boolean;
+  plan?: string;
+  team?: string;
+};
+
+export const defaultCursorStorageDir = (home = os.homedir()): string => path.join(
+  home,
+  'Library',
+  'Application Support',
+  'Cursor',
+  'User',
+  'globalStorage'
+);
+
+const plainString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string' || value.length > 4096) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === 'string' ? parsed : undefined;
+  } catch {
+    return value;
+  }
+};
+
+const teamName = (value: unknown): string | undefined => {
+  const plain = plainString(value);
+  if (plain) return plain;
+  if (typeof value !== 'string' || value.length > 4096) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object') return undefined;
+    const row = parsed as Record<string, unknown>;
+    return plainString(row.name) ?? plainString(row.teamName);
+  } catch {
+    return undefined;
+  }
+};
+
+const isTrue = (value: unknown): boolean => {
+  if (value === true || value === 1) return true;
+  if (typeof value === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (parsed === true || parsed === 1) return true;
+    } catch {
+      // Fall through to plain string forms.
+    }
+  }
+  const plain = plainString(value)?.toLowerCase();
+  return plain === 'true' || plain === '1';
+};
+
+/** Read only the small allow-list needed for Cursor account usage. */
+export const readCursorStorage = (dir: string): CursorStorage | null => {
+  const file = path.join(dir, 'state.vscdb');
+  let db: DatabaseSync | undefined;
+  try {
+    const stat = fs.statSync(file);
+    if (!stat.isFile() || stat.size <= 0 || stat.size > MAX_DATABASE_BYTES) return null;
+    db = new DatabaseSync(file, { readOnly: true });
+    const placeholders = KEYS.map(() => '?').join(', ');
+    const rows = db.prepare(`SELECT key, value FROM ItemTable WHERE key IN (${placeholders})`).all(...KEYS) as {
+      key?: unknown;
+      value?: unknown;
+    }[];
+    const values = new Map(rows.flatMap(({ key, value }) => typeof key === 'string' ? [[key, value] as const] : []));
+    return {
+      accessToken: plainString(values.get('cursorAuth/accessToken')),
+      email: plainString(values.get('cursorAuth/cachedEmail')),
+      grokInstalled: isTrue(values.get('cursor/grokBotInstalled')),
+      plan: plainString(values.get('cursorAuth/stripeMembershipType')),
+      team: teamName(values.get('cursorAuth/cachedTeam'))
+    };
+  } catch {
+    return null;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // A failed close does not expose account data.
+    }
+  }
+};

--- a/src/preload/cursor.test.ts
+++ b/src/preload/cursor.test.ts
@@ -1,0 +1,28 @@
+import { type AIAccount } from 'types/aiUsage';
+import { expect, it, vi } from 'vitest';
+
+import { type Bridge } from './index';
+
+const { exposeInMainWorld, invoke } = vi.hoisted(() => ({ exposeInMainWorld: vi.fn(), invoke: vi.fn() }));
+vi.mock('electron', () => ({ contextBridge: { exposeInMainWorld }, ipcRenderer: { invoke } }));
+
+await import('./index');
+const [, bridge] = exposeInMainWorld.mock.calls[0] as [string, Bridge];
+
+it('routes Cursor as one provider', () => {
+  const account: AIAccount = { dir: '/cursor/globalStorage', label: 'Cursor', provider: 'cursor', surfaces: ['ide', 'cli'] };
+  bridge.cursor.detect();
+  bridge.cursor.accounts();
+  bridge.cursor.usage(account);
+  expect(invoke.mock.calls).toEqual([['cursor:detect'], ['cursor:accounts'], ['cursor:usage', account]]);
+});
+
+it('routes admin key calls without any read-key call', () => {
+  bridge.aiUsageCredentials.status();
+  bridge.aiUsageCredentials.set('openai', 'sk-admin-test');
+  bridge.aiUsageCredentials.clear('openai');
+  expect(invoke.mock.calls.slice(-3)).toEqual([
+    ['aiUsageCredentials:status'], ['aiUsageCredentials:set', 'openai', 'sk-admin-test'], ['aiUsageCredentials:clear', 'openai']
+  ]);
+  expect(Object.keys(bridge.aiUsageCredentials)).toEqual(['clear', 'set', 'status']);
+});

--- a/src/preload/demo/bridge.test.ts
+++ b/src/preload/demo/bridge.test.ts
@@ -7,7 +7,7 @@ vi.mock('electron', () => ({
 }));
 
 import { demoBridge } from './bridge';
-import { claudeAccounts, codexAccounts, runsById } from './data';
+import { claudeAccounts, codexAccounts, cursorAccounts, runsById } from './data';
 
 describe('demoBridge gitAPI', () => {
   beforeEach(() => {
@@ -81,8 +81,8 @@ describe('demoBridge claude', () => {
     const usage = await demoBridge.claude.usage({ dir: claudeAccounts[0].dir });
 
     expect(usage.account).toMatchObject({ dir: claudeAccounts[0].dir });
-    expect(usage.fiveHour.active).toBe(true);
-    expect(usage.week.tokens).toBeGreaterThan(0);
+    expect(usage.metrics).toHaveLength(2);
+    expect(usage.metrics[1].tokens).toBeGreaterThan(0);
   });
 
   it('falls back to the first account usage for an unknown account dir', async () => {
@@ -97,8 +97,27 @@ describe('demoBridge codex', () => {
     expect(await demoBridge.codex.accounts()).toEqual(codexAccounts);
     const usages = await Promise.all(codexAccounts.map((account) => demoBridge.codex.usage(account)));
     expect(usages.map((usage) => usage.account.dir)).toEqual(codexAccounts.map((account) => account.dir));
-    expect(usages[0].week.pct).not.toBe(usages[1].week.pct);
+    expect(usages[0].account.dir).not.toBe(usages[1].account.dir);
     await expect(demoBridge.codex.usage({ dir: claudeAccounts[0].dir })).rejects.toThrow('Unknown Codex profile');
+  });
+});
+
+describe('demoBridge cursor', () => {
+  it('shows IDE, CLI, and Grok as one Cursor account', async () => {
+    expect(await demoBridge.cursor.accounts()).toEqual(cursorAccounts);
+    const usage = await demoBridge.cursor.usage(cursorAccounts[0]);
+    expect(usage.metrics.map(({ id }) => id)).toEqual(['cursor-models', 'other-models']);
+    expect(usage.spend?.label).toBe('On-demand');
+    expect(usage.account.surfaces).toEqual(['ide', 'cli', 'grok-bot']);
+  });
+});
+
+describe('demoBridge AI usage credentials', () => {
+  it('returns saved status without returning a key', async () => {
+    await demoBridge.aiUsageCredentials.set('openai', 'sk-admin-demo');
+    expect(await demoBridge.aiUsageCredentials.status()).toEqual({ anthropic: false, openai: true });
+    await demoBridge.aiUsageCredentials.clear('openai');
+    expect(await demoBridge.aiUsageCredentials.status()).toEqual({ anthropic: false, openai: false });
   });
 });
 

--- a/src/preload/demo/bridge.ts
+++ b/src/preload/demo/bridge.ts
@@ -6,6 +6,7 @@
 // through IPC so the pin works while demoing.
 
 import { ipcRenderer } from 'electron';
+import { type PRStatus } from 'types/gitHub';
 import { type WindowOpacity } from 'types/window';
 
 import {
@@ -14,6 +15,8 @@ import {
   codexAccounts,
   codexUsageByDir,
   conflictFilesByPR,
+  cursorAccounts,
+  cursorUsageByDir,
   gitStatusById,
   groups,
   jobsForRun,
@@ -50,18 +53,45 @@ const store: Record<string, any> = {
   projects,
   themeSource: 'system'
 };
+const savedAdminKeys = { anthropic: false, openai: false };
 
-const ok = (extra: Record<string, any> = {}) => Promise.resolve({ success: true, ...extra });
+const ok = <T extends Record<string, unknown> = Record<never, never>>(extra: T = {} as T) => Promise.resolve({ success: true as const, ...extra });
 const noop = () => Promise.resolve();
+const emptyPRStatus: PRStatus = {
+  allowedMergeMethods: [],
+  autoMergeAllowed: false,
+  autoMergeEnabled: false,
+  behind: false,
+  checks: [],
+  mergeable: false,
+  mergeableState: 'unknown',
+  review: null,
+  success: true,
+  unresolvedComments: 0,
+  unresolvedThreads: [],
+  workflowRuns: []
+};
 
 export const demoBridge = {
+  aiUsageCredentials: {
+    clear: (provider: 'anthropic' | 'openai') => {
+      savedAdminKeys[provider] = false;
+      return Promise.resolve();
+    },
+    set: (provider: 'anthropic' | 'openai', value: string) => {
+      if (!value.trim()) return Promise.reject(new Error('Invalid admin key'));
+      savedAdminKeys[provider] = true;
+      return Promise.resolve();
+    },
+    status: () => Promise.resolve({ ...savedAdminKeys })
+  },
   analytics: {
     trackEvent: noop
   },
   claude: {
     accounts: () => Promise.resolve(claudeAccounts),
     detect: () => Promise.resolve({ installed: true, version: '2.0.14' }),
-    usage: (account: { dir: string }) => Promise.resolve(usageByDir[account.dir] ?? usageByDir[claudeAccounts[0].dir])
+    usage: (account: { dir: string }) => Promise.resolve(usageByDir[account.dir as keyof typeof usageByDir] ?? usageByDir[claudeAccounts[0].dir as keyof typeof usageByDir])
   },
   clipboard: {
     onDownscaled: () => () => {}
@@ -72,6 +102,14 @@ export const demoBridge = {
     usage: (account: { dir: string }) => {
       const usage = codexUsageByDir[account.dir];
       return usage ? Promise.resolve(usage) : Promise.reject(new Error('Unknown Codex profile'));
+    }
+  },
+  cursor: {
+    accounts: () => Promise.resolve(cursorAccounts),
+    detect: () => Promise.resolve({ installed: true, surfaces: ['ide', 'cli', 'grok-bot'], version: '1.7.0' }),
+    usage: (account: { dir: string }) => {
+      const usage = cursorUsageByDir[account.dir as keyof typeof cursorUsageByDir];
+      return usage ? Promise.resolve(usage) : Promise.reject(new Error('Unknown Cursor account'));
     }
   },
   darkMode: {
@@ -94,8 +132,7 @@ export const demoBridge = {
     getJobs: (_id: string, runId: number) => ok({ jobs: jobsForRun(runId) }),
     getOpenPulls: (id: string) => ok({ pulls: pullsById[id] ?? [] }),
     getPinnedRuns: () => ok({ runs: [] }),
-    getPRChecks: (_id: string, prNumber: number) =>
-      Promise.resolve(prChecksByPR[prNumber] ?? { allowedMergeMethods: [], autoMergeAllowed: false, autoMergeEnabled: false, behind: false, checks: [], mergeable: false, mergeableState: 'unknown', review: null, success: true, unresolvedComments: 0, unresolvedThreads: [] }),
+    getPRChecks: (_id: string, prNumber: number) => Promise.resolve(prChecksByPR[prNumber] ?? emptyPRStatus),
     getPulls: (id: string, type: string) => {
       const nums = type === 'author' ? authoredPRNumbers[id] : type === 'review-requested' ? reviewRequestedPRNumbers[id] : [];
       return ok({ pulls: (nums ?? []).map((number) => ({ number })) });

--- a/src/preload/demo/data.ts
+++ b/src/preload/demo/data.ts
@@ -3,6 +3,8 @@
 // Every object here is a plain literal shaped to match exactly the fields the
 // renderer reads (see the demo bridge). No network, no git, no GitHub.
 
+import { type PRReview, type PRReviewer, type PRStatus, type PRThread } from 'types/gitHub';
+
 import { avatars } from './avatars';
 
 const now = Date.now();
@@ -523,33 +525,35 @@ export const checksByPR: Record<number, any[]> = {
 // comment threads, and auto-merge availability. Shaped so the demo cards show
 // off every PR action added today — approve badge, green Merge split button,
 // Update branch, Resolve conflicts, unresolved-comment pill, Auto-merge on.
-const reviewer = (u: any, state: string, reReviewRequested = false) => ({
+type PRChecksOptions = {
+  allowedMergeMethods?: PRStatus['allowedMergeMethods'];
+  approvedBy?: string[];
+  autoMergeAllowed?: boolean;
+  autoMergeEnabled?: boolean;
+  behind?: boolean;
+  changesRequestedBy?: string[];
+  mergeableState?: PRStatus['mergeableState'];
+  number: number;
+  reviewers?: PRReviewer[];
+  reviewState?: PRReview['state'];
+  unresolvedThreads?: PRThread[];
+};
+
+const reviewer = (u: { avatar_url: string; login: string }, state: PRReviewer['state'], reReviewRequested = false): PRReviewer => ({
   avatarUrl: u.avatar_url,
   login: u.login,
   reReviewRequested,
   state
 });
 
-const thread = (u: any, count: number, path: null | string) => ({
+const thread = (u: { avatar_url: string; login: string }, count: number, path: null | string): PRThread => ({
   avatarUrl: u.avatar_url,
   count,
   login: u.login,
   path
 });
 
-const prChecks = (o: {
-  allowedMergeMethods?: string[];
-  approvedBy?: string[];
-  autoMergeAllowed?: boolean;
-  autoMergeEnabled?: boolean;
-  behind?: boolean;
-  changesRequestedBy?: string[];
-  mergeableState?: string;
-  number: number;
-  reviewers?: any[];
-  reviewState?: 'approved' | 'changes_requested' | null;
-  unresolvedThreads?: any[];
-}) => {
+const prChecks = (o: PRChecksOptions): PRStatus => {
   const threads = o.unresolvedThreads ?? [];
   const ms = o.mergeableState ?? 'clean';
   return {
@@ -570,12 +574,13 @@ const prChecks = (o: {
           }
         : null,
     success: true,
-    unresolvedComments: threads.reduce((n: number, t: any) => n + t.count, 0),
-    unresolvedThreads: threads
+    unresolvedComments: threads.reduce((count, current) => count + current.count, 0),
+    unresolvedThreads: threads,
+    workflowRuns: []
   };
 };
 
-export const prChecksByPR: Record<number, any> = {
+export const prChecksByPR: Record<number, PRStatus> = {
   // The "everything" card for UI testing: approved badge + green Merge split
   // button + 10 labels (→ +7 overflow pill) + unresolved-comment pill, all at
   // once. unstable state (a check pending) still counts as mergeable.
@@ -656,20 +661,9 @@ export const conflictFilesByPR: Record<number, string[]> = {
 // ---- AI usage ----
 const model = (m: string, tokens: number) => ({ model: m, tokens });
 
-const usageWindow = (o: { models: any[]; pct: number; resetsInMs: number; tokens: number }) => ({
-  active: true,
-  cap: Math.round(o.tokens / Math.max(o.pct, 0.01)),
-  models: o.models,
-  pct: o.pct,
-  reported: true,
-  resetsAt: now + o.resetsInMs,
-  startsAt: now - (7 * day - o.resetsInMs),
-  tokens: o.tokens
-});
-
 export const claudeAccounts = [
-  { dir: '/Users/egor/.claude', email: 'evgeni.s@trustic.ai', label: 'claude', org: 'TegoAI', plan: 'Max 20×' },
-  { dir: '/Users/egor/.claude-b', email: 'egor@personal.dev', label: 'claude-b', org: 'Personal', plan: 'Max 5×' }
+  { dir: '/Users/egor/.claude', email: 'evgeni.s@trustic.ai', label: 'claude', org: 'TegoAI', plan: 'Max 20×', provider: 'claude' as const },
+  { dir: '/Users/egor/.claude-b', email: 'egor@personal.dev', label: 'claude-b', org: 'Personal', plan: 'Max 5×', provider: 'claude' as const }
 ];
 
 export const codexAccounts = [
@@ -677,53 +671,51 @@ export const codexAccounts = [
   { dir: '/Users/demo/.codex-work', email: 'developer@work.example', label: 'codex-work', plan: 'Business', provider: 'codex' as const }
 ];
 
+export const cursorAccounts = [
+  { dir: '/Users/demo/Library/Application Support/Cursor/User/globalStorage', email: 'developer@example.com', label: 'Cursor', plan: 'Pro', provider: 'cursor' as const, surfaces: ['ide', 'cli', 'grok-bot'] as const }
+];
+
 export const codexUsageByDir = Object.fromEntries(codexAccounts.map((account, index) => [account.dir, {
   account,
   computedAt: now,
-  fiveHour: {
-    ...usageWindow({ models: [model('gpt-5.4', 840_000 + index * 220_000)], pct: index ? 0.67 : 0.24, resetsInMs: 3 * hour + 18 * min, tokens: 840_000 + index * 220_000 }),
-    durationMs: 5 * hour
-  },
+  metrics: [
+    { id: 'seven-day' as const, label: '7D', models: [model('gpt-5.4', 5_200_000 + index * 900_000)], scope: 'account' as const, source: 'local' as const, title: '7D', tokens: 5_200_000 + index * 900_000, tokensPeriod: 'trailing-window' as const },
+    { id: 'month' as const, label: 'Org API', scope: 'organization' as const, source: 'admin' as const, title: 'Current month API tokens', tokens: 12_800_000 }
+  ],
   reportedAt: now - 3 * min,
-  week: {
-    ...usageWindow({ models: [model('gpt-5.4', 5_200_000 + index * 900_000)], pct: index ? 0.81 : 0.38, resetsInMs: 4 * day + 2 * hour, tokens: 5_200_000 + index * 900_000 }),
-    durationMs: 7 * day
-  }
+  spend: { amountUsdMicros: 18_420_000, label: 'Org API spend' as const, period: 'calendar-month' as const, scope: 'organization' as const, source: 'admin' as const }
 }]));
 
-export const usageByDir: Record<string, any> = {
+export const usageByDir = {
   '/Users/egor/.claude': {
     account: claudeAccounts[0],
     computedAt: now,
-    fiveHour: usageWindow({
-      models: [model('claude-opus-4-8', 1_840_000), model('claude-sonnet-5', 620_000)],
-      pct: 0.41,
-      resetsInMs: 2 * hour + 12 * min,
-      tokens: 2_460_000
-    }),
+    metrics: [
+      { id: 'five-hour' as const, label: '5H', models: [model('claude-opus-4-8', 1_840_000), model('claude-sonnet-5', 620_000)], percent: 0.41, resetsAt: now + 2 * hour + 12 * min, scope: 'account' as const, source: 'provider' as const, title: '5H', tokens: 2_460_000, tokensPeriod: 'provider-period' as const },
+      { id: 'seven-day' as const, label: '7D', models: [model('claude-opus-4-8', 18_400_000), model('claude-sonnet-5', 9_100_000)], percent: 0.63, resetsAt: now + 3 * day + 6 * hour, scope: 'account' as const, source: 'provider' as const, title: '7D', tokens: 27_500_000, tokensPeriod: 'provider-period' as const }
+    ],
     reportedAt: now - 4 * min,
-    week: usageWindow({
-      models: [model('claude-opus-4-8', 18_400_000), model('claude-sonnet-5', 9_100_000), model('claude-haiku-4-5', 2_300_000)],
-      pct: 0.63,
-      resetsInMs: 3 * day + 6 * hour,
-      tokens: 29_800_000
-    })
   },
   '/Users/egor/.claude-b': {
     account: claudeAccounts[1],
     computedAt: now,
-    fiveHour: usageWindow({
-      models: [model('claude-sonnet-5', 340_000)],
-      pct: 0.18,
-      resetsInMs: 1 * hour + 5 * min,
-      tokens: 340_000
-    }),
+    metrics: [
+      { id: 'five-hour' as const, label: '5H', models: [model('claude-sonnet-5', 340_000)], percent: 0.18, resetsAt: now + 1 * hour + 5 * min, scope: 'account' as const, source: 'provider' as const, title: '5H', tokens: 340_000, tokensPeriod: 'provider-period' as const },
+      { id: 'seven-day' as const, label: '7D', models: [model('claude-opus-4-8', 6_200_000), model('claude-sonnet-5', 4_400_000)], percent: 0.82, resetsAt: now + 2 * day + hour, scope: 'account' as const, source: 'provider' as const, title: '7D', tokens: 10_600_000, tokensPeriod: 'provider-period' as const }
+    ],
     reportedAt: now - 9 * min,
-    week: usageWindow({
-      models: [model('claude-opus-4-8', 6_200_000), model('claude-sonnet-5', 4_400_000)],
-      pct: 0.82,
-      resetsInMs: 2 * day + 1 * hour,
-      tokens: 10_600_000
-    })
+  }
+};
+
+export const cursorUsageByDir = {
+  [cursorAccounts[0].dir]: {
+    account: cursorAccounts[0],
+    computedAt: now,
+    metrics: [
+      { id: 'cursor-models' as const, label: 'Cursor', percent: 0.46, resetsAt: now + 12 * day, scope: 'account' as const, source: 'provider' as const, title: 'Cursor Models' },
+      { id: 'other-models' as const, label: 'Other', percent: 0.21, resetsAt: now + 12 * day, scope: 'account' as const, source: 'provider' as const, title: 'Other Models' }
+    ],
+    reportedAt: now - min,
+    spend: { amountUsdMicros: 7_300_000, label: 'On-demand' as const, limitUsdMicros: 50_000_000, period: 'billing-cycle' as const, qualifier: 'Shared by Cursor and Grok Bot.', scope: 'account' as const, source: 'provider' as const }
   }
 };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,11 +1,10 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
 import { type AIAccount, type AIDetection, type AIUsage } from 'types/aiUsage';
 import { type AppSettings } from 'types/appSettings';
-import { type ClaudeAccount, type ClaudeDetection, type ClaudeUsage } from 'types/claudeUsage';
 import { type DownscaleResult } from 'types/clipboard';
 import { type FoundEditor } from 'types/foundEditor';
 import { type FoundShell } from 'types/foundShell';
-import { type pullTypes } from 'types/gitHub';
+import { type PRStatusResult, type pullTypes } from 'types/gitHub';
 import { type ThemeSource } from 'types/Modal';
 import { type GitStatus, type Project } from 'types/project';
 import { type Settings } from 'types/settings';
@@ -14,13 +13,18 @@ import { type WindowAppearance, type WindowOpacity } from 'types/window';
 import { demoBridge } from './demo/bridge';
 
 const bridge = {
+  aiUsageCredentials: {
+    clear: (provider: 'anthropic' | 'openai'): Promise<void> => ipcRenderer.invoke('aiUsageCredentials:clear', provider),
+    set: (provider: 'anthropic' | 'openai', value: string): Promise<void> => ipcRenderer.invoke('aiUsageCredentials:set', provider, value),
+    status: (): Promise<{ anthropic: boolean; openai: boolean }> => ipcRenderer.invoke('aiUsageCredentials:status')
+  },
   analytics: {
     trackEvent: (name: string, params?: Record<string, unknown>) => ipcRenderer.invoke('analytics:trackEvent', name, params)
   },
   claude: {
-    accounts: (): Promise<ClaudeAccount[]> => ipcRenderer.invoke('claude:accounts'),
-    detect: (): Promise<ClaudeDetection> => ipcRenderer.invoke('claude:detect'),
-    usage: (account: ClaudeAccount): Promise<ClaudeUsage> => ipcRenderer.invoke('claude:usage', account)
+    accounts: (): Promise<AIAccount[]> => ipcRenderer.invoke('claude:accounts'),
+    detect: (): Promise<AIDetection> => ipcRenderer.invoke('claude:detect'),
+    usage: (account: AIAccount): Promise<AIUsage> => ipcRenderer.invoke('claude:usage', account)
   },
   clipboard: {
     onDownscaled: (callback: (result: DownscaleResult) => void) => {
@@ -33,6 +37,11 @@ const bridge = {
     accounts: (): Promise<AIAccount[]> => ipcRenderer.invoke('codex:accounts'),
     detect: (): Promise<AIDetection> => ipcRenderer.invoke('codex:detect'),
     usage: (account: AIAccount): Promise<AIUsage> => ipcRenderer.invoke('codex:usage', account)
+  },
+  cursor: {
+    accounts: (): Promise<AIAccount[]> => ipcRenderer.invoke('cursor:accounts'),
+    detect: (): Promise<AIDetection> => ipcRenderer.invoke('cursor:detect'),
+    usage: (account: AIAccount): Promise<AIUsage> => ipcRenderer.invoke('cursor:usage', account)
   },
   darkMode: {
     on: (callback: (event: IpcRendererEvent, theme: ThemeSource) => void) => ipcRenderer.on('theme-changed', callback),
@@ -55,7 +64,7 @@ const bridge = {
     getJobs: (id: string, runId: number) => ipcRenderer.invoke('git:api:getJobs', id, runId),
     getOpenPulls: (id: string) => ipcRenderer.invoke('git:api:getOpenPulls', id),
     getPinnedRuns: (id: string) => ipcRenderer.invoke('git:api:getPinnedRuns', id),
-    getPRChecks: (id: string, prNumber: number) => ipcRenderer.invoke('git:api:getPRChecks', id, prNumber),
+    getPRChecks: (id: string, prNumber: number): Promise<PRStatusResult> => ipcRenderer.invoke('git:api:getPRChecks', id, prNumber),
     getPulls: (id: string, type: (typeof pullTypes)[number]) => ipcRenderer.invoke('git:api:getPulls', id, type),
     getRuns: (id: string, deep = false) => ipcRenderer.invoke('git:api:getRuns', id, deep),
     getRunsPage: (id: string, page: number, branch?: string) => ipcRenderer.invoke('git:api:getRunsPage', id, page, branch),

--- a/src/renderer/components/AppNavbar/AppNavbar.test.tsx
+++ b/src/renderer/components/AppNavbar/AppNavbar.test.tsx
@@ -8,7 +8,7 @@ const longBranch = 'HERO-10251/this-is-a-very-long-focused-worktree-name-that-mu
 vi.mock('renderer/hooks/useAIUsage', () => ({
   useAIUsage: (selector: (state: object) => unknown) => selector({
     accounts: [{ dir: '/test', provider: 'claude' }],
-    detection: { claude: { installed: true }, codex: { installed: false } },
+    detection: { claude: { installed: true }, codex: { installed: false }, cursor: { installed: true, surfaces: ['ide', 'cli'] } },
     discoveryErrors: {},
     init: vi.fn()
   })

--- a/src/renderer/components/AppNavbar/AppNavbar.tsx
+++ b/src/renderer/components/AppNavbar/AppNavbar.tsx
@@ -97,7 +97,7 @@ export const AppNavbar = () => {
   const { themeSource, toggleDarkMode } = useDarkMode();
   const { claudeEnabled, clipboardDownscale, set, showClaudeUsage, showLogo } = useAppSettings();
   const isSunset = useIsSunset();
-  const aiAvailable = useAIUsage((s) => s.accounts.length > 0 || s.detection.claude.installed || s.detection.codex.installed || Object.keys(s.discoveryErrors).length > 0);
+  const aiAvailable = useAIUsage((s) => s.accounts.length > 0 || Object.values(s.detection).some(({ installed }) => installed) || Object.keys(s.discoveryErrors).length > 0);
   const refreshAIUsage = useAIUsage((s) => s.init);
   const { addProject, projects } = useProjects();
   const { clear } = useFilter();

--- a/src/renderer/components/ClaudeUsage/AccountPills.tsx
+++ b/src/renderer/components/ClaudeUsage/AccountPills.tsx
@@ -2,6 +2,8 @@ import { Tooltip } from '@blueprintjs/core';
 import { cn } from 'renderer/utils/cn';
 import { type AIAccount } from 'types/aiUsage';
 
+const providerName = (provider: AIAccount['provider']) => ({ claude: 'Claude', codex: 'Codex', cursor: 'Cursor' })[provider];
+
 type Props = {
   accounts: AIAccount[];
   activeDir?: string;
@@ -20,7 +22,7 @@ export const AccountPills = ({ accounts, activeDir, onSelect }: Props) => {
           placement="top"
         >
           <button
-            aria-label={`${account.provider === 'claude' ? 'Claude' : 'Codex'} account ${i + 1}: ${account.email ?? account.label}`}
+            aria-label={`${providerName(account.provider)} account ${i + 1}: ${account.email ?? account.label}`}
             aria-pressed={account.dir === activeDir}
             className={cn(
               'app-region-no-drag flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[11px] font-semibold tabular-nums focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500',

--- a/src/renderer/components/ClaudeUsage/ClaudeFooter.test.tsx
+++ b/src/renderer/components/ClaudeUsage/ClaudeFooter.test.tsx
@@ -8,9 +8,9 @@ const mocks = vi.hoisted(() => ({ pathname: '/', setActive: vi.fn(), setProvider
 vi.mock('react-router', () => ({ useLocation: () => ({ pathname: mocks.pathname }) }));
 vi.mock('renderer/hooks/useAppSettings', () => ({ useAppSettings: () => ({ claudeEnabled: true, showClaudeUsage: true }), useIsSunset: () => false }));
 vi.mock('renderer/hooks/useAIUsage', () => ({
-  AI_PROVIDERS: ['claude', 'codex'], aiAccountKey: (account: AIAccount) => `${account.provider}:${account.dir}`, useAIUsage: () => mocks.state
+  AI_PROVIDER_CONFIG: { claude: { name: 'Claude' }, codex: { name: 'Codex' }, cursor: { name: 'Cursor' } },
+  AI_PROVIDERS: ['claude', 'codex', 'cursor'], aiAccountKey: (account: AIAccount) => `${account.provider}:${account.dir}`, useAIUsage: () => mocks.state
 }));
-vi.mock('@number-flow/react', () => ({ default: ({ suffix, value }: { suffix?: string; value: number }) => <span>{value}{suffix}</span> }));
 vi.mock('@blueprintjs/core', () => ({
   Icon: (): null => null,
   Popover: ({ children, content }: { children: ReactNode; content: ReactNode }) => <div>{children}{content}</div>,
@@ -21,10 +21,8 @@ import { ClaudeFooter } from './ClaudeFooter';
 
 const claude: AIAccount = { dir: '/claude', label: 'Claude main', provider: 'claude' };
 const codex: AIAccount = { dir: '/codex', label: 'Codex main', provider: 'codex' };
-const usage = (account: AIAccount): AIUsage => {
-  const window: AIUsage['fiveHour'] = { active: true, cap: 0, models: [], pct: 0.25, reported: true, resetsAt: Date.now() + 3600000, startsAt: Date.now(), tokens: 1000 };
-  return { account, computedAt: Date.now(), fiveHour: window, reportedAt: Date.now() - 60000, week: window };
-};
+const cursor: AIAccount = { dir: '/cursor', label: 'Cursor', provider: 'cursor', surfaces: ['ide', 'cli', 'grok-bot'] };
+const usage = (account: AIAccount): AIUsage => ({ account, computedAt: Date.now(), metrics: [{ id: 'seven-day', label: '7D', percent: 0.25, resetsAt: Date.now() + 3600000, scope: 'account', source: 'provider', title: '7D', tokens: 1000 }], reportedAt: Date.now() - 60000 });
 
 describe('AI Analytics footer', () => {
   beforeEach(() => {
@@ -32,50 +30,111 @@ describe('AI Analytics footer', () => {
     mocks.pathname = '/';
     vi.stubGlobal('ResizeObserver', class { disconnect() {} observe() {} });
     mocks.state = {
-      accounts: [claude, { ...claude, dir: '/claude-2', label: 'Claude work' }, codex, { ...codex, dir: '/codex-2', label: 'Codex work' }],
-      activeDirs: { claude: claude.dir, codex: codex.dir }, activeProvider: 'claude', detection: { claude: { installed: true }, codex: { installed: true } },
-      discoveryErrors: {}, errorByAccount: {}, init: vi.fn(), loadingByAccount: {}, setActive: mocks.setActive, setProvider: mocks.setProvider,
-      usageByAccount: { 'claude:/claude': usage(claude), 'codex:/codex': usage(codex) }
+      accounts: [claude, { ...claude, dir: '/claude-2', label: 'Claude work' }, codex, cursor],
+      activeDirs: { claude: claude.dir, codex: codex.dir, cursor: cursor.dir }, activeProvider: 'claude',
+      detection: { claude: { installed: true }, codex: { installed: true }, cursor: { installed: true } },
+      discoveryErrors: {}, errorByAccount: {}, loadingByAccount: {}, setActive: mocks.setActive, setProvider: mocks.setProvider,
+      usageByAccount: { 'claude:/claude': usage(claude), 'codex:/codex': usage(codex), 'cursor:/cursor': usage(cursor) }
     };
   });
 
-  it('uses icon buttons to switch immediately to cached provider usage', () => {
+  it('switches among three providers and keeps the footer at 44 pixels', () => {
     const { rerender } = render(<ClaudeFooter />);
-    expect(screen.queryByRole('button', { name: 'Both' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Show Claude usage' }).getAttribute('aria-pressed')).toBe('true');
-    expect(screen.getByRole('button', { name: 'Show Claude usage' }).getAttribute('title')).toBe('Claude');
-    expect(screen.getByRole('button', { name: 'Claude account 1: Claude main' }).getAttribute('aria-pressed')).toBe('true');
-    expect(screen.queryByRole('button', { name: /Codex account/ })).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: 'Show Codex usage' }));
-    expect(mocks.setProvider).toHaveBeenCalledWith('codex');
-    mocks.state.activeProvider = 'codex';
+    fireEvent.click(screen.getByRole('button', { name: 'Show Cursor usage' }));
+    expect(mocks.setProvider).toHaveBeenCalledWith('cursor');
+    mocks.state.activeProvider = 'cursor';
     rerender(<ClaudeFooter />);
-    expect(screen.getByRole('button', { name: /Codex · 7D usage/ })).toBeDefined();
-    expect(screen.queryByText('Reading usage…')).toBeNull();
+    expect(screen.getByRole('button', { name: /7D: 25% of current quota period/ })).toBeDefined();
     expect(screen.getByRole('contentinfo').className).toContain('h-11');
   });
 
-  it('shows only weekly Codex usage, with no five-hour meter', () => {
-    const codexUsage = usage(codex);
-    codexUsage.week = { ...codexUsage.week, cap: 0, durationMs: 7 * 24 * 3600000, reported: false };
-    mocks.state.activeProvider = 'codex';
-    mocks.state.usageByAccount = { 'codex:/codex': codexUsage };
+  it('uses the official Cursor SVG mark and shows its key hint', () => {
     render(<ClaudeFooter />);
-    expect(screen.getByRole('button', { name: /Codex · 7D usage: 1.0K tokens, quota unavailable/ })).toBeDefined();
-    expect(screen.getByText('— · 1.0K tokens')).toBeDefined();
-    expect(screen.queryByRole('button', { name: /Codex · 5H usage/ })).toBeNull();
-    expect(screen.queryByRole('button', { name: /Claude account/ })).toBeNull();
+    const button = screen.getByRole('button', { name: 'Show Cursor usage' });
+    expect(button.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 466.73 532.09');
+    expect(button.textContent).toBe('');
+    expect(button.getAttribute('aria-keyshortcuts')).toBe('Meta+3');
+    expect(button.getAttribute('title')).toBe('Cursor · ⌘3');
   });
 
-  it('shows empty state without a footer refresh and hides controls on Settings', () => {
-    mocks.state.accounts = [];
-    mocks.state.usageByAccount = {};
-    const { rerender } = render(<ClaudeFooter />);
-    expect(screen.getByText('No Claude accounts found.')).toBeDefined();
-    expect(screen.queryByRole('button', { name: 'Rescan AI accounts' })).toBeNull();
+  it('maps exact Command number keys to providers', () => {
+    render(<ClaudeFooter />);
+    for (const [code, provider] of [['Digit1', 'claude'], ['Digit2', 'codex'], ['Digit3', 'cursor']] as const) {
+      const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, code, metaKey: true });
+      document.body.dispatchEvent(event);
+      expect(mocks.setProvider).toHaveBeenLastCalledWith(provider);
+      expect(event.defaultPrevented).toBe(true);
+    }
+    expect(screen.getByRole('button', { name: 'Show Claude usage' }).getAttribute('aria-keyshortcuts')).toBe('Meta+1');
+    expect(screen.getByRole('button', { name: 'Show Codex usage' }).getAttribute('aria-keyshortcuts')).toBe('Meta+2');
+  });
+
+  it('ignores other modifiers, repeats, plain numbers, and editable targets', () => {
+    const { container } = render(<ClaudeFooter />);
+    for (const options of [
+      { code: 'Digit1' }, { code: 'Digit1', ctrlKey: true, metaKey: true }, { altKey: true, code: 'Digit1', metaKey: true },
+      { code: 'Digit1', metaKey: true, shiftKey: true }, { code: 'Digit1', metaKey: true, repeat: true }
+    ]) fireEvent.keyDown(document.body, options);
+    for (const element of [document.createElement('input'), document.createElement('textarea'), document.createElement('select')]) {
+      container.append(element);
+      fireEvent.keyDown(element, { code: 'Digit1', metaKey: true });
+    }
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    container.append(editable);
+    fireEvent.keyDown(editable, { code: 'Digit1', metaKey: true });
+    const textbox = document.createElement('div');
+    textbox.setAttribute('role', 'textbox');
+    container.append(textbox);
+    fireEvent.keyDown(textbox, { code: 'Digit1', metaKey: true });
+    expect(mocks.setProvider).not.toHaveBeenCalled();
+  });
+
+  it('does not handle provider keys while hidden or on Settings', () => {
     mocks.pathname = '/settings/integrations';
-    rerender(<ClaudeFooter />);
-    expect(screen.queryByRole('contentinfo')).toBeNull();
+    render(<ClaudeFooter />);
+    fireEvent.keyDown(document.body, { code: 'Digit2', metaKey: true });
+    expect(mocks.setProvider).not.toHaveBeenCalled();
+  });
+
+  it('keeps spend compact and gives quota meters the free width', () => {
+    mocks.state.activeProvider = 'cursor';
+    mocks.state.usageByAccount = { 'cursor:/cursor': { ...usage(cursor), spend: { amountUsdMicros: 1_000_000, label: 'On-demand', period: 'billing-cycle', scope: 'account', source: 'provider' } } };
+    render(<ClaudeFooter />);
+    expect(screen.getByTestId('usage-meter-row').className).toContain('flex-1');
+    expect(screen.getByTestId('quota-meter-slot').className).toContain('basis-0');
+    expect(screen.getByTestId('quota-meter-slot').className).toContain('flex-1');
+    expect(screen.getByTestId('spend-meter-slot').className).toContain('shrink-0');
+    expect(screen.getByTestId('spend-meter-slot').className).not.toContain('flex-1');
+  });
+
+  it('shows only 7D for Codex', () => {
+    mocks.state.activeProvider = 'codex';
+    render(<ClaudeFooter />);
+    expect(screen.getByRole('button', { name: /7D: 25%/ })).toBeDefined();
+    expect(screen.queryByText('5H')).toBeNull();
+  });
+
+  it('shows Grok as unavailable instead of inventing weekly use', () => {
+    mocks.state.activeProvider = 'cursor';
+    mocks.state.accounts = [claude, codex, { ...cursor, surfaces: ['ide'] }];
+    mocks.state.detection = { claude: { installed: true }, codex: { installed: true }, cursor: { installed: true, surfaces: ['cli', 'grok-bot'] } };
+    render(<ClaudeFooter />);
+    expect(screen.getByText('Used by Cursor IDE and CLI. Grok Bot installed · usage unavailable')).toBeDefined();
+  });
+
+  it('keeps the last good value visible with a read error', () => {
+    mocks.state.activeProvider = 'codex';
+    mocks.state.errorByAccount = { 'codex:/codex': 'Temporary read error' };
+    render(<ClaudeFooter />);
+    expect(screen.getByRole('button', { name: /7D: 25%/ })).toBeDefined();
+    expect(screen.getByRole('status').textContent).toContain('Temporary read error');
+  });
+
+  it('hides controls on Settings', () => {
+    mocks.pathname = '/settings/integrations';
+    render(<ClaudeFooter />);
     expect(screen.getByRole('contentinfo', { hidden: true }).hasAttribute('inert')).toBe(true);
   });
 });

--- a/src/renderer/components/ClaudeUsage/ClaudeFooter.tsx
+++ b/src/renderer/components/ClaudeUsage/ClaudeFooter.tsx
@@ -1,37 +1,49 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { SiOpenai } from 'react-icons/si';
 import { useLocation } from 'react-router';
-import { AI_PROVIDERS, aiAccountKey, useAIUsage } from 'renderer/hooks/useAIUsage';
+import { AI_PROVIDER_CONFIG, AI_PROVIDERS, aiAccountKey, useAIUsage } from 'renderer/hooks/useAIUsage';
 import { useAppSettings, useIsSunset } from 'renderer/hooks/useAppSettings';
 import { cn } from 'renderer/utils/cn';
-import { type AIProvider, type AIUsageWindow } from 'types/aiUsage';
+import { type AIProvider } from 'types/aiUsage';
 
 import { AccountPills } from './AccountPills';
-import { UsageMeter } from './UsageMeter';
+import { SpendMeter, UsageMeter } from './UsageMeter';
 
-const providerNames: Record<AIProvider, string> = { claude: 'Claude', codex: 'Codex' };
 const ClaudeCodeMark = () => (
   <svg aria-hidden
     fill="currentColor"
-    fillRule="evenodd"
     height={16}
     viewBox="0 0 24 24"
     width={16}
-    xmlns="http://www.w3.org/2000/svg"
+  ><path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-8.093-.34L0 11.784l.535-.673 8.585.673h.389l.055-.157-7.207-4.85-.364-.462-.158-1.008.656-.722 7.488 5.622.145-.103-3.695-7.051L6.283.134 6.696 0l.996.134 4.296 8.937h.158l1.11-8.227.747-.492.584.28.48.685-1.766 8.14h.212l5.461-6.336h1.033l.76 1.129-5.472 7.31.188-.02 6.073-1.12.833.388.091.395-.328.807-6.766 1.599-.042.03.049.061 6.853.407.79.522.474.638-.079.485-1.215.62-7.758-1.628h-.182v.11l6.217 5.208.127.578-.322.455-.34-.049-6.356-5.024h-.128v.17l3.032 5.25.122 1.08-.17.353-.608.213-.668-.122-4.606-7.511-.14.08-.99 9.178-.729.28-.607-.461.604-6.677-.152-.042-5.34 6.02-.717-.37.067-.662 4.719-6.012-.006-.158h-.055L3.002 18.706l-.487-.456.061-.746.231-.243 1.908-1.312z" /></svg>
+);
+const CursorMark = () => (
+  <svg aria-hidden
+    fill="currentColor"
+    height={16}
+    viewBox="0 0 466.73 532.09"
+    width={16}
   >
-    <path d="M4.709 15.955l4.72-2.647.08-.23-.08-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z" />
+    <path d="M457.43,125.94L244.42,2.96c-6.84-3.95-15.28-3.95-22.12,0L9.3,125.94c-5.75,3.32-9.3,9.46-9.3,16.11v247.99c0,6.65,3.55,12.79,9.3,16.11l213.01,122.98c6.84,3.95,15.28,3.95,22.12,0l213.01-122.98c5.75-3.32,9.3-9.46,9.3-16.11v-247.99c0-6.65-3.55-12.79-9.3-16.11h-.01ZM444.05,151.99l-205.63,356.16c-1.39,2.4-5.06,1.42-5.06-1.36v-233.21c0-4.66-2.49-8.97-6.53-11.31L24.87,145.67c-2.4-1.39-1.42-5.06,1.36-5.06h411.26c5.84,0,9.49,6.33,6.57,11.39h-.01Z" />
   </svg>
 );
-const windowLabel = (window: AIUsageWindow, fallback: string) => {
-  if (!window.durationMs) return fallback;
-  const hours = window.durationMs / 3600000;
-  return hours % 24 === 0 ? `${hours / 24}D` : `${hours}H`;
+const ProviderIcon = ({ provider }: { provider: AIProvider }) => {
+  if (provider === 'claude') return <ClaudeCodeMark />;
+  if (provider === 'codex') return <SiOpenai aria-hidden
+    size={16}
+                                   />;
+  return <CursorMark />;
 };
+
+const PROVIDER_SHORTCUTS = { Digit1: 'claude', Digit2: 'codex', Digit3: 'cursor' } satisfies Record<string, AIProvider>;
+const isEditableTarget = (target: EventTarget | null) => target instanceof Element
+  && Boolean(target.closest('input, textarea, select, [role="textbox"], [contenteditable]:not([contenteditable="false"])'));
 
 export const ClaudeFooter = ({ onHeightChange }: { onHeightChange?: (height: number) => void }) => {
   const { claudeEnabled, showClaudeUsage } = useAppSettings();
   const isSunset = useIsSunset();
   const state = useAIUsage();
+  const { setProvider } = state;
   const onSettings = useLocation().pathname.startsWith('/settings');
   const available = state.accounts.length > 0 || AI_PROVIDERS.some((provider) => state.detection[provider].installed) || Object.keys(state.discoveryErrors).length > 0;
   const visible = (claudeEnabled ?? true) && showClaudeUsage && !onSettings && available;
@@ -54,22 +66,38 @@ export const ClaudeFooter = ({ onHeightChange }: { onHeightChange?: (height: num
     const timer = window.setInterval(() => setNow(Date.now()), 30000);
     return () => window.clearInterval(timer);
   }, []);
+  useEffect(() => {
+    if (!visible) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey || event.repeat || isEditableTarget(event.target)) return;
+      const next = PROVIDER_SHORTCUTS[event.code];
+      if (!next) return;
+      event.preventDefault();
+      setProvider(next);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [setProvider, visible]);
   if (!available) return null;
-  const provider: AIProvider = state.activeProvider === 'codex' ? 'codex' : 'claude';
+  const provider = state.activeProvider;
+  const providerName = AI_PROVIDER_CONFIG[provider].name;
   const accounts = state.accounts.filter((account) => account.provider === provider);
   const account = accounts.find((candidate) => candidate.dir === state.activeDirs[provider]);
   const key = account && aiAccountKey(account);
   const usage = key ? state.usageByAccount[key] : undefined;
   const error = (key && state.errorByAccount[key]) || state.discoveryErrors[provider];
-  const windows = provider === 'claude' ? (['week', 'fiveHour'] as const) : (['week'] as const);
+  const cursorSurfaces = provider === 'cursor' ? [...new Set([...(account?.surfaces ?? []), ...(state.detection.cursor.surfaces ?? [])])] : [];
+  const grokUnavailable = cursorSurfaces.includes('grok-bot') && !usage?.metrics.some(({ id }) => id === 'grok-weekly');
+  const cursorApps = [cursorSurfaces.includes('ide') && 'Cursor IDE', cursorSurfaces.includes('cli') && 'CLI'].filter(Boolean);
+  const cursorNote = provider === 'cursor' ? [cursorApps.length ? `Used by ${cursorApps.join(' and ')}` : '', grokUnavailable ? 'Grok Bot installed · usage unavailable' : ''].filter(Boolean).join('. ') : undefined;
+
   return (
-    <footer
-      aria-hidden={!visible}
+    <footer aria-hidden={!visible}
       aria-label="AI Analytics"
       className={cn(
         'app-region-no-drag fixed bottom-0 left-0 right-0 z-10 flex h-11 select-none items-center gap-3 px-4',
         isSunset ? 'devkitty-footer-glass' : 'border-t border-bp-light-gray-1 bg-bp-light-gray-4 dark:border-bp-dark-gray-2 dark:bg-bp-dark-gray-1',
-        'transition-transform duration-300 ease-out',
+        'transition-transform duration-300 ease-out motion-reduce:transition-none',
         visible ? 'translate-y-0' : 'pointer-events-none translate-y-full'
       )}
       inert={!visible}
@@ -79,24 +107,22 @@ export const ClaudeFooter = ({ onHeightChange }: { onHeightChange?: (height: num
         className="flex shrink-0 items-center gap-1"
         role="group"
       >
-        {AI_PROVIDERS.map((candidate) => (
-          <button
-            aria-label={`Show ${providerNames[candidate]} usage`}
+        {AI_PROVIDERS.map((candidate, index) => (
+          <button aria-keyshortcuts={`Meta+${index + 1}`}
+            aria-label={`Show ${AI_PROVIDER_CONFIG[candidate].name} usage`}
             aria-pressed={provider === candidate}
             className={cn(
-                'flex h-7 w-7 items-center justify-center rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500',
-                provider === candidate ? 'bg-black/10 text-bp-dark-gray-1 ring-1 ring-black/10 dark:bg-white/15 dark:text-white dark:ring-white/20' : 'text-bp-gray-1 hover:bg-black/5 dark:text-bp-gray-4 dark:hover:bg-white/10'
-              )}
+              'flex h-7 w-7 items-center justify-center rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500',
+              provider === candidate ? 'bg-black/10 text-bp-dark-gray-1 ring-1 ring-black/10 dark:bg-white/15 dark:text-white dark:ring-white/20' : 'text-bp-gray-1 hover:bg-black/5 dark:text-bp-gray-4 dark:hover:bg-white/10'
+            )}
             key={candidate}
             onClick={() => state.setProvider(candidate)}
-            title={providerNames[candidate]}
+            title={`${AI_PROVIDER_CONFIG[candidate].name} · ⌘${index + 1}`}
             type="button"
           >
-            {candidate === 'claude' ? <ClaudeCodeMark /> : <SiOpenai aria-hidden
-              size={16}
-                                                           />}
+            <ProviderIcon provider={candidate} />
           </button>
-          ))}
+        ))}
       </div>
 
       <AccountPills accounts={accounts}
@@ -105,40 +131,41 @@ export const ClaudeFooter = ({ onHeightChange }: { onHeightChange?: (height: num
       />
 
       {usage ? (
-        <div className="flex min-w-0 flex-1 items-center gap-3">
-          {windows.map((name) => {
-            const label = windowLabel(usage[name], name === 'week' ? '7D' : '5H');
-            return (
-              <div className="min-w-0 flex-1"
-                key={name}
-              >
-                <UsageMeter
-                  label={label}
-                  now={now}
-                  provider={provider}
-                  reportedAt={usage.reportedAt}
-                  title={`${providerNames[provider]} · ${label} usage`}
-                  window={usage[name]}
-                />
-              </div>
-            );
-          })}
+        <div className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden"
+          data-testid="usage-meter-row"
+        >
+          {usage.metrics.map((metric, index) => (
+            <div className="min-w-0 flex-1 basis-0"
+              data-testid="quota-meter-slot"
+              key={metric.id}
+            >
+              <UsageMeter metric={metric}
+                note={index === 0 ? cursorNote : undefined}
+                now={now}
+                provider={provider}
+                reportedAt={metric.source === 'admin' ? usage.computedAt : usage.reportedAt}
+              />
+            </div>
+          ))}
+
+          {usage.spend && (
+            <div className="shrink-0"
+              data-testid="spend-meter-slot"
+            >
+              <SpendMeter spend={usage.spend} />
+            </div>
+          )}
+
+          {usage.metrics.length === 0 && !usage.spend && <span className="min-w-0 flex-1 truncate text-xs text-bp-gray-1 dark:text-bp-gray-4">{grokUnavailable ? 'Grok Bot installed · usage unavailable' : 'Usage unavailable.'}</span>}
         </div>
       ) : (
-        <span className="min-w-0 flex-1 truncate text-xs text-bp-gray-1 dark:text-bp-gray-4">
-          {key && state.loadingByAccount[key] ? 'Reading usage…' : account ? 'Usage unavailable.' : `No ${providerNames[provider]} accounts found.`}
-        </span>
+        <span className="min-w-0 flex-1 truncate text-xs text-bp-gray-1 dark:text-bp-gray-4">{key && state.loadingByAccount[key] ? 'Reading usage…' : account ? 'Usage unavailable.' : `No ${providerName} accounts found.`}</span>
       )}
 
-      {error && (
-        <span className="max-w-48 shrink truncate text-[11px] text-bp-gray-1 dark:text-bp-gray-4"
-          role="status"
-          title={`${providerNames[provider]}: ${error}`}
-        >
-          {providerNames[provider]}: {error}
-        </span>
-      )}
-
+      {error && <span className="max-w-48 shrink truncate text-[11px] text-bp-gray-1 dark:text-bp-gray-4"
+        role="status"
+        title={`${providerName}: ${error}`}
+                >{providerName}: {error}</span>}
     </footer>
   );
 };

--- a/src/renderer/components/ClaudeUsage/UsageMeter.test.tsx
+++ b/src/renderer/components/ClaudeUsage/UsageMeter.test.tsx
@@ -8,51 +8,51 @@ vi.mock('@blueprintjs/core', () => ({
   Popover: ({ children, content }: { children: ReactNode; content: ReactNode }) => <div>{children}{content}</div>
 }));
 
-import { UsageMeter } from './UsageMeter';
+import { SpendMeter, UsageMeter } from './UsageMeter';
 
 describe('UsageMeter', () => {
-  beforeEach(() => {
-    vi.mocked(window.matchMedia).mockReturnValue({ matches: true } as MediaQueryList);
-  });
+  beforeEach(() => vi.mocked(window.matchMedia).mockReturnValue({ matches: true } as MediaQueryList));
 
-  it('labels reported Codex model totals as local and keeps all local rows sorted', () => {
-    render(
-      <UsageMeter
-        label="7D"
-        now={1_000_000}
-        provider="codex"
-        reportedAt={940_000}
-        title="Codex · 7D usage"
-        window={{
-          active: true,
-          cap: 0,
-          models: [
-            { model: 'gpt-5.6-luna', tokens: 222_100 },
-            { model: 'gpt-5.6-sol', tokens: 94_400_000 },
-            { model: 'codex-auto-review', tokens: 2_300_000 },
-            { model: 'gpt-5.6-terra', tokens: 5_400_000 }
-          ],
-          pct: 0.49,
-          reported: true,
-          resetsAt: 605_800_000,
-          startsAt: 1,
-          tokens: 102_322_100
-        }}
-      />
-    );
+  it('keeps the quota period separate from local trailing token history', () => {
+    render(<UsageMeter metric={{
+      id: 'seven-day', label: '7D', models: [
+        { model: 'gpt-5.6-luna', tokens: 222_100 }, { model: 'gpt-5.6-sol', tokens: 94_400_000 },
+        { model: 'codex-auto-review', tokens: 2_300_000 }, { model: 'gpt-5.6-terra', tokens: 5_400_000 }
+      ], percent: 0.04, resetsAt: 605_800_000, scope: 'account', source: 'provider', title: '7D', tokens: 102_322_100, tokensPeriod: 'provider-period'
+    }}
+      now={1_000_000}
+      provider="codex"
+      reportedAt={940_000}
+           />);
 
-    expect(screen.getByText('Local by model')).toBeDefined();
-    expect(screen.getByText('ran 102.3M locally')).toBeDefined();
-    expect(screen.getByText('Quota can include use not recorded in local sessions.')).toBeDefined();
-    expect(screen.queryByText('gpt-6-astra')).toBeNull();
-
+    expect(screen.getByRole('button', { name: '7D: 4% of current quota period' })).toBeDefined();
+    expect(screen.getByText(/Current quota period/)).toBeDefined();
+    expect(screen.getByText('Local tokens in this quota period')).toBeDefined();
+    expect(screen.getByText('Local log tokens can miss use on other machines. They are not billed spend and do not match the quota percent.')).toBeDefined();
+    expect(screen.getByText('102.3M')).toBeDefined();
     const modelList = screen.getByText('gpt-5.6-sol').parentElement?.parentElement;
     expect(modelList).not.toBeNull();
-    expect(within(modelList as HTMLElement).getAllByText(/^(gpt-|codex-)/).map((row) => row.textContent)).toEqual([
-      'gpt-5.6-sol',
-      'gpt-5.6-terra',
-      'codex-auto-review',
-      'gpt-5.6-luna'
+    expect(within(modelList!).getAllByText(/^(gpt-|codex-)/).map((row) => row.textContent)).toEqual([
+      'gpt-5.6-sol', 'gpt-5.6-terra', 'codex-auto-review', 'gpt-5.6-luna'
     ]);
+  });
+
+  it('does not draw a fake quota bar when only local tokens exist', () => {
+    render(<UsageMeter metric={{ id: 'five-hour', label: '5H · Quota unavailable', scope: 'account', source: 'local', title: '5H', tokens: 1200, tokensPeriod: 'trailing-window' }}
+      now={1}
+      provider="claude"
+           />);
+    expect(screen.getByRole('button', { name: '5H: quota unavailable, 1.2K tokens' })).toBeDefined();
+    expect(screen.getAllByText('Quota unavailable').length).toBeGreaterThan(0);
+    expect(screen.getByText('Local token history for the last 5 hours')).toBeDefined();
+  });
+
+  it('shows spend once and draws a bar only with an exact limit', () => {
+    const { rerender } = render(<SpendMeter spend={{ amountUsdMicros: 5_000_000, label: 'Org API spend', period: 'calendar-month', scope: 'organization', source: 'admin' }} />);
+    expect(screen.getByRole('button', { name: 'Org API spend: $5.00' })).toBeDefined();
+    expect(screen.queryByText('of $')).toBeNull();
+    rerender(<SpendMeter spend={{ amountUsdMicros: 5_000_000, label: 'On-demand', limitUsdMicros: 20_000_000, period: 'billing-cycle', qualifier: 'Shared by Cursor and Grok Bot.', scope: 'account', source: 'provider' }} />);
+    expect(screen.getByRole('button', { name: 'On-demand: $5.00 of $20.00' })).toBeDefined();
+    expect(screen.getByText('Shared by Cursor and Grok Bot.')).toBeDefined();
   });
 });

--- a/src/renderer/components/ClaudeUsage/UsageMeter.tsx
+++ b/src/renderer/components/ClaudeUsage/UsageMeter.tsx
@@ -1,201 +1,236 @@
 import { Icon, Popover } from '@blueprintjs/core';
 import { useEffect, useRef, useState } from 'react';
-import { type AIProvider, type AIUsageWindow } from 'types/aiUsage';
+import { type AIProvider, type AIUsageMetric, type AIUsageSpend } from 'types/aiUsage';
 
 import { formatCountdown, formatTokens, meterColor, modelLabel } from './format';
 
-const ResetCountdown = ({ ms }: { ms: number }) => <span>{formatCountdown(ms)}</span>;
-
 type Props = {
-  label: string; // e.g. "7D"
+  metric: AIUsageMetric;
+  note?: string;
   now: number;
   provider: AIProvider;
   reportedAt?: number;
-  title: string; // e.g. "Last 7 days"
-  window: AIUsageWindow;
 };
 
+const PROVIDER_NAMES: Record<AIProvider, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  cursor: 'Cursor'
+};
+const SCOPE_NAMES: Record<AIUsageMetric['scope'], string> = {
+  account: 'Account',
+  organization: 'Org',
+  project: 'Project',
+  workspace: 'Workspace'
+};
+const SOURCE_NAMES: Record<AIUsageMetric['source'], string> = {
+  admin: 'Admin API',
+  local: 'Local files',
+  provider: 'Provider report'
+};
+const COMPACT_LABELS: Record<AIUsageMetric['id'], string> = {
+  'cursor-models': 'Cursor',
+  'five-hour': '5H',
+  'grok-weekly': 'Grok',
+  month: 'Month',
+  'other-models': 'Other',
+  'seven-day': '7D'
+};
+
+const scopeLabel = (scope: AIUsageMetric['scope']) => SCOPE_NAMES[scope];
 const clockTime = (ms: number) => new Date(ms).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+const metricPercent = (metric: AIUsageMetric) => metric.percent === undefined ? undefined : Math.round(metric.percent * 100);
+const localHistoryLabel = (metric: AIUsageMetric) => {
+  if (metric.source === 'admin') return 'Provider report for this calendar month';
+  if (metric.tokensPeriod === 'provider-period') return 'Local tokens in this quota period';
+  if (metric.id === 'five-hour') return 'Local token history for the last 5 hours';
+  if (metric.id === 'seven-day') return 'Local token history for the last 7 days';
+  return 'Token history';
+};
+const compactLabel = (metric: AIUsageMetric) => COMPACT_LABELS[metric.id];
 
 const useAnimatedPercentage = (target: number) => {
   const [value, setValue] = useState(target);
   const valueRef = useRef(target);
-
   useEffect(() => {
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       valueRef.current = target;
       setValue(target);
       return;
     }
-
     const from = valueRef.current;
     const startedAt = performance.now();
     let frame = 0;
     const tick = (now: number) => {
       const elapsed = Math.min(1, (now - startedAt) / 900);
-      const eased = 1 - (1 - elapsed) ** 3;
-      const next = from + (target - from) * eased;
+      const next = from + (target - from) * (1 - (1 - elapsed) ** 3);
       valueRef.current = next;
       setValue(next);
       if (elapsed < 1) frame = window.requestAnimationFrame(tick);
     };
-
     frame = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(frame);
   }, [target]);
-
   return value;
 };
 
-const Detail = ({ now, provider, reportedAt, title, window }: Omit<Props, 'label'>) => {
-  const known = window.reported || window.cap > 0;
-  const pct = Math.round(window.pct * 100);
-  const color = meterColor(window.pct);
-  const localModels = [...window.models].sort((a, b) => b.tokens - a.tokens || a.model.localeCompare(b.model));
-  const modelTotal = localModels.reduce((sum, m) => sum + m.tokens, 0);
-  const reportedCodex = provider === 'codex' && window.reported;
-
+const Detail = ({ metric, note, now, provider, reportedAt }: Props) => {
+  const pct = metricPercent(metric);
+  const color = meterColor(metric.percent ?? 0);
+  const models = [...(metric.models ?? [])].sort((a, b) => b.tokens - a.tokens || a.model.localeCompare(b.model));
+  const total = models.reduce((sum, item) => sum + item.tokens, 0);
   return (
-    <div className="w-[268px] p-4 text-bp-dark-gray-1 dark:text-bp-light-gray-5">
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-semibold">{title}</span>
+    <div className="max-h-[min(420px,70vh)] w-[284px] overflow-y-auto p-4 text-bp-dark-gray-1 dark:text-bp-light-gray-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-semibold">{PROVIDER_NAMES[provider]} · {metric.title}</div>
+          <div className="mt-0.5 text-[11px] text-bp-gray-2">{scopeLabel(metric.scope)} · {SOURCE_NAMES[metric.source]}</div>
+        </div>
 
-        <span
-          className="text-xl font-bold tabular-nums leading-none"
+        <span className="text-xl font-bold tabular-nums leading-none"
           style={{ color }}
-        >
-          {known ? `${pct}%` : '—'}
-        </span>
+        >{pct === undefined ? '—' : `${pct}%`}</span>
       </div>
 
-      <div className="mt-2.5 h-2 w-full overflow-hidden rounded-full bg-bp-light-gray-2 dark:bg-bp-dark-gray-4">
-        {window.active && known && (
-          <div
-            className="h-full rounded-full"
-            style={{ backgroundColor: color, width: `${Math.max(pct, 2)}%` }}
-          />
-        )}
-      </div>
+      {pct === undefined ? (
+        <div className="mt-3 rounded bg-black/5 px-2 py-1.5 text-xs dark:bg-white/5">Quota unavailable</div>
+      ) : (
+        <>
+          <div className="mt-2.5 h-2 w-full overflow-hidden rounded-full bg-bp-light-gray-2 dark:bg-bp-dark-gray-4">
+            <div className="h-full rounded-full"
+              style={{ backgroundColor: color, width: `${Math.max(pct, 2)}%` }}
+            />
+          </div>
 
-      <div className="mt-2 text-xs tabular-nums text-bp-gray-1 dark:text-bp-gray-4">
-        {!known ? `${formatTokens(window.tokens)} tokens · quota unavailable` : window.active
-          ? `Resets ${clockTime(window.resetsAt)} · in ${formatCountdown(window.resetsAt - now)}`
-          : 'Idle — no activity in this window'}
-      </div>
+          <div className="mt-2 text-xs tabular-nums text-bp-gray-1 dark:text-bp-gray-4">
+            Current quota period{metric.resetsAt ? ` · resets ${clockTime(metric.resetsAt)} · in ${formatCountdown(metric.resetsAt - now)}` : ''}
+          </div>
+        </>
+      )}
 
-      {localModels.length > 0 && (
+      {metric.tokens !== undefined && (
         <div className="mt-3.5 border-t border-bp-light-gray-2 pt-3 dark:border-bp-dark-gray-3">
-          <div className="mb-2 flex items-baseline justify-between">
-            <span className="text-[11px] font-semibold uppercase tracking-wide text-bp-gray-2">
-              {reportedCodex ? 'Local by model' : 'By model'}
-            </span>
-
-            <span className="text-[11px] tabular-nums text-bp-gray-2">
-              ran {formatTokens(window.tokens)}{reportedCodex ? ' locally' : ''}
-            </span>
+          <div className="flex items-baseline justify-between gap-3 text-xs">
+            <span className="text-bp-gray-1 dark:text-bp-gray-4">{localHistoryLabel(metric)}</span>
+            <span className="shrink-0 font-semibold tabular-nums">{formatTokens(metric.tokens)}</span>
           </div>
 
-          <div className="flex flex-col gap-1.5">
-            {localModels.map((m) => (
-              <div
-                className="flex items-baseline justify-between gap-3 text-xs"
-                key={m.model}
-              >
-                <span className="truncate font-medium">{modelLabel(m.model)}</span>
+          {metric.source !== 'admin' && (
+            <div className="mt-2 text-[11px] leading-snug text-bp-gray-2">
+              Local log tokens can miss use on other machines. They are not billed spend and do not match the quota percent.
+            </div>
+          )}
 
-                <span className="shrink-0 tabular-nums text-bp-gray-1 dark:text-bp-gray-4">
-                  {formatTokens(m.tokens)}
-
-                  <span className="ml-1.5 text-bp-gray-3 dark:text-bp-gray-3">
-                    {modelTotal ? Math.round((m.tokens / modelTotal) * 100) : 0}%
-                  </span>
-                </span>
-              </div>
-            ))}
-          </div>
+          {models.length > 0 && (
+            <div className="mt-2 flex flex-col gap-1.5">
+              {models.map((item) => (
+                <div className="flex items-baseline justify-between gap-3 text-xs"
+                  key={item.model}
+                >
+                  <span className="truncate font-medium">{modelLabel(item.model)}</span>
+                  <span className="shrink-0 tabular-nums text-bp-gray-1 dark:text-bp-gray-4">{formatTokens(item.tokens)} <span className="text-bp-gray-3">{total ? Math.round(item.tokens / total * 100) : 0}%</span></span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 
-      {reportedCodex && (
-        <div className="mt-3 text-[11px] leading-snug text-bp-gray-2">
-          Quota can include use not recorded in local sessions.
-        </div>
-      )}
+      {note && <div className="mt-3 text-[11px] text-bp-gray-2">{note}</div>}
 
-      <div className="mt-3.5 border-t border-bp-light-gray-2 pt-2.5 text-[11px] leading-snug text-bp-gray-2 dark:border-bp-dark-gray-3">
-        {window.reported
-          ? `Reported by ${provider === 'claude' ? 'Claude Code' : 'Codex'}${reportedAt ? ` · captured ${formatCountdown(Math.max(0, now - reportedAt))} ago` : ' · capture time unknown'}`
-          : provider === 'codex' ? 'Local session tokens on this machine. Quota unavailable until Codex records a rate-limit snapshot.' : 'Approximate — local sessions on this machine, vs your 28-day peak.'}
+      <div className="mt-3 border-t border-bp-light-gray-2 pt-2.5 text-[11px] text-bp-gray-2 dark:border-bp-dark-gray-3">
+        {reportedAt ? `Captured ${formatCountdown(Math.max(0, now - reportedAt))} ago` : 'Capture time unavailable'}
       </div>
     </div>
   );
 };
 
-export const UsageMeter = ({ label, now, provider, reportedAt, title, window }: Props) => {
-  const known = window.reported || window.cap > 0;
-  const pct = Math.round(window.pct * 100);
-  const animatedPct = useAnimatedPercentage(pct);
-
+export const UsageMeter = (props: Props) => {
+  const { metric, note, now, provider, reportedAt } = props;
+  const pct = metricPercent(metric);
+  const animatedPct = useAnimatedPercentage(pct ?? 0);
+  const color = meterColor(metric.percent ?? 0);
+  const tokens = metric.tokens === undefined ? '' : `, ${formatTokens(metric.tokens)} tokens`;
   return (
-    <Popover
-      content={
-        <Detail
-          now={now}
-          provider={provider}
-          reportedAt={reportedAt}
-          title={title}
-          window={window}
-        />
-      }
+    <Popover content={(
+      <Detail metric={metric}
+        note={note}
+        now={now}
+        provider={provider}
+        reportedAt={reportedAt}
+      />
+    )}
       fill
       interactionKind="hover"
       minimal
       placement="top"
     >
-      <button aria-label={`${title}: ${known ? `${pct}%` : `${formatTokens(window.tokens)} tokens, quota unavailable`}`}
+      <button
+        aria-label={`${metric.title}: ${pct === undefined ? `quota unavailable${tokens}` : `${pct}% of current quota period`}`}
         className="flex w-full min-w-0 items-center gap-2 rounded text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
         type="button"
       >
-        <span className="shrink-0 rounded bg-black/5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-bp-gray-1 dark:bg-white/10 dark:text-white/85">
-          {label}
-        </span>
+        <span className="shrink-0 rounded bg-black/5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-bp-gray-1 dark:bg-white/10 dark:text-white/85">{compactLabel(metric)}</span>
 
-        <div className="h-2 min-w-2 flex-1 overflow-hidden rounded-full bg-bp-light-gray-2 dark:bg-bp-dark-gray-4">
-          {window.active && known && (
-            <div
-              className="h-full rounded-full"
-              style={{
-                backgroundColor: meterColor(window.pct),
-                width: `${Math.max(animatedPct, 2)}%`
-              }}
-            />
-          )}
-        </div>
-
-        {!known ? (
-          <span className="shrink-0 text-[11px] tabular-nums text-bp-gray-1 dark:text-bp-gray-4">— · {formatTokens(window.tokens)} tokens</span>
-        ) : window.active ? (
-          <>
-            <span
-              className="w-10 shrink-0 text-right text-sm font-semibold tabular-nums text-bp-dark-gray-1 dark:text-bp-light-gray-5"
-              style={{ color: meterColor(window.pct) }}
-            >
-              {Math.round(animatedPct)}%
-            </span>
-
-            <span className="flex shrink-0 items-center gap-1 text-xs tabular-nums text-bp-gray-1 dark:text-bp-gray-4">
-              <Icon
-                className="opacity-60"
-                icon="time"
-                size={11}
-              />
-
-              <ResetCountdown ms={window.resetsAt - now} />
-            </span>
-          </>
+        {pct === undefined ? (
+          <span className="min-w-0 flex-1 truncate text-[11px] text-bp-gray-1 dark:text-bp-gray-4">Quota unavailable{metric.tokens === undefined ? '' : ` · ${formatTokens(metric.tokens)}`}</span>
         ) : (
-          <span className="w-10 shrink-0 text-right text-xs italic text-bp-gray-2 dark:text-bp-gray-3">idle</span>
+          <>
+            <div className="h-2 min-w-2 flex-1 overflow-hidden rounded-full bg-bp-light-gray-2 dark:bg-bp-dark-gray-4">
+              <div className="h-full rounded-full"
+                style={{ backgroundColor: color, width: `${Math.max(animatedPct, 2)}%` }}
+              />
+            </div>
+
+            <span className="w-10 shrink-0 text-right text-sm font-semibold tabular-nums"
+              style={{ color }}
+            >{Math.round(animatedPct)}%</span>
+
+            {metric.resetsAt && <span className="flex shrink-0 items-center gap-1 text-xs tabular-nums text-bp-gray-1 dark:text-bp-gray-4"><Icon className="opacity-60"
+              icon="time"
+              size={11}
+                                                                                                                                           />{formatCountdown(metric.resetsAt - now)}</span>}
+          </>
         )}
+      </button>
+    </Popover>
+  );
+};
+
+const money = (micros: number) => new Intl.NumberFormat(undefined, { currency: 'USD', style: 'currency' }).format(micros / 1_000_000);
+
+export const SpendMeter = ({ spend }: { spend: AIUsageSpend }) => {
+  const percent = spend.limitUsdMicros && spend.limitUsdMicros > 0 ? Math.min(1, spend.amountUsdMicros / spend.limitUsdMicros) : undefined;
+  const text = `${money(spend.amountUsdMicros)}${spend.limitUsdMicros ? ` of ${money(spend.limitUsdMicros)}` : ''}`;
+  const period = spend.period === 'calendar-month' ? 'Current calendar month' : 'Current billing cycle';
+  return (
+    <Popover content={(
+      <div className="w-[260px] p-4 text-sm">
+        <div className="font-semibold">{spend.label}</div>
+        <div className="mt-1 text-xs text-bp-gray-2">{scopeLabel(spend.scope)} · {period}</div>
+        <div className="mt-3 text-lg font-bold tabular-nums">{text}</div>
+
+        {percent !== undefined && (
+          <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-bp-light-gray-2 dark:bg-bp-dark-gray-4">
+            <div className="h-full rounded-full bg-green-500"
+              style={{ width: `${Math.max(2, percent * 100)}%` }}
+            />
+          </div>
+        )}
+
+        {spend.qualifier && <div className="mt-2 text-xs text-bp-gray-2">{spend.qualifier}</div>}
+      </div>
+    )}
+      interactionKind="hover"
+      minimal
+      placement="top"
+    >
+      <button aria-label={`${spend.label}: ${text}`}
+        className="inline-flex w-auto shrink-0 items-center gap-2 rounded text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+        type="button"
+      >
+        <span className="shrink-0 rounded bg-black/5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-bp-gray-1 dark:bg-white/10 dark:text-white/85">USD</span>
+        <span className="shrink-0 text-xs tabular-nums">{text}</span>
       </button>
     </Popover>
   );

--- a/src/renderer/components/Project/components/CheckoutCard/CheckoutCard.tsx
+++ b/src/renderer/components/Project/components/CheckoutCard/CheckoutCard.tsx
@@ -187,28 +187,32 @@ export const CheckoutCard: FC<Props> = ({
     >
       {pull && (
         <PullRequest
+          isRoot={isMain}
           onHide={onHidePull}
-          projectId={project.id}
+          onRefresh={onRefresh}
+          project={project}
           pull={pull.pull}
+          stickyTop={isMain ? 55 : solo ? 45 : 100}
           tags={pull.tags}
         />
       )}
 
-      {/* Main carries the whole repo's traffic, so it gets the configured cap;
-          a worktree only ever shows its own branch and keeps the default. */}
-      <GroupRuns
-        footer={footer}
-        isRoot={isMain}
-        limit={isMain ? count : undefined}
-        loadingOlder={loadingOlder}
-        moreHistory={moreHistory}
-        onLoadOlder={onLoadOlder}
-        onRefresh={onRefresh}
-        paged={!pull}
-        project={project}
-        runs={runs}
-        stickyTop={isMain ? 55 : 100}
-      />
+      {!pull && (
+        /* Main carries the whole repo's traffic, so it gets the configured cap;
+            a worktree only ever shows its own branch and keeps the default. */
+        <GroupRuns
+          footer={footer}
+          isRoot={isMain}
+          limit={isMain ? count : undefined}
+          loadingOlder={loadingOlder}
+          moreHistory={moreHistory}
+          onLoadOlder={onLoadOlder}
+          onRefresh={onRefresh}
+          project={project}
+          runs={runs}
+          stickyTop={isMain ? 55 : 100}
+        />
+      )}
     </div>
   );
 

--- a/src/renderer/components/Project/components/CheckoutCard/GroupRuns.tsx
+++ b/src/renderer/components/Project/components/CheckoutCard/GroupRuns.tsx
@@ -26,6 +26,9 @@ type Props = {
   paged?: boolean;
   project: Project;
   runs: Run[];
+  // PR checks need this fold even when the PR is shown on the root checkout.
+  // Root branch history does not: its finished runs stay reachable in History.
+  showDoneFold?: boolean;
   stickyTop?: number;
 };
 
@@ -42,6 +45,7 @@ export const GroupRuns: FC<Props> = ({
   paged = true,
   project,
   runs,
+  showDoneFold,
   stickyTop
 }) => {
   const [showDone, setShowDone] = useState(false);
@@ -49,6 +53,7 @@ export const GroupRuns: FC<Props> = ({
   const { gitHubActions } = useAppSettings();
   const { query } = useFilter();
   const { active, done, pinned } = splitDoneRuns(runs, gitHubActions.pinnedWorkflows);
+  const canShowDoneFold = showDoneFold ?? !isRoot;
 
   // How many runs a page of the active list holds. Loading more grows it a page
   // at a time, with no ceiling; hiding drops back to exactly one page.
@@ -102,7 +107,7 @@ export const GroupRuns: FC<Props> = ({
 
       {/* The root card omits the "Passing checks" fold — its finished runs are
           already reachable through History. Per-branch groups keep it. */}
-      {done.length > 0 && !isRoot && (
+      {done.length > 0 && canShowDoneFold && (
         <FoldChip
           icon="tick-circle"
           label="Passing checks"
@@ -139,7 +144,7 @@ export const GroupRuns: FC<Props> = ({
   const hasChips = Boolean(
     remainingActive > 0 ||
       shownActive.length > step ||
-      done.length > 0 ||
+      (done.length > 0 && canShowDoneFold) ||
       (paged && moreHistory && onLoadOlder) ||
       footer
   );

--- a/src/renderer/components/Project/components/PullRequest/PullRequest.checkRows.test.tsx
+++ b/src/renderer/components/Project/components/PullRequest/PullRequest.checkRows.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useAppSettings } from 'renderer/hooks/useAppSettings';
+import { __reset, getSnapshot, refresh } from 'renderer/services/poller/coordinator';
+import { type PRStatus, type Pull, type Run } from 'types/gitHub';
+import { type Project } from 'types/project';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('renderer/assets/gitHubStatusUtils', () => ({
+  getStatusIcon: () => () => <span data-testid="workflow-status" />
+}));
+
+import { PullRequest } from './PullRequest';
+
+const project = { filePath: '/repo', id: 'project-1', name: 'repo' } as Project;
+
+const pull = {
+  created_at: '2026-09-01T00:00:00Z',
+  draft: false,
+  head: { sha: 'exact-head-sha' },
+  html_url: 'https://github.com/example/repo/pull/42',
+  id: 42,
+  labels: [],
+  merged_at: null,
+  number: 42,
+  state: 'open',
+  title: 'Keep PR checks after the cache expires',
+  updated_at: '2026-09-12T00:00:00Z',
+  user: { avatar_url: 'https://example.com/avatar.png', login: 'octocat', type: 'User' }
+} as unknown as Pull;
+
+const oldSuccessfulRun = {
+  conclusion: 'success',
+  created_at: '2026-09-06T00:00:00Z',
+  display_title: 'Keep PR checks after the cache expires',
+  event: 'pull_request',
+  head_branch: 'feature/check-rows',
+  head_sha: 'exact-head-sha',
+  html_url: 'https://github.com/example/repo/actions/runs/9001',
+  id: 9001,
+  name: 'Services Unit Testing',
+  path: '.github/workflows/test.yml',
+  run_number: 12,
+  status: 'completed',
+  updated_at: '2026-09-06T00:03:00Z'
+} as Run;
+
+const activeRun = {
+  ...oldSuccessfulRun,
+  conclusion: null,
+  id: 9002,
+  name: 'Current Head Build',
+  status: 'in_progress'
+} as Run;
+
+const status = (overrides: Partial<PRStatus> = {}): PRStatus => ({
+  allowedMergeMethods: ['merge'],
+  autoMergeAllowed: false,
+  autoMergeEnabled: false,
+  behind: false,
+  checks: Array.from({ length: 28 }, (_, id) => ({
+    conclusion: id < 23 ? 'success' : 'failure',
+    id,
+    name: `check-${id}`,
+    status: 'completed'
+  })),
+  mergeable: false,
+  mergeableState: 'blocked',
+  review: { approvedBy: [], changesRequestedBy: [], reviewers: [], state: null },
+  success: true,
+  unresolvedComments: 0,
+  unresolvedThreads: [],
+  workflowRuns: [oldSuccessfulRun],
+  ...overrides
+});
+
+describe('PullRequest workflow rows', () => {
+  beforeEach(() => {
+    __reset();
+    useAppSettings.setState((current) => ({
+      gitHubActions: { ...current.gitHubActions, ignoredWorkflows: [] }
+    }));
+    vi.mocked(window.bridge.gitAPI.getPRChecks).mockResolvedValue(status());
+  });
+
+  afterEach(() => {
+    __reset();
+    vi.clearAllMocks();
+  });
+
+  it('shows an old exact-head passing workflow when the repo run cache is empty', async () => {
+    render(
+      <PullRequest
+        isRoot
+        onRefresh={vi.fn()}
+        project={project}
+        pull={pull}
+        stickyTop={55}
+      />
+    );
+
+    expect(await screen.findByText('23/28')).toBeTruthy();
+    const fold = await screen.findByText('Passing checks');
+    fireEvent.click(fold);
+    expect(await screen.findByText('Services Unit Testing', { exact: false })).toBeTruthy();
+  });
+
+  it('uses a separate status cache for each PR head SHA', async () => {
+    const { rerender } = render(
+      <PullRequest isRoot
+        onRefresh={vi.fn()}
+        project={project}
+        pull={pull}
+        stickyTop={55}
+      />
+    );
+
+    await waitFor(() => expect(window.bridge.gitAPI.getPRChecks).toHaveBeenCalledTimes(1));
+    expect(getSnapshot<PRStatus>('prChecks:project-1:42:exact-head-sha')).toBeTruthy();
+
+    const nextPull = { ...pull, head: { sha: 'next-head-sha' } } as Pull;
+    rerender(<PullRequest isRoot
+      onRefresh={vi.fn()}
+      project={project}
+      pull={nextPull}
+      stickyTop={55}
+             />);
+
+    await waitFor(() => expect(window.bridge.gitAPI.getPRChecks).toHaveBeenCalledTimes(2));
+    expect(getSnapshot<PRStatus>('prChecks:project-1:42:next-head-sha')).toBeTruthy();
+  });
+
+  it('keeps the last good status when a later bridge read fails', async () => {
+    vi.mocked(window.bridge.gitAPI.getPRChecks)
+      .mockResolvedValueOnce(status({ workflowRuns: [activeRun] }))
+      .mockResolvedValue({ message: 'GitHub is unavailable', success: false });
+
+    render(<PullRequest isRoot
+      onRefresh={vi.fn()}
+      project={project}
+      pull={pull}
+      stickyTop={55}
+           />);
+    expect(await screen.findByText('Current Head Build', { exact: false })).toBeTruthy();
+
+    refresh('prChecks:project-1:42:exact-head-sha');
+    await waitFor(() => expect(window.bridge.gitAPI.getPRChecks).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Current Head Build', { exact: false })).toBeTruthy();
+  });
+
+  it('hides an exact-head row when its workflow is hidden on pull requests', async () => {
+    useAppSettings.setState((current) => ({
+      gitHubActions: {
+        ...current.gitHubActions,
+        ignoredWorkflows: [{ path: activeRun.path, scopes: ['pr'] }]
+      }
+    }));
+    vi.mocked(window.bridge.gitAPI.getPRChecks).mockResolvedValue(status({ workflowRuns: [activeRun] }));
+
+    render(<PullRequest isRoot
+      onRefresh={vi.fn()}
+      project={project}
+      pull={pull}
+      stickyTop={55}
+           />);
+
+    await waitFor(() => expect(window.bridge.gitAPI.getPRChecks).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText('Current Head Build', { exact: false })).toBeNull();
+  });
+
+  it('keeps a PR row when the workflow is hidden only on worktrees', async () => {
+    useAppSettings.setState((current) => ({
+      gitHubActions: {
+        ...current.gitHubActions,
+        ignoredWorkflows: [{ path: activeRun.path, scopes: ['worktree'] }]
+      }
+    }));
+    vi.mocked(window.bridge.gitAPI.getPRChecks).mockResolvedValue(status({ workflowRuns: [activeRun] }));
+
+    render(<PullRequest isRoot={false}
+      onRefresh={vi.fn()}
+      project={project}
+      pull={pull}
+      stickyTop={55}
+           />);
+
+    expect(await screen.findByText('Current Head Build', { exact: false })).toBeTruthy();
+  });
+});

--- a/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
+++ b/src/renderer/components/Project/components/PullRequest/PullRequest.tsx
@@ -1,53 +1,31 @@
 import { Button, ButtonGroup, Icon, Menu, MenuDivider, MenuItem, Popover, Tooltip } from '@blueprintjs/core';
-import { type FC, useCallback, useEffect, useState } from 'react';
+import { type FC, useEffect, useMemo, useRef, useState } from 'react';
 import { FaCopy, FaRegCopy } from 'react-icons/fa';
-import { useIsSunset } from 'renderer/hooks/useAppSettings';
+import { useAppSettings, useIsSunset } from 'renderer/hooks/useAppSettings';
 import { mutate, refresh, usePoll } from 'renderer/services/poller';
 import { appToaster } from 'renderer/utils/appToaster';
 import { cn } from 'renderer/utils/cn';
+import { isWorkflowHidden, parseIgnored } from 'renderer/utils/ignoredWorkflows';
 import { timeAgo } from 'renderer/utils/timeAgo';
-import { type Pull } from 'types/gitHub';
+import { type MergeMethod, type PRCheck, type PRReviewer, type PRStatus, type Pull } from 'types/gitHub';
+import { type Project } from 'types/project';
 
+import { GroupRuns } from '../CheckoutCard/GroupRuns';
 import { LabelStrip } from './LabelStrip';
-
-type Check = {
-  conclusion: null | string;
-  id: number;
-  name: string;
-  status: string;
-};
-
-type ChecksResult = Awaited<ReturnType<typeof window.bridge.gitAPI.getPRChecks>>;
-type MergeMethod = 'merge' | 'rebase' | 'squash';
+import { getPullRequestActionState } from './pullRequestActionState';
 
 type MutationResult = { message?: string; success: boolean };
-
+type PendingAction = 'auto-merge' | 'merge' | 'update';
 type Props = {
+  // This may be the root checkout. Keep that scope for a workflow's hide menu,
+  // even though PR checks always show their own Passing checks fold.
+  isRoot: boolean;
   onHide?: (pullId: number, label: string) => void;
-  projectId: string;
+  onRefresh: () => void;
+  project: Project;
   pull: Pull;
+  stickyTop: number;
   tags?: string[];
-};
-
-type Review = {
-  approvedBy: string[];
-  changesRequestedBy: string[];
-  reviewers: Reviewer[];
-  state: 'approved' | 'changes_requested' | null;
-};
-
-type Reviewer = {
-  avatarUrl: string;
-  login: string;
-  reReviewRequested: boolean;
-  state: 'approved' | 'changes_requested' | 'commented' | 'pending';
-};
-
-type UnresolvedThread = {
-  avatarUrl: string;
-  count: number;
-  login: string;
-  path: null | string;
 };
 
 const mergeMenuLabel: Record<MergeMethod, string> = {
@@ -62,7 +40,7 @@ const autoMergeMenuLabel: Record<MergeMethod, string> = {
   squash: 'Enable auto-merge (squash)'
 };
 
-const reviewerStatus = (r: Reviewer): { color: string; icon: 'chat' | 'cross' | 'dot' | 'tick'; label: string } => {
+const reviewerStatus = (r: PRReviewer): { color: string; icon: 'chat' | 'cross' | 'dot' | 'tick'; label: string } => {
   // Icons mirror GitHub's Reviewers panel 1:1: bare green check for approved,
   // red cross for changes requested, a comment bubble for a commented review,
   // and a faint dot for an awaiting/requested reviewer.
@@ -80,7 +58,7 @@ const cleanApiError = (message?: string, fallback = 'Something went wrong') => {
   return clean.length > 0 ? clean.charAt(0).toUpperCase() + clean.slice(1) : fallback;
 };
 
-const getChecksSummary = (checks: Check[]) => {
+const getChecksSummary = (checks: PRCheck[]) => {
   if (checks.length === 0) return null;
 
   const success = checks.filter((c) => c.conclusion === 'success').length;
@@ -90,21 +68,13 @@ const getChecksSummary = (checks: Check[]) => {
   return { failed, pending, success, total: checks.length };
 };
 
-export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) => {
+export const PullRequest: FC<Props> = ({ isRoot, onHide, onRefresh, project, pull, stickyTop, tags = [] }) => {
   const { created_at, draft, html_url, labels, merged_at, number, state, title, user } = pull;
   const isSunset = useIsSunset();
-  const [checks, setChecks] = useState<Check[]>([]);
-  const [review, setReview] = useState<null | Review>(null);
-  const [behind, setBehind] = useState(false);
-  const [updating, setUpdating] = useState(false);
-  const [mergeableState, setMergeableState] = useState<string>('unknown');
-  const [merging, setMerging] = useState(false);
+  const ignoredWorkflows = useAppSettings((settings) => settings.gitHubActions.ignoredWorkflows);
+  const [pendingAction, setPendingAction] = useState<null | PendingAction>(null);
+  const pendingActionRef = useRef(false);
   const [conflictFiles, setConflictFiles] = useState<null | string[]>(null);
-  const [unresolvedComments, setUnresolvedComments] = useState(0);
-  const [unresolvedThreads, setUnresolvedThreads] = useState<UnresolvedThread[]>([]);
-  const [autoMergeAllowed, setAutoMergeAllowed] = useState(false);
-  const [autoMergeEnabled, setAutoMergeEnabled] = useState(false);
-  const [allowedMergeMethods, setAllowedMergeMethods] = useState<MergeMethod[]>([]);
   // Set the instant a merge succeeds so the action buttons clear immediately,
   // without waiting for the parent list to re-poll and hand down a merged pull.
   const [justMerged, setJustMerged] = useState(false);
@@ -112,57 +82,49 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
 
   const isMerged = Boolean(merged_at) || justMerged;
   const isClosed = !isMerged && state === 'closed';
-  const totalUnresolvedComments = unresolvedThreads.reduce((sum, t) => sum + t.count, 0);
-
-  const applyChecks = useCallback((res: ChecksResult) => {
-    if (!res.success) return;
-    if (res.checks) setChecks(res.checks);
-    if (res.review) setReview(res.review);
-    setBehind(Boolean(res.behind));
-    setMergeableState(res.mergeableState ?? 'unknown');
-    setUnresolvedComments(res.unresolvedComments ?? 0);
-    setUnresolvedThreads(res.unresolvedThreads ?? []);
-    setAutoMergeAllowed(Boolean(res.autoMergeAllowed));
-    setAutoMergeEnabled(Boolean(res.autoMergeEnabled));
-    setAllowedMergeMethods(res.allowedMergeMethods ?? []);
-  }, []);
 
   // One shared-coordinator poll per PR, keyed so every subscriber (this card,
   // any other view of the same PR) shares one cache entry and one fetch. The
   // coordinator owns the timer, pause-when-hidden/offline, refetch-on-focus,
   // in-flight dedupe and error backoff — no local setInterval / refresh-event
   // listener needed here.
-  const pollKey = `prChecks:${projectId}:${number}`;
+  const pollKey = `prChecks:${project.id}:${number}:${pull.head?.sha ?? 'unknown'}`;
 
-  const { data: checksData } = usePoll<ChecksResult>({
-    fetch: () => window.bridge.gitAPI.getPRChecks(projectId, number),
+  const { data: checksData } = usePoll<PRStatus>({
+    fetch: async () => {
+      const result = await window.bridge.gitAPI.getPRChecks(project.id, number);
+      // The bridge reports API errors as resolved `{ success: false }` values.
+      // Turn them into poll errors so the coordinator keeps its last good data.
+      if (!result.success) throw new Error(result.message);
+      return result;
+    },
     // Poll hot (every 8s) while anything is still in flux — a check not done,
     // GitHub still computing mergeable state, or the branch behind base — and
     // back off to once a minute once everything has settled.
     interval: (data) => {
-      if (!data || !data.success) return 8000;
-      const checksInFlux = (data.checks ?? []).some((c: Check) => c.status !== 'completed');
-      const inFlux = checksInFlux || data.mergeableState === 'unknown' || data.behind === true;
+      if (!data) return 8000;
+      const checksInFlux = data.checks.some((c) => c.status !== 'completed');
+      const inFlux = checksInFlux || data.mergeableState === 'unknown' || data.behind;
       return inFlux ? 8000 : 60000;
     },
     key: pollKey
   });
 
   useEffect(() => {
-    if (!checksData) return;
-    applyChecks(checksData);
-    // Clear the "Update branch" spinner only on a real read that reports the
-    // branch caught up — never on a stale one, and never by giving up.
-    if (checksData.success && !checksData.behind) setUpdating(false);
-  }, [applyChecks, checksData]);
+    // Clear the Update spinner only on a real read that reports the branch
+    // caught up. This keeps operation state separate from server state.
+    if (checksData?.success && !checksData.behind && pendingAction === 'update') {
+      pendingActionRef.current = false;
+      setPendingAction(null);
+    }
+  }, [checksData, pendingAction]);
 
-  // A new head commit or updated_at means GitHub has fresh PR data even though
-  // the poll key itself hasn't changed — re-heat this key now instead of
-  // waiting out the adaptive interval.
+  // A new head SHA gets a new cache key. A metadata-only update keeps the same
+  // key, so re-heat it instead of waiting out the adaptive interval.
   useEffect(() => {
     refresh(pollKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pull.head?.sha, pull.updated_at]);
+  }, [pull.updated_at]);
 
   const openInBrowser = () => {
     window.open(html_url, '_blank');
@@ -176,26 +138,38 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
     navigator.clipboard.writeText(html_url);
   };
 
+  const startAction = (action: PendingAction) => {
+    if (pendingActionRef.current) return false;
+    pendingActionRef.current = true;
+    setPendingAction(action);
+    return true;
+  };
+
+  const finishAction = () => {
+    pendingActionRef.current = false;
+    setPendingAction(null);
+  };
+
   const updateBranch = async (method: 'merge' | 'rebase' = 'merge') => {
-    setUpdating(true);
+    if (!startAction('update')) return;
     // mutate() runs the bridge call, then hot re-polls prChecks (now, +800ms,
     // +1500ms); the adaptive interval above keeps polling every 8s for as long
     // as GitHub still reports "behind" (its recompute is asynchronous), so this
     // settles on its own without a hand-rolled retry loop. The spinner clears
     // in the poll-apply effect above, only on a real "not behind" read.
-    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.updateBranch(projectId, number, method));
+    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.updateBranch(project.id, number, method));
     const toaster = await appToaster;
     if (!res.success) {
       toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to update branch'), timeout: 0 });
-      setUpdating(false);
+      finishAction();
       return;
     }
     toaster.show({ icon: 'git-merge', intent: 'success', message: `Updated #${number} with the base branch` });
   };
 
-  const mergePR = async (method: 'merge' | 'rebase' | 'squash') => {
-    setMerging(true);
-    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.mergePR(projectId, number, method));
+  const mergePR = async (method: MergeMethod) => {
+    if (!startAction('merge')) return;
+    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.mergePR(project.id, number, method));
     const toaster = await appToaster;
     if (res.success) {
       toaster.show({ icon: 'git-merge', intent: 'success', message: `Merged #${number}` });
@@ -203,48 +177,53 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
     } else {
       toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to merge'), timeout: 0 });
     }
-    setMerging(false);
+    finishAction();
   };
 
-  const enableAutoMerge = async (method: 'merge' | 'rebase' | 'squash') => {
-    setMerging(true);
-    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.enableAutoMerge(projectId, number, method));
+  const enableAutoMerge = async (method: MergeMethod) => {
+    if (!startAction('auto-merge')) return;
+    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.enableAutoMerge(project.id, number, method));
     const toaster = await appToaster;
     if (res.success) {
       toaster.show({ icon: 'automatic-updates', intent: 'success', message: `Auto-merge enabled for #${number}` });
-      setAutoMergeEnabled(true);
     } else {
       toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to enable auto-merge'), timeout: 0 });
     }
-    setMerging(false);
+    finishAction();
   };
 
   const disableAutoMerge = async () => {
-    setMerging(true);
-    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.disableAutoMerge(projectId, number));
+    if (!startAction('auto-merge')) return;
+    const res = await mutate<MutationResult>(pollKey, () => window.bridge.gitAPI.disableAutoMerge(project.id, number));
     const toaster = await appToaster;
     if (res.success) {
       toaster.show({ icon: 'automatic-updates', intent: 'success', message: `Auto-merge disabled for #${number}` });
-      setAutoMergeEnabled(false);
     } else {
       toaster.show({ icon: 'warning-sign', intent: 'warning', message: cleanApiError(res.message, 'Failed to disable auto-merge'), timeout: 0 });
     }
-    setMerging(false);
+    finishAction();
   };
 
-  // Only surface Merge when GitHub itself would allow it — an allow-list, not a
-  // block-list, so ambiguous states never show a button that can't work:
-  //   clean       — mergeable, all requirements met
-  //   unstable    — mergeable, but non-required checks are failing/pending
-  //   has_hooks   — mergeable, with pre-receive hooks
-  // Everything else hides it: 'blocked' (review/checks required), 'dirty'
-  // (conflicts), 'behind' (up-to-date IS required here), 'draft', and 'unknown'
-  // (GitHub still computing — show nothing rather than a button that would fail).
-  // Note: a branch can be behind base yet still 'clean' (up-to-date not
-  // required) — that PR is mergeable, so Merge shows alongside Update branch.
   const isOpen = !isMerged && !isClosed && !draft;
-  const canMerge = isOpen && ['clean', 'has_hooks', 'unstable'].includes(mergeableState);
-  const hasConflicts = isOpen && mergeableState === 'dirty';
+  const status = checksData;
+  const checks = status?.checks ?? [];
+  const review = status?.review ?? null;
+  const behind = status?.behind ?? false;
+  const unresolvedComments = status?.unresolvedComments ?? 0;
+  const unresolvedThreads = status?.unresolvedThreads ?? [];
+  const totalUnresolvedComments = unresolvedThreads.reduce((sum, t) => sum + t.count, 0);
+  const autoMergeAllowed = status?.autoMergeAllowed ?? false;
+  const autoMergeEnabled = status?.autoMergeEnabled ?? false;
+  const allowedMergeMethods = status?.allowedMergeMethods ?? [];
+  const actionState = getPullRequestActionState({
+    autoMergeEnabled,
+    behind,
+    isOpen,
+    mergeableState: status?.mergeableState ?? 'unknown'
+  });
+  const isMerging = pendingAction === 'merge';
+  const isUpdating = pendingAction === 'update';
+  const isActionPending = pendingAction !== null;
 
   // Only the merge methods this repo enables (GitHub's own order). Fall back to
   // all three if the repo settings could not be read, so the buttons still work.
@@ -256,11 +235,17 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
   const loadConflicts = async () => {
     if (conflictFiles !== null) return;
     setConflictFiles([]);
-    const res = await window.bridge.gitAPI.getConflictFiles(projectId, number);
+    const res = await window.bridge.gitAPI.getConflictFiles(project.id, number);
     if (res.success && res.files) setConflictFiles(res.files);
   };
 
   const summary = getChecksSummary(checks);
+  const visibleWorkflowRuns = useMemo(() => {
+    const ignored = parseIgnored(ignoredWorkflows);
+    return (status?.workflowRuns ?? []).filter(
+      (run) => !isWorkflowHidden(ignored, { isPr: true, isRoot, path: run.path })
+    );
+  }, [ignoredWorkflows, isRoot, status?.workflowRuns]);
 
   // GitHub-style Reviewers panel: every reviewer with their avatar and current
   // status icon (approved / requested changes / commented / awaiting).
@@ -572,41 +557,43 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
             green/red status pills, while blue keeps it read as "sync the base in"
             rather than competing with the primary green merge. Primary merges the
             base in; the caret offers merge vs rebase. Shown only when behind. */}
-          {behind && isOpen && !hasConflicts && (
-            <div className={cn('flex shrink-0 rounded-md overflow-hidden border border-[#0969da]/35 dark:border-[#4493f8]/35', updating && 'opacity-60')}>
+          {actionState.update && (
+            <div className={cn('flex shrink-0 rounded-md overflow-hidden border border-[#0969da]/35 dark:border-[#4493f8]/35', isActionPending && 'opacity-60')}>
               <button
                 className="flex items-center gap-1.5 h-[30px] pl-2.5 pr-3 text-[12px] font-medium text-[#0969da] dark:text-[#4493f8] bg-[#0969da]/10 hover:bg-[#0969da]/[0.18] active:bg-[#0969da]/25 transition-colors disabled:cursor-not-allowed"
-                disabled={updating}
+                disabled={isActionPending}
                 onClick={() => updateBranch('merge')}
                 type="button"
               >
-                <Icon icon={updating ? 'refresh' : 'git-merge'}
+                <Icon icon={isUpdating ? 'refresh' : 'git-merge'}
                   size={13}
                 />
 
-                {updating ? 'Updating…' : 'Update branch'}
+                {isUpdating ? 'Updating…' : 'Update branch'}
               </button>
 
               <Popover
                 content={
                   <Menu>
-                    <MenuItem icon="git-merge"
+                    <MenuItem disabled={isActionPending}
+                      icon="git-merge"
                       onClick={() => updateBranch('merge')}
                       text="Update with merge commit"
                     />
 
-                    <MenuItem icon="git-branch"
+                    <MenuItem disabled={isActionPending}
+                      icon="git-branch"
                       onClick={() => updateBranch('rebase')}
                       text="Update with rebase"
                     />
                   </Menu>
               }
-                disabled={updating}
+                disabled={isActionPending}
                 placement="bottom-end"
               >
                 <button aria-label="Update branch options"
                   className="flex items-center h-[30px] px-1.5 text-[#0969da] dark:text-[#4493f8] bg-[#0969da]/10 hover:bg-[#0969da]/[0.18] active:bg-[#0969da]/25 transition-colors border-l border-[#0969da]/35 dark:border-[#4493f8]/35 disabled:cursor-not-allowed"
-                  disabled={updating}
+                  disabled={isActionPending}
                   type="button"
                 >
                   <Icon icon="caret-down"
@@ -620,19 +607,19 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
           {/* GitHub-style green "Merge" split button: primary squash-merges; the
             caret offers merge commit / squash / rebase. Shown only when the PR
             is actually mergeable — no greyed-out placeholder. */}
-          {canMerge && (
-            <div className={cn('flex shrink-0 rounded-md overflow-hidden', merging && 'opacity-60')}>
+          {actionState.merge && (
+            <div className={cn('flex shrink-0 rounded-md overflow-hidden', isActionPending && 'opacity-60')}>
               <button
                 className="flex items-center gap-1.5 h-[30px] pl-2.5 pr-3 text-[12px] font-semibold text-white bg-[#1f883d] hover:bg-[#2ea043] active:bg-[#1a7f37] transition-colors disabled:cursor-not-allowed"
-                disabled={merging}
+                disabled={isActionPending}
                 onClick={() => mergePR(primaryMethod)}
                 type="button"
               >
-                <Icon icon={merging ? 'refresh' : 'git-merge'}
+                <Icon icon={isMerging ? 'refresh' : 'git-merge'}
                   size={13}
                 />
 
-                {merging ? 'Merging…' : mergeMenuLabel[primaryMethod]}
+                {isMerging ? 'Merging…' : mergeMenuLabel[primaryMethod]}
               </button>
 
               {(mergeMethods.length > 1 || (autoMergeAllowed && !autoMergeEnabled)) && (
@@ -640,7 +627,8 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
                   content={
                     <Menu>
                       {mergeMethods.map((m) => (
-                        <MenuItem icon="git-merge"
+                        <MenuItem disabled={isActionPending}
+                          icon="git-merge"
                           key={m}
                           onClick={() => mergePR(m)}
                           text={mergeMenuLabel[m]}
@@ -652,7 +640,8 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
                           <MenuDivider />
 
                           {mergeMethods.map((m) => (
-                            <MenuItem icon="automatic-updates"
+                            <MenuItem disabled={isActionPending}
+                              icon="automatic-updates"
                               key={`auto-${m}`}
                               onClick={() => enableAutoMerge(m)}
                               text={autoMergeMenuLabel[m]}
@@ -662,11 +651,11 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
                     )}
                     </Menu>
                 }
-                  disabled={merging}
+                  disabled={isActionPending}
                   placement="bottom-end"
                 >
                   <button className="flex items-center h-[30px] px-1.5 text-white bg-[#1f883d] hover:bg-[#2ea043] active:bg-[#1a7f37] transition-colors border-l border-black/20 disabled:cursor-not-allowed"
-                    disabled={merging}
+                    disabled={isActionPending}
                     type="button"
                   >
                     <Icon icon="caret-down"
@@ -679,16 +668,18 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
         )}
 
           {/* Auto-merge is armed: show its state with a one-click disable. */}
-          {isOpen && autoMergeEnabled && (
+          {actionState.autoMerge && (
             <Popover
               content={
                 <Menu>
-                  <MenuItem icon="disable"
+                  <MenuItem disabled={isActionPending}
+                    icon="disable"
                     onClick={disableAutoMerge}
                     text="Disable auto-merge"
                   />
                 </Menu>
             }
+              disabled={isActionPending}
               placement="bottom-end"
             >
               <div className="flex items-center gap-1.5 h-[30px] px-3 rounded-md text-[12px] font-medium text-[#3fb950] bg-[#3fb950]/10 border border-[#3fb950]/35 cursor-pointer shrink-0">
@@ -703,7 +694,7 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
           {/* Conflicts: GitHub shows an unclickable "Resolve conflicts" button —
             conflicts can only be fixed on the command line. Hovering lists the
             conflicting files (computed locally on demand). */}
-          {hasConflicts && (
+          {actionState.conflicts && (
             <Popover
               content={
                 <div className="min-w-[240px] px-3.5 py-3">
@@ -752,6 +743,16 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
             </Popover>
         )}
 
+          {(actionState.recomputing || actionState.blocked) && (
+            <div className="flex items-center gap-1.5 h-[30px] px-3 rounded-md text-[12px] font-medium text-bp-gray-1 dark:text-bp-gray-4 bg-bp-light-gray-3 dark:bg-bp-dark-gray-3 border border-bp-gray-3 dark:border-bp-gray-2 shrink-0">
+              <Icon icon={actionState.recomputing ? 'refresh' : 'lock'}
+                size={13}
+              />
+
+              {actionState.recomputing ? 'Checking merge…' : 'Merge blocked'}
+            </div>
+          )}
+
           <ButtonGroup>
             <Tooltip compact
               content="Copy pull request link"
@@ -782,10 +783,11 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
                 <Menu>
                   {/* Auto-merge lives here rather than as an always-on button —
                     it is a "set and forget" action, not a primary one. */}
-                  {isOpen && !hasConflicts && autoMergeAllowed && !autoMergeEnabled && (
+                  {isOpen && !actionState.conflicts && autoMergeAllowed && !autoMergeEnabled && (
                     <>
                       {mergeMethods.map((m) => (
-                        <MenuItem icon="automatic-updates"
+                        <MenuItem disabled={isActionPending}
+                          icon="automatic-updates"
                           key={`auto-${m}`}
                           onClick={() => enableAutoMerge(m)}
                           text={autoMergeMenuLabel[m]}
@@ -798,7 +800,8 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
 
                   {isOpen && autoMergeEnabled && (
                     <>
-                      <MenuItem icon="disable"
+                      <MenuItem disabled={isActionPending}
+                        icon="disable"
                         onClick={disableAutoMerge}
                         text="Disable auto-merge"
                       />
@@ -825,6 +828,16 @@ export const PullRequest: FC<Props> = ({ onHide, projectId, pull, tags = [] }) =
           </ButtonGroup>
         </div>
       </div>
+
+      <GroupRuns
+        isRoot={isRoot}
+        onRefresh={onRefresh}
+        paged={false}
+        project={project}
+        runs={visibleWorkflowRuns}
+        showDoneFold
+        stickyTop={stickyTop}
+      />
     </div>
   );
 };

--- a/src/renderer/components/Project/components/PullRequest/PullRequest.updateBranch.test.tsx
+++ b/src/renderer/components/Project/components/PullRequest/PullRequest.updateBranch.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { __reset } from 'renderer/services/poller/coordinator';
-import { type Pull } from 'types/gitHub';
+import { type PRStatus, type Pull } from 'types/gitHub';
+import { type Project } from 'types/project';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PullRequest } from './PullRequest';
@@ -21,17 +22,23 @@ const basePull = {
   user: { avatar_url: 'https://example.com/avatar.png', login: 'octocat', type: 'User' }
 } as unknown as Pull;
 
-const checksResponse = (behind: boolean) => ({
+const project = { id: 'project-1' } as Project;
+
+type ChecksResponseOptions = Partial<Pick<PRStatus, 'behind' | 'checks'>> & Pick<PRStatus, 'mergeableState'>;
+
+const checksResponse = ({ behind = false, checks = [], mergeableState }: ChecksResponseOptions): PRStatus => ({
   allowedMergeMethods: ['merge'],
   autoMergeAllowed: false,
   autoMergeEnabled: false,
   behind,
-  checks: [],
-  mergeableState: 'clean',
-  review: null,
+  checks,
+  mergeable: mergeableState === 'clean',
+  mergeableState,
+  review: { approvedBy: [], changesRequestedBy: [], reviewers: [], state: null },
   success: true,
   unresolvedComments: 0,
-  unresolvedThreads: []
+  unresolvedThreads: [],
+  workflowRuns: []
 });
 
 // The whole "Update branch" split button (including this caret) is gated on
@@ -51,53 +58,73 @@ describe('PullRequest "Update branch" button', () => {
     vi.clearAllMocks();
   });
 
-  it('clears the button once GitHub settles, polling past the stale post-update read that still reports behind', async () => {
-    // Mount sees behind: true. The update succeeds, but GitHub's first recompute
-    // still says behind (eventual consistency); the coordinator's hot re-poll
-    // burst (mutate) keeps reading until one reports it caught up.
+  it('moves from Update branch through blocked checks and restores Merge', async () => {
+    // The update succeeds. GitHub then reports completed branch sync but still
+    // has a pending check and a blocked merge state. A later read is clean.
     vi.mocked(window.bridge.gitAPI.getPRChecks)
-      .mockResolvedValueOnce(checksResponse(true)) // mount
-      .mockResolvedValueOnce(checksResponse(true)) // first re-poll: still stale
-      .mockResolvedValue(checksResponse(false)); // later polls: settled
+      .mockResolvedValueOnce(checksResponse({ behind: true, mergeableState: 'clean' })) // mount
+      .mockResolvedValueOnce(checksResponse({ checks: [{ conclusion: null, id: 1, name: 'CI', status: 'in_progress' }], mergeableState: 'blocked' }))
+      .mockResolvedValue(checksResponse({ mergeableState: 'clean' }));
     vi.mocked(window.bridge.gitAPI.updateBranch).mockResolvedValue({ success: true });
 
-    render(<PullRequest projectId="project-1"
+    render(<PullRequest isRoot={false}
+      onRefresh={vi.fn()}
+      project={project}
       pull={basePull}
+      stickyTop={55}
            />);
 
     expect(await screen.findByText('Update branch')).toBeTruthy();
 
     fireEvent.click(screen.getByText('Update branch'));
 
-    // Polls run behind the spinner; the affordance disappears only after a read
-    // actually reports the branch is no longer behind.
-    await waitFor(() => expect(caret()).toBeNull(), { timeout: 5000 });
-
-    // And it stays gone — no flicker back to "Update branch".
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await screen.findByText('Merge blocked', {}, { timeout: 5000 });
     expect(caret()).toBeNull();
+    await screen.findByText('Create a merge commit', {}, { timeout: 5000 });
+    expect(screen.queryByText('Merge blocked')).toBeNull();
 
     expect(window.bridge.gitAPI.updateBranch).toHaveBeenCalledWith('project-1', 1, 'merge');
-    // mount + at least two re-polls (the stale one, then the settled one).
+    // Mount plus the blocked and clean reads.
     expect(vi.mocked(window.bridge.gitAPI.getPRChecks).mock.calls.length).toBeGreaterThanOrEqual(3);
   });
 
-  it('keeps the button while GitHub still reports the branch behind, instead of falsely hiding it', async () => {
-    // GitHub never catches up. The button must NOT lie and hide — it stays
-    // until a real "not behind" read (or the next refresh).
-    vi.mocked(window.bridge.gitAPI.getPRChecks).mockResolvedValue(checksResponse(true));
-    vi.mocked(window.bridge.gitAPI.updateBranch).mockResolvedValue({ success: true });
+  it('shows Merge blocked for a stable blocked PR', async () => {
+    vi.mocked(window.bridge.gitAPI.getPRChecks).mockResolvedValue(checksResponse({ mergeableState: 'blocked' }));
 
-    render(<PullRequest projectId="project-1"
+    render(<PullRequest isRoot={false}
+      onRefresh={vi.fn()}
+      project={project}
       pull={basePull}
+      stickyTop={55}
            />);
 
-    expect(await screen.findByText('Update branch')).toBeTruthy();
-    fireEvent.click(screen.getByText('Update branch'));
+    expect(await screen.findByText('Merge blocked')).toBeTruthy();
+    expect(screen.queryByText('Update branch')).toBeNull();
+    expect(screen.queryByText('Create a merge commit')).toBeNull();
+  });
 
-    // Past the first re-poll (which still reports behind) the affordance is
-    // still present — a spinner, not a vanished button.
-    await new Promise((resolve) => setTimeout(resolve, 1200));
-    expect(caret()).not.toBeNull();
+  it('starts only one mutation while a merge is pending', async () => {
+    let resolveMerge: (result: { success: true }) => void;
+    const mergePending = new Promise<{ success: true }>((resolve) => { resolveMerge = resolve; });
+    vi.mocked(window.bridge.gitAPI.getPRChecks).mockResolvedValue(checksResponse({ mergeableState: 'clean' }));
+    vi.mocked(window.bridge.gitAPI.mergePR).mockReturnValue(mergePending);
+
+    render(<PullRequest isRoot={false}
+      onRefresh={vi.fn()}
+      project={project}
+      pull={basePull}
+      stickyTop={55}
+           />);
+
+    const mergeButton = await screen.findByText('Create a merge commit');
+    fireEvent.click(mergeButton);
+    fireEvent.click(mergeButton);
+
+    expect(window.bridge.gitAPI.mergePR).toHaveBeenCalledTimes(1);
+    expect(mergeButton.getAttribute('disabled')).not.toBeNull();
+    await act(async () => {
+      resolveMerge!({ success: true });
+      await mergePending;
+    });
   });
 });

--- a/src/renderer/components/Project/components/PullRequest/pullRequestActionState.test.ts
+++ b/src/renderer/components/Project/components/PullRequest/pullRequestActionState.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPullRequestActionState } from './pullRequestActionState';
+
+describe('getPullRequestActionState', () => {
+  const open = { autoMergeEnabled: false, behind: false, isOpen: true } as const;
+
+  it('shows Update branch while the PR is behind', () => {
+    expect(getPullRequestActionState({ ...open, behind: true, mergeableState: 'blocked' })).toMatchObject({
+      blocked: false,
+      update: true
+    });
+  });
+
+  it('shows Checking merge while GitHub recomputes mergeability', () => {
+    expect(getPullRequestActionState({ ...open, mergeableState: 'unknown' })).toMatchObject({
+      blocked: false,
+      recomputing: true
+    });
+  });
+
+  it('restores Merge when GitHub reports a clean PR', () => {
+    expect(getPullRequestActionState({ ...open, mergeableState: 'clean' })).toMatchObject({
+      blocked: false,
+      merge: true
+    });
+  });
+
+  it('keeps a stable blocked status for an open PR', () => {
+    expect(getPullRequestActionState({ ...open, mergeableState: 'blocked' })).toEqual({
+      autoMerge: false,
+      blocked: true,
+      conflicts: false,
+      merge: false,
+      recomputing: false,
+      update: false
+    });
+  });
+});

--- a/src/renderer/components/Project/components/PullRequest/pullRequestActionState.ts
+++ b/src/renderer/components/Project/components/PullRequest/pullRequestActionState.ts
@@ -1,0 +1,33 @@
+import { type MergeableState } from 'types/gitHub';
+
+type PullRequestActionState = {
+  autoMerge: boolean;
+  blocked: boolean;
+  conflicts: boolean;
+  merge: boolean;
+  recomputing: boolean;
+  update: boolean;
+};
+
+type PullRequestActionStateInput = {
+  autoMergeEnabled: boolean;
+  behind: boolean;
+  isOpen: boolean;
+  mergeableState: MergeableState;
+};
+
+export const getPullRequestActionState = ({
+  autoMergeEnabled,
+  behind,
+  isOpen,
+  mergeableState
+}: PullRequestActionStateInput): PullRequestActionState => {
+  const conflicts = isOpen && mergeableState === 'dirty';
+  const recomputing = isOpen && mergeableState === 'unknown';
+  const update = isOpen && behind && !conflicts;
+  const merge = isOpen && ['clean', 'has_hooks', 'unstable'].includes(mergeableState);
+  const autoMerge = isOpen && autoMergeEnabled;
+  const blocked = isOpen && !update && !merge && !conflicts && !recomputing && !autoMerge;
+
+  return { autoMerge, blocked, conflicts, merge, recomputing, update };
+};

--- a/src/renderer/components/Project/components/WorkflowActionAlert/WorkflowActionAlert.test.tsx
+++ b/src/renderer/components/Project/components/WorkflowActionAlert/WorkflowActionAlert.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { refresh } from 'renderer/services/poller';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('renderer/services/poller', () => ({ refresh: vi.fn() }));
+
+import { WorkflowActionAlert } from './WorkflowActionAlert';
+
+describe('WorkflowActionAlert', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refreshes PR status after a workflow rerun starts', async () => {
+    vi.mocked(window.bridge.gitAPI.rerunWorkflow).mockResolvedValue({ success: true });
+
+    render(
+      <WorkflowActionAlert
+        action="rerun"
+        darkMode={false}
+        isOpen
+        onClose={vi.fn()}
+        projectId="project-1"
+        runId={9001}
+        runName="Build"
+      />
+    );
+
+    fireEvent.click(screen.getByText('Re-run all'));
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledWith('prChecks:project-1:'));
+  });
+});

--- a/src/renderer/components/Project/components/WorkflowActionAlert/WorkflowActionAlert.tsx
+++ b/src/renderer/components/Project/components/WorkflowActionAlert/WorkflowActionAlert.tsx
@@ -1,6 +1,7 @@
 import { Alert, Classes } from '@blueprintjs/core';
 import { type IconName } from '@blueprintjs/icons';
 import { type FC, useState } from 'react';
+import { refresh } from 'renderer/services/poller';
 import { type ModalProps } from 'types/Modal';
 
 export type WorkflowAction = 'cancel' | 'rerun' | 'rerun-failed';
@@ -51,9 +52,11 @@ export const WorkflowActionAlert: FC<ModalProps & WorkflowActionAlertProps> = ({
       if (action === 'cancel') {
         await window.bridge.gitAPI.cancelRun(projectId, runId);
       } else if (action === 'rerun') {
-        await window.bridge.gitAPI.rerunWorkflow(projectId, runId);
+        const result = await window.bridge.gitAPI.rerunWorkflow(projectId, runId);
+        if (result.success) refresh(`prChecks:${projectId}:`);
       } else if (action === 'rerun-failed') {
-        await window.bridge.gitAPI.rerunFailedJobs(projectId, runId);
+        const result = await window.bridge.gitAPI.rerunFailedJobs(projectId, runId);
+        if (result.success) refresh(`prChecks:${projectId}:`);
       }
     } finally {
       setLoading(false);

--- a/src/renderer/components/Project/hooks/useRepoData/groupByBranch.test.ts
+++ b/src/renderer/components/Project/hooks/useRepoData/groupByBranch.test.ts
@@ -326,7 +326,7 @@ describe('orphanRuns', () => {
 });
 
 describe('buildDetailGroups', () => {
-  it('should pair each pull request with the runs on its head branch', () => {
+  it('should leave pull request runs to the exact-head PR status request', () => {
     const pulls = tagPulls([pull(1, 42, 'feature')], [42], []);
     const runsByBranch = groupRunsByBranch([run(1, 'feature', '2026-08-16T10:00:00Z')], 5);
 
@@ -334,7 +334,7 @@ describe('buildDetailGroups', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].pull?.pull.number).toBe(42);
-    expect(result[0].runs.map((item) => item.id)).toEqual([1]);
+    expect(result[0].runs).toEqual([]);
   });
 
   it('should append runs that belong to no pull request as a trailing group', () => {
@@ -366,7 +366,7 @@ describe('buildDetailGroups', () => {
     const result = buildDetailGroups(pulls, runsByBranch, 'main');
 
     expect(result.map((group) => group.pull?.pull.number)).toEqual([42, undefined]);
-    expect(result[0].runs.map((item) => item.id)).toEqual([1]);
+    expect(result[0].runs).toEqual([]);
     expect(result[1].runs.map((item) => item.id)).toEqual([2]);
   });
 

--- a/src/renderer/components/Project/hooks/useRepoData/groupByBranch.ts
+++ b/src/renderer/components/Project/hooks/useRepoData/groupByBranch.ts
@@ -67,7 +67,7 @@ export const splitDoneRuns = (
 };
 
 // What a checkout shows when opened: each pull request followed by its own
-// runs, then any runs that belong to no pull request.
+// checks, then any runs that belong to no pull request.
 export type DetailGroup = {
   // True when the branch is not checked out in any worktree — shown under the
   // main checkout because it has nowhere else to go.
@@ -81,20 +81,9 @@ export const buildDetailGroups = (
   runsByBranch: Record<string, Run[]>,
   branch: string
 ): DetailGroup[] => {
-  // GitHub's PR UI shows checks for the PR's HEAD commit only — runs from
-  // earlier commits on the same branch (a since-superseded failing build, say)
-  // are not the PR's current state and must not surface under it. Scope each
-  // pull's runs to its head SHA; runs from older commits fall through to the
-  // branch's loose bucket (or vanish once the branch view no longer needs them).
-  const groups: DetailGroup[] = pulls.map((pull) => {
-    const ref = pull.pull.head?.ref;
-    const sha = pull.pull.head?.sha;
-    const branchRuns = ref ? (runsByBranch[ref] ?? []) : [];
-    return {
-      pull,
-      runs: sha ? branchRuns.filter((run) => run.head_sha === sha) : branchRuns
-    };
-  });
+  // PR rows fetch their exact-head workflow runs with the PR status. The repo
+  // run cache only keeps recent history, so it cannot be the source here.
+  const groups = pulls.map((pull): DetailGroup => ({ pull, runs: [] }));
 
   const claimed = new Set(pulls.map(({ pull }) => pull.head?.ref));
   const loose = claimed.has(branch) ? [] : (runsByBranch[branch] ?? []);

--- a/src/renderer/components/SettingsIntegrations/SettingsIntegrations.test.tsx
+++ b/src/renderer/components/SettingsIntegrations/SettingsIntegrations.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ set: vi.fn(), settings: {} as Record<string, unknown>, show: vi.fn() }));
+vi.mock('renderer/hooks/useAppSettings', () => ({ useAppSettings: () => ({
+  anthropicUsageWorkspaceId: '', claudeEnabled: true, editors: [], gitHubToken: '', openAIUsageProjectId: '',
+  selectedEditor: undefined, selectedShell: undefined, set: mocks.set, shells: [], telemetry: true, ...mocks.settings
+}) }));
+vi.mock('renderer/utils/appToaster', () => ({ appToaster: Promise.resolve({ show: mocks.show }) }));
+
+import { SettingsIntegrations } from './SettingsIntegrations';
+
+describe('AI usage settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.settings = {};
+    vi.mocked(window.bridge.aiUsageCredentials.status).mockResolvedValue({ anthropic: false, openai: false });
+  });
+
+  it('explains the three providers and stores only admin-key status in the renderer', async () => {
+    render(<SettingsIntegrations />);
+    expect(screen.getByText(/Claude Code, Codex, and Cursor/)).toBeDefined();
+    expect(screen.getByText(/high access/)).toBeDefined();
+    fireEvent.change(screen.getByLabelText('OpenAI Admin API key'), { target: { value: 'sk-admin-secret' } });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[1]);
+    await vi.waitFor(() => {
+      expect(window.bridge.aiUsageCredentials.set).toHaveBeenCalledWith('openai', 'sk-admin-secret');
+      expect((screen.getByLabelText('OpenAI Admin API key') as HTMLInputElement).value).toBe('');
+    });
+  });
+
+  it('shows and uses clear buttons for saved keys', async () => {
+    vi.mocked(window.bridge.aiUsageCredentials.status).mockResolvedValue({ anthropic: true, openai: true });
+    render(<SettingsIntegrations />);
+    await vi.waitFor(() => expect(screen.getAllByRole('button', { name: 'Clear' })).toHaveLength(2));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Clear' })[0]);
+    expect(window.bridge.aiUsageCredentials.clear).toHaveBeenCalledWith('anthropic');
+  });
+
+  it('saves optional report scope IDs as normal settings', () => {
+    render(<SettingsIntegrations />);
+    fireEvent.change(screen.getByLabelText('Workspace ID (optional)'), { target: { value: 'wrk_123' } });
+    fireEvent.change(screen.getByLabelText('Project ID (optional)'), { target: { value: 'proj_123' } });
+    expect(mocks.set).toHaveBeenCalledWith({ anthropicUsageWorkspaceId: 'wrk_123' });
+    expect(mocks.set).toHaveBeenCalledWith({ openAIUsageProjectId: 'proj_123' });
+  });
+});

--- a/src/renderer/components/SettingsIntegrations/SettingsIntegrations.tsx
+++ b/src/renderer/components/SettingsIntegrations/SettingsIntegrations.tsx
@@ -1,14 +1,38 @@
 import { Button, Divider, InputGroup, MenuItem, Switch } from '@blueprintjs/core';
 import { Select } from '@blueprintjs/select';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAppSettings } from 'renderer/hooks/useAppSettings';
 import { appToaster } from 'renderer/utils/appToaster';
 import { type FoundEditor } from 'types/foundEditor';
 import { type FoundShell } from 'types/foundShell';
 
 export const SettingsIntegrations = () => {
-  const { claudeEnabled, editors, gitHubToken, selectedEditor, selectedShell, set, shells, telemetry } = useAppSettings();
+  const { anthropicUsageWorkspaceId, claudeEnabled, editors, gitHubToken, openAIUsageProjectId, selectedEditor, selectedShell, set, shells, telemetry } = useAppSettings();
   const [token, setToken] = useState(gitHubToken ?? '');
+  const [adminKeys, setAdminKeys] = useState({ anthropic: '', openai: '' });
+  const [savedKeys, setSavedKeys] = useState({ anthropic: false, openai: false });
+
+  useEffect(() => {
+    void window.bridge.aiUsageCredentials.status().then(setSavedKeys);
+  }, []);
+
+  const saveAdminKey = async (provider: 'anthropic' | 'openai') => {
+    const value = adminKeys[provider].trim();
+    if (!value) return;
+    try {
+      await window.bridge.aiUsageCredentials.set(provider, value);
+      setAdminKeys((current) => ({ ...current, [provider]: '' }));
+      setSavedKeys((current) => ({ ...current, [provider]: true }));
+      (await appToaster).show({ icon: 'tick', intent: 'success', message: 'Admin key saved' });
+    } catch (error) {
+      (await appToaster).show({ icon: 'error', intent: 'danger', message: error instanceof Error ? error.message : 'Could not save admin key' });
+    }
+  };
+
+  const clearAdminKey = async (provider: 'anthropic' | 'openai') => {
+    await window.bridge.aiUsageCredentials.clear(provider);
+    setSavedKeys((current) => ({ ...current, [provider]: false }));
+  };
 
   // Dev-only demo mode. The preload picks the fake bridge at startup from this
   // flag, so flipping it has to reload the window to take effect.
@@ -133,7 +157,84 @@ export const SettingsIntegrations = () => {
           onChange={() => set({ claudeEnabled: !(claudeEnabled ?? true) })}
         />
 
-        <p className="text-xs text-bp-gray-1 dark:text-bp-gray-4">Scan Claude Code and Codex profiles. View either provider with separate account selections.</p>
+        <p className="text-xs text-bp-gray-1 dark:text-bp-gray-4">Scan Claude Code, Codex, and Cursor. Cursor IDE and CLI use one account meter.</p>
+
+        <div className="mt-4 max-w-lg rounded border border-bp-light-gray-1 p-3 dark:border-bp-dark-gray-3">
+          <h4 className="text-sm font-semibold">Optional API cost reports</h4>
+          <p className="mt-1 text-xs text-bp-gray-1 dark:text-bp-gray-4">These admin keys have high access to your group. Devkitty encrypts them. The app never sends them to the screen.</p>
+
+          <div className="mt-3 grid gap-4">
+            <div>
+              <label className="mb-1 block text-xs font-semibold"
+                htmlFor="anthropic-admin-key"
+              >Anthropic Admin API key</label>
+
+              <div className="flex gap-2">
+                <InputGroup autoComplete="off"
+                  id="anthropic-admin-key"
+                  onChange={({ target: { value } }) => setAdminKeys((current) => ({ ...current, anthropic: value }))}
+                  placeholder={savedKeys.anthropic ? 'Saved' : 'sk-ant-admin…'}
+                  type="password"
+                  value={adminKeys.anthropic}
+                />
+
+                <Button disabled={!adminKeys.anthropic.trim()}
+                  onClick={() => void saveAdminKey('anthropic')}
+                  text="Save"
+                />
+
+                {savedKeys.anthropic && <Button onClick={() => void clearAdminKey('anthropic')}
+                  text="Clear"
+                                        />}
+              </div>
+
+              <label className="mb-1 mt-2 block text-xs"
+                htmlFor="anthropic-workspace-id"
+              >Workspace ID (optional)</label>
+
+              <InputGroup id="anthropic-workspace-id"
+                onChange={({ target: { value } }) => set({ anthropicUsageWorkspaceId: value || undefined })}
+                placeholder="All org workspaces"
+                value={anthropicUsageWorkspaceId ?? ''}
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs font-semibold"
+                htmlFor="openai-admin-key"
+              >OpenAI Admin API key</label>
+
+              <div className="flex gap-2">
+                <InputGroup autoComplete="off"
+                  id="openai-admin-key"
+                  onChange={({ target: { value } }) => setAdminKeys((current) => ({ ...current, openai: value }))}
+                  placeholder={savedKeys.openai ? 'Saved' : 'sk-admin…'}
+                  type="password"
+                  value={adminKeys.openai}
+                />
+
+                <Button disabled={!adminKeys.openai.trim()}
+                  onClick={() => void saveAdminKey('openai')}
+                  text="Save"
+                />
+
+                {savedKeys.openai && <Button onClick={() => void clearAdminKey('openai')}
+                  text="Clear"
+                                     />}
+              </div>
+
+              <label className="mb-1 mt-2 block text-xs"
+                htmlFor="openai-project-id"
+              >Project ID (optional)</label>
+
+              <InputGroup id="openai-project-id"
+                onChange={({ target: { value } }) => set({ openAIUsageProjectId: value || undefined })}
+                placeholder="All org projects"
+                value={openAIUsageProjectId ?? ''}
+              />
+            </div>
+          </div>
+        </div>
       </section>
 
       <section className="mt-4">

--- a/src/renderer/hooks/useAIUsage.test.ts
+++ b/src/renderer/hooks/useAIUsage.test.ts
@@ -8,13 +8,14 @@ const mocks = vi.hoisted(() => {
   const provider = () => ({ accounts: vi.fn().mockResolvedValue([]), detect: vi.fn().mockResolvedValue({ installed: false }), usage: vi.fn() });
   const claude = provider();
   const codex = provider();
+  const cursor = provider();
   const settings = vi.fn().mockResolvedValue({});
   const save = vi.fn();
   const unsubscribe = vi.fn();
   const subscribe = vi.fn<(spec: PollSpec<AIUsage>, onData: (data: AIUsage) => void) => () => void>(() => unsubscribe);
   const refresh = vi.fn<(key?: string) => void>();
-  Object.assign(window.bridge, { claude, codex, settings: { ...window.bridge.settings, get: settings } });
-  return { claude, codex, refresh, save, settings, subscribe, unsubscribe };
+  Object.assign(window.bridge, { claude, codex, cursor, settings: { ...window.bridge.settings, get: settings } });
+  return { claude, codex, cursor, refresh, save, settings, subscribe, unsubscribe };
 });
 vi.mock('./useAppSettings', () => ({ useAppSettings: { getState: () => ({ set: mocks.save }) } }));
 vi.mock('renderer/services/poller', () => ({ refresh: mocks.refresh, subscribe: mocks.subscribe }));
@@ -25,10 +26,10 @@ const claude: AIAccount = { dir: '/profiles/shared', label: 'Claude', provider: 
 const claude2: AIAccount = { ...claude, dir: '/profiles/claude-2' };
 const codex: AIAccount = { dir: '/profiles/shared', label: 'Codex', provider: 'codex' };
 const codex2: AIAccount = { ...codex, dir: '/profiles/codex-2' };
-const usage = (account: AIAccount): AIUsage => {
-  const window: AIUsage['fiveHour'] = { active: true, cap: 100, models: [], pct: 0.2, reported: true, resetsAt: 2000, startsAt: 1000, tokens: 20 };
-  return { account, computedAt: 1000, fiveHour: window, week: window };
-};
+const cursor: AIAccount = { dir: '/profiles/cursor', label: 'Cursor', provider: 'cursor', surfaces: ['ide'] };
+const usage = (account: AIAccount): AIUsage => ({
+  account, computedAt: 1000, metrics: [{ id: 'seven-day', label: '7D', percent: 0.2, resetsAt: 2000, scope: 'account', source: 'provider', title: '7D', tokens: 20 }]
+});
 const deferred = <T>() => {
   let resolve!: (value: T) => void;
   let reject!: (error: Error) => void;
@@ -44,13 +45,14 @@ describe('AI usage provider and account isolation', () => {
     mocks.refresh.mockImplementation(() => {});
     useAIUsage.setState({
       accounts: [], activeDirs: {}, activeProvider: 'claude',
-      detection: { claude: { installed: false }, codex: { installed: false } },
+      detection: { claude: { installed: false }, codex: { installed: false }, cursor: { installed: false } },
       discoveryErrors: {}, errorByAccount: {}, loadingByAccount: {}, ready: false, usageByAccount: {}
     });
     mocks.settings.mockResolvedValue({});
     mocks.claude.accounts.mockResolvedValue([claude, claude2]);
     mocks.codex.accounts.mockResolvedValue([codex, codex2]);
-    for (const provider of [mocks.claude, mocks.codex]) {
+    mocks.cursor.accounts.mockResolvedValue([]);
+    for (const provider of [mocks.claude, mocks.codex, mocks.cursor]) {
       provider.detect.mockResolvedValue({ installed: true });
       provider.usage.mockImplementation(async (account: AIAccount) => usage(account));
     }
@@ -81,13 +83,25 @@ describe('AI usage provider and account isolation', () => {
   it('restores provider and separate legacy Claude / Codex preferences', async () => {
     mocks.settings.mockResolvedValue({ aiProvider: 'codex', claudeAccountDir: claude2.dir, codexAccountDir: codex2.dir });
     await useAIUsage.getState().init();
-    expect(useAIUsage.getState().activeDirs).toEqual({ claude: claude2.dir, codex: codex2.dir });
+    expect(useAIUsage.getState().activeDirs).toEqual({ claude: claude2.dir, codex: codex2.dir, cursor: undefined });
     expect(mocks.claude.usage).toHaveBeenCalledWith(claude2);
     expect(mocks.codex.usage).toHaveBeenCalledWith(codex2);
     useAIUsage.getState().setProvider('claude');
     await useAIUsage.getState().refresh();
     expect(mocks.claude.usage).toHaveBeenCalledWith(claude2);
     expect(mocks.save).toHaveBeenCalledWith({ aiProvider: 'claude' });
+  });
+
+  it('adds Cursor once and merges CLI and app-only Grok detection into its surfaces', async () => {
+    mocks.cursor.accounts.mockResolvedValue([cursor]);
+    mocks.cursor.detect.mockResolvedValue({ installed: true, surfaces: ['cli', 'grok-bot'] });
+    await useAIUsage.getState().init();
+    const cursorAccounts = useAIUsage.getState().accounts.filter(({ provider }) => provider === 'cursor');
+    expect(cursorAccounts).toHaveLength(1);
+    expect(cursorAccounts[0].surfaces).toEqual(['ide', 'cli', 'grok-bot']);
+    expect(mocks.cursor.usage).toHaveBeenCalledExactlyOnceWith(cursorAccounts[0]);
+    useAIUsage.getState().setProvider('cursor');
+    expect(mocks.save).toHaveBeenCalledWith({ aiProvider: 'cursor' });
   });
 
   it('remembers independent account choices across provider switches', async () => {
@@ -100,7 +114,7 @@ describe('AI usage provider and account isolation', () => {
     await useAIUsage.getState().refresh();
     useAIUsage.getState().setProvider('claude');
     await useAIUsage.getState().refresh();
-    expect(useAIUsage.getState().activeDirs).toEqual({ claude: claude2.dir, codex: codex2.dir });
+    expect(useAIUsage.getState().activeDirs).toEqual({ claude: claude2.dir, codex: codex2.dir, cursor: undefined });
     expect(mocks.save).toHaveBeenCalledWith({ claudeAccountDir: claude2.dir });
     expect(mocks.save).toHaveBeenCalledWith({ codexAccountDir: codex2.dir });
   });

--- a/src/renderer/hooks/useAIUsage.ts
+++ b/src/renderer/hooks/useAIUsage.ts
@@ -1,14 +1,29 @@
 import { refresh as refreshPoller, subscribe, type Unsubscribe } from 'renderer/services/poller';
 import { type AIAccount, type AIDetection, type AIProvider, type AIUsage } from 'types/aiUsage';
 import { type AppSettings } from 'types/appSettings';
-import { type ClaudeAccount } from 'types/claudeUsage';
 import { create } from 'zustand';
 
 import { useAppSettings } from './useAppSettings';
 
 export const AI_POLL_MS = 60000;
 export const aiAccountKey = (account: Pick<AIAccount, 'dir' | 'provider'>) => `${account.provider}:${account.dir}`;
-export const AI_PROVIDERS: AIProvider[] = ['claude', 'codex'];
+
+type ProviderBridge = {
+  accounts: () => Promise<AIAccount[]>;
+  detect: () => Promise<AIDetection>;
+  usage: (account: AIAccount) => Promise<AIUsage>;
+};
+type ProviderConfig = {
+  name: string;
+  settingsKey: 'claudeAccountDir' | 'codexAccountDir' | 'cursorAccountDir';
+};
+
+export const AI_PROVIDER_CONFIG = {
+  claude: { name: 'Claude', settingsKey: 'claudeAccountDir' },
+  codex: { name: 'Codex', settingsKey: 'codexAccountDir' },
+  cursor: { name: 'Cursor', settingsKey: 'cursorAccountDir' }
+} satisfies Record<AIProvider, ProviderConfig>;
+export const AI_PROVIDERS = Object.keys(AI_PROVIDER_CONFIG) as AIProvider[];
 
 type Actions = {
   init: () => Promise<void>;
@@ -32,13 +47,13 @@ const subscriptions = new Map<string, Unsubscribe>();
 const inFlight = new Map<string, Promise<AIUsage>>();
 const lastReads = new Map<string, number>();
 let initGeneration = 0;
-const message = (error: unknown) => error instanceof Error ? error.message : 'Could not read usage';
-const selectedAccounts = (state: State) => state.accounts.filter((account) =>
+const errorMessage = (error: unknown) => error instanceof Error ? error.message : 'Could not read usage';
+const bridgeFor = (provider: AIProvider): ProviderBridge => window.bridge[provider];
+const pollKey = (account: AIAccount) => `aiUsage:${aiAccountKey(account)}`;
+const currentAccount = (state: State) => state.accounts.filter((account) => (
   state.activeProvider === account.provider && state.activeDirs[account.provider] === account.dir
-);
-const selectedProviderAccounts = (state: State) => state.accounts.filter((account) =>
-  state.activeDirs[account.provider] === account.dir
-);
+));
+const activeAccounts = (state: State) => state.accounts.filter((account) => state.activeDirs[account.provider] === account.dir);
 
 export const useAIUsage = create<Actions & State>((set, get) => {
   const read = (account: AIAccount, force = false): Promise<AIUsage> => {
@@ -46,22 +61,14 @@ export const useAIUsage = create<Actions & State>((set, get) => {
     const pending = inFlight.get(key);
     if (pending) return pending;
     const cached = get().usageByAccount[key];
-    // Joining a newly selected poll subscription must not repeat its initial read.
     if (!force && cached && Date.now() - (lastReads.get(key) ?? 0) < 1000) return Promise.resolve(cached);
     set((state) => ({ loadingByAccount: { ...state.loadingByAccount, [key]: !cached } }));
-    const request = Promise.resolve().then(async () => {
-      if (account.provider === 'codex') return window.bridge.codex.usage(account);
-      const usage = await window.bridge.claude.usage(account);
-      return { ...usage, account };
-    }).then((usage) => {
+    const request = Promise.resolve().then(() => bridgeFor(account.provider).usage(account)).then((usage) => {
       lastReads.set(key, Date.now());
-      set((state) => ({
-        errorByAccount: { ...state.errorByAccount, [key]: undefined },
-        usageByAccount: { ...state.usageByAccount, [key]: usage }
-      }));
+      set((state) => ({ errorByAccount: { ...state.errorByAccount, [key]: undefined }, usageByAccount: { ...state.usageByAccount, [key]: usage } }));
       return usage;
     }).catch((error: unknown) => {
-      set((state) => ({ errorByAccount: { ...state.errorByAccount, [key]: message(error) } }));
+      set((state) => ({ errorByAccount: { ...state.errorByAccount, [key]: errorMessage(error) } }));
       throw error;
     }).finally(() => {
       inFlight.delete(key);
@@ -70,41 +77,33 @@ export const useAIUsage = create<Actions & State>((set, get) => {
     inFlight.set(key, request);
     return request;
   };
+
   const syncSubscriptions = () => {
-    const accounts = selectedAccounts(get());
+    const accounts = currentAccount(get());
     const keys = new Set(accounts.map(aiAccountKey));
     for (const [key, unsubscribe] of subscriptions) {
-      if (!keys.has(key)) {
-        unsubscribe();
-        subscriptions.delete(key);
-      }
+      if (!keys.has(key)) { unsubscribe(); subscriptions.delete(key); }
     }
     for (const account of accounts) {
       const key = aiAccountKey(account);
       if (subscriptions.has(key)) continue;
-      subscriptions.set(key, subscribe<AIUsage>({
-        fetch: () => read(account), interval: () => AI_POLL_MS, key: `aiUsage:${key}`
-      }, () => {}));
-      // The coordinator parks unsubscribed cached keys at Infinity. Re-arm a
-      // returning account even when subscribe delivers cached data immediately.
-      refreshPoller(`aiUsage:${key}`);
+      subscriptions.set(key, subscribe<AIUsage>({ fetch: () => read(account), interval: () => AI_POLL_MS, key: pollKey(account) }, () => {}));
+      refreshPoller(pollKey(account));
     }
   };
+
   return {
     accounts: [],
     activeDirs: {},
     activeProvider: 'claude',
-    detection: { claude: { installed: false }, codex: { installed: false } },
+    detection: { claude: { installed: false }, codex: { installed: false }, cursor: { installed: false } },
     discoveryErrors: {},
     errorByAccount: {},
     init: async () => {
       const generation = ++initGeneration;
       const results = await Promise.all(AI_PROVIDERS.map(async (provider) => {
-        const bridge = window.bridge[provider];
-        const [detection, accounts] = await Promise.allSettled([
-          Promise.resolve().then(() => bridge.detect()),
-          Promise.resolve().then(() => bridge.accounts())
-        ]);
+        const bridge = bridgeFor(provider);
+        const [detection, accounts] = await Promise.allSettled([bridge.detect(), bridge.accounts()]);
         return { accounts, detection, provider };
       }));
       const settings: AppSettings | undefined = await window.bridge.settings.get('appSettings').catch((): undefined => undefined);
@@ -117,35 +116,37 @@ export const useAIUsage = create<Actions & State>((set, get) => {
       for (const result of results) {
         const { provider } = result;
         if (result.detection.status === 'fulfilled') detection[provider] = result.detection.value;
-        const providerAccounts: AIAccount[] = result.accounts.status === 'fulfilled'
-          ? result.accounts.value.map((account: ClaudeAccount) => ({ ...account, provider }))
+        const detectedSurfaces = provider === 'cursor' && result.detection.status === 'fulfilled' ? result.detection.value.surfaces ?? [] : [];
+        const providerAccounts = result.accounts.status === 'fulfilled'
+          ? result.accounts.value.map((account) => {
+            const surfaces = provider === 'cursor' ? [...new Set([...(account.surfaces ?? []), ...detectedSurfaces])] : account.surfaces;
+            return { ...account, ...(surfaces?.length ? { surfaces } : {}), provider };
+          })
           : state.accounts.filter((account) => account.provider === provider);
         accounts.push(...providerAccounts);
-        if (result.accounts.status === 'rejected') discoveryErrors[provider] = message(result.accounts.reason);
-        else if (result.detection.status === 'rejected') discoveryErrors[provider] = message(result.detection.reason);
-        const preferred = state.ready ? state.activeDirs[provider] : settings?.[provider === 'claude' ? 'claudeAccountDir' : 'codexAccountDir'];
+        if (result.accounts.status === 'rejected') discoveryErrors[provider] = errorMessage(result.accounts.reason);
+        else if (result.detection.status === 'rejected') discoveryErrors[provider] = errorMessage(result.detection.reason);
+        const preferred = state.ready ? state.activeDirs[provider] : settings?.[AI_PROVIDER_CONFIG[provider].settingsKey];
         activeDirs[provider] = providerAccounts.find((account) => account.dir === preferred)?.dir ?? providerAccounts[0]?.dir;
       }
       const preferredProvider = state.ready ? state.activeProvider : settings?.aiProvider;
-      const providersWithAccounts = AI_PROVIDERS.filter((provider) => accounts.some((account) => account.provider === provider));
-      const availableProviders = providersWithAccounts.length > 0
-        ? providersWithAccounts : AI_PROVIDERS.filter((provider) => detection[provider].installed);
-      const activeProvider: AIProvider = preferredProvider !== 'both' && preferredProvider && availableProviders.includes(preferredProvider)
-        ? preferredProvider : availableProviders[0] ?? 'claude';
+      const withAccounts = AI_PROVIDERS.filter((provider) => accounts.some((account) => account.provider === provider));
+      const available = withAccounts.length > 0 ? withAccounts : AI_PROVIDERS.filter((provider) => detection[provider].installed);
+      const activeProvider = preferredProvider && preferredProvider !== 'both' && available.includes(preferredProvider) ? preferredProvider : available[0] ?? 'claude';
       set({ accounts, activeDirs, activeProvider, detection, discoveryErrors, ready: true });
-      await Promise.allSettled(selectedProviderAccounts(get()).map((account) => read(account, true)));
+      await Promise.allSettled(activeAccounts(get()).map((account) => read(account, true)));
       syncSubscriptions();
     },
     loadingByAccount: {},
     ready: false,
     refresh: async () => {
-      await Promise.allSettled(selectedAccounts(get()).map((account) => read(account, true)));
+      await Promise.allSettled(currentAccount(get()).map((account) => read(account, true)));
     },
     setActive: (provider, dir) => {
       const state = get();
       if (state.activeDirs[provider] === dir || !state.accounts.some((account) => account.provider === provider && account.dir === dir)) return;
       set({ activeDirs: { ...state.activeDirs, [provider]: dir } });
-      useAppSettings.getState().set(provider === 'claude' ? { claudeAccountDir: dir } : { codexAccountDir: dir });
+      useAppSettings.getState().set({ [AI_PROVIDER_CONFIG[provider].settingsKey]: dir });
       void get().refresh();
       syncSubscriptions();
     },

--- a/src/renderer/test-setup.ts
+++ b/src/renderer/test-setup.ts
@@ -2,12 +2,33 @@
 // This file runs before any test module is imported, so it can set up
 // globals that are accessed at module evaluation time (top-level IIFEs in stores)
 
+import { type PRStatus } from 'types/gitHub';
 import { vi } from 'vitest';
+
+const emptyPRStatus: PRStatus = {
+  allowedMergeMethods: [],
+  autoMergeAllowed: false,
+  autoMergeEnabled: false,
+  behind: false,
+  checks: [],
+  mergeable: false,
+  mergeableState: 'unknown',
+  review: { approvedBy: [], changesRequestedBy: [], reviewers: [], state: null },
+  success: true,
+  unresolvedComments: 0,
+  unresolvedThreads: [],
+  workflowRuns: []
+};
 
 // Provide a comprehensive window.bridge mock for all renderer tests
 // The stores (useProjects, useGroups, useAppSettings, useDarkMode) have
 // top-level IIFEs that call window.bridge.* at import time
 const mockBridge = {
+  aiUsageCredentials: {
+    clear: vi.fn(),
+    set: vi.fn(),
+    status: vi.fn().mockResolvedValue({ anthropic: false, openai: false })
+  },
   claude: {
     accounts: vi.fn().mockResolvedValue([]),
     detect: vi.fn().mockResolvedValue({ installed: false }),
@@ -17,6 +38,11 @@ const mockBridge = {
     onDownscaled: vi.fn(() => () => {})
   },
   codex: {
+    accounts: vi.fn().mockResolvedValue([]),
+    detect: vi.fn().mockResolvedValue({ installed: false }),
+    usage: vi.fn()
+  },
+  cursor: {
     accounts: vi.fn().mockResolvedValue([]),
     detect: vi.fn().mockResolvedValue({ installed: false }),
     usage: vi.fn()
@@ -41,18 +67,7 @@ const mockBridge = {
     getJobs: vi.fn(),
     getOpenPulls: vi.fn(),
     getPinnedRuns: vi.fn(),
-    getPRChecks: vi.fn().mockResolvedValue({
-      allowedMergeMethods: [],
-      autoMergeAllowed: false,
-      autoMergeEnabled: false,
-      behind: false,
-      checks: [],
-      mergeableState: 'unknown',
-      review: null,
-      success: true,
-      unresolvedComments: 0,
-      unresolvedThreads: []
-    }),
+    getPRChecks: vi.fn().mockResolvedValue(emptyPRStatus),
     getPulls: vi.fn(),
     getRuns: vi.fn(),
     getRunsPage: vi.fn(),

--- a/src/types/aiUsage.ts
+++ b/src/types/aiUsage.ts
@@ -1,14 +1,51 @@
-import { type ClaudeAccount, type ClaudeDetection, type ClaudeUsageWindow } from './claudeUsage';
+export type AIAccount = {
+  dir: string;
+  email?: string;
+  label: string;
+  org?: string;
+  plan?: string;
+  provider: AIProvider;
+  surfaces?: CursorSurface[];
+};
+export type AIDetection = {
+  installed: boolean;
+  surfaces?: CursorSurface[];
+  version?: string;
+};
+export type AIProvider = 'claude' | 'codex' | 'cursor';
 
-export type AIAccount = ClaudeAccount & { provider: AIProvider };
-export type AIDetection = ClaudeDetection;
-export type AIProvider = 'claude' | 'codex';
 export type AIProviderFilter = 'both' | AIProvider;
+
 export type AIUsage = {
   account: AIAccount;
   computedAt: number;
-  fiveHour: AIUsageWindow;
+  metrics: AIUsageMetric[];
   reportedAt?: number;
-  week: AIUsageWindow;
+  spend?: AIUsageSpend;
 };
-export type AIUsageWindow = ClaudeUsageWindow & { durationMs?: number };
+
+export type AIUsageMetric = {
+  id: 'cursor-models' | 'five-hour' | 'grok-weekly' | 'month' | 'other-models' | 'seven-day';
+  label: string;
+  models?: { model: string; tokens: number }[];
+  percent?: number;
+  resetsAt?: number;
+  scope: 'account' | 'organization' | 'project' | 'workspace';
+  source: 'admin' | 'local' | 'provider';
+  title: string;
+  tokens?: number;
+  tokensPeriod?: 'provider-period' | 'trailing-window';
+};
+
+export type AIUsageSpend = {
+  amountUsdMicros: number;
+  label: 'On-demand' | 'Org API spend' | 'Project API spend' | 'Workspace API spend';
+  limitUsdMicros?: number;
+  period: 'billing-cycle' | 'calendar-month';
+  qualifier?: string;
+  scope: 'account' | 'organization' | 'project' | 'workspace';
+  source: 'admin' | 'provider';
+  startsAt?: number;
+};
+
+export type CursorSurface = 'cli' | 'grok-bot' | 'ide';

--- a/src/types/appSettings.ts
+++ b/src/types/appSettings.ts
@@ -5,10 +5,12 @@ import { type IgnoredWorkflow } from './ignoredWorkflow';
 
 export type AppSettings = {
   aiProvider?: AIProviderFilter;
+  anthropicUsageWorkspaceId?: string;
   claudeAccountDir?: string; // config dir of the account shown in the usage footer
   claudeEnabled: boolean; // legacy storage key: master switch for AI analytics
   clipboardDownscale: boolean; // header toggle: auto-shrink clipboard images > 1200px for Claude Code
   codexAccountDir?: string; // Codex profile shown in AI analytics
+  cursorAccountDir?: string; // Cursor account shown in AI analytics
   editors: FoundEditor[];
   fetchInterval: number;
   gitHubActions: {
@@ -23,6 +25,7 @@ export type AppSettings = {
     pollInterval: number;
   };
   gitHubToken?: string;
+  openAIUsageProjectId?: string;
   selectedEditor?: FoundEditor;
   selectedShell?: FoundShell<string>;
   shells: FoundShell<string>[];

--- a/src/types/gitHub.ts
+++ b/src/types/gitHub.ts
@@ -1,8 +1,49 @@
 import { type GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
 import { type Octokit } from 'octokit';
 
-export type Pull = GetResponseDataTypeFromEndpointMethod<typeof Octokit.prototype.rest.pulls.list>[0];
+export type MergeableState =
+  | 'behind'
+  | 'blocked'
+  | 'clean'
+  | 'dirty'
+  | 'draft'
+  | 'has_hooks'
+  | 'unknown'
+  | 'unstable';
 
+export type MergeMethod = 'merge' | 'rebase' | 'squash';
+export type PRCheck = { conclusion: null | string; id: number; name: string; status: string };
+export type PRReview = {
+  approvedBy: string[];
+  changesRequestedBy: string[];
+  reviewers: PRReviewer[];
+  state: 'approved' | 'changes_requested' | null;
+};
+export type PRReviewer = {
+  avatarUrl: string;
+  login: string;
+  reReviewRequested: boolean;
+  state: 'approved' | 'changes_requested' | 'commented' | 'pending';
+};
+export type PRStatus = {
+  allowedMergeMethods: MergeMethod[];
+  autoMergeAllowed: boolean;
+  autoMergeEnabled: boolean;
+  behind: boolean;
+  checks: PRCheck[];
+  mergeable: boolean | null;
+  mergeableState: MergeableState;
+  review: null | PRReview;
+  success: true;
+  unresolvedComments: number;
+  unresolvedThreads: PRThread[];
+  workflowRuns: Run[];
+};
+
+export type PRStatusResult = PRStatus | { message: string; success: false };
+
+export type PRThread = { avatarUrl: string; count: number; login: string; path: null | string };
+export type Pull = GetResponseDataTypeFromEndpointMethod<typeof Octokit.prototype.rest.pulls.list>[0];
 export type Run = GetResponseDataTypeFromEndpointMethod<
   typeof Octokit.prototype.rest.actions.listWorkflowRunsForRepo
 >['workflow_runs'][0];


### PR DESCRIPTION
## What changed
- Add Cursor usage with the official cube icon.
- Show Claude Code and Codex usage. Keep Codex on the 7D view.
- Add optional admin reports for API tokens and cost. Store keys in the main process.
- Fix PR check rows and action state after branch updates.
- Add provider keys: Command+1, Command+2, and Command+3.
- Let the main usage bar use the free footer width.

## Checks
- 875 tests pass.
- Production build passes.
- Git diff check passes.

## Note
The dev app logs a GitHub workflow request as Not Found. This did not stop the tests or build.